### PR TITLE
Fix universal translator imports so that goimports doesn't get remove them

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/go-playground/universal-translator"
+	ut "github.com/go-playground/universal-translator"
 )
 
 const (

--- a/examples/translations/main.go
+++ b/examples/translations/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/go-playground/locales/en"
-	"github.com/go-playground/universal-translator"
+	ut "github.com/go-playground/universal-translator"
 	"gopkg.in/go-playground/validator.v9"
 	en_translations "gopkg.in/go-playground/validator.v9/translations/en"
 )

--- a/translations.go
+++ b/translations.go
@@ -1,6 +1,6 @@
 package validator
 
-import "github.com/go-playground/universal-translator"
+import ut "github.com/go-playground/universal-translator"
 
 // TranslationFunc is the function type used to register or override
 // custom translations

--- a/translations/en/en.go
+++ b/translations/en/en.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/go-playground/locales"
-	"github.com/go-playground/universal-translator"
+	ut "github.com/go-playground/universal-translator"
 	"gopkg.in/go-playground/validator.v9"
 )
 

--- a/translations/en/en_test.go
+++ b/translations/en/en_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	english "github.com/go-playground/locales/en"
-	"github.com/go-playground/universal-translator"
+	ut "github.com/go-playground/universal-translator"
 	. "gopkg.in/go-playground/assert.v1"
 	"gopkg.in/go-playground/validator.v9"
 )

--- a/validator_instance.go
+++ b/validator_instance.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-playground/universal-translator"
+	ut "github.com/go-playground/universal-translator"
 )
 
 const (

--- a/validator_test.go
+++ b/validator_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/go-playground/locales/en"
 	"github.com/go-playground/locales/fr"
 	"github.com/go-playground/locales/nl"
-	"github.com/go-playground/universal-translator"
+	ut "github.com/go-playground/universal-translator"
 )
 
 // NOTES:


### PR DESCRIPTION
@go-playground/admins

Running goimports on the codebase deletes all the imports of "github.com/go-playground/universal-translator".

The fix consists of explicitly qualifying the import statements with ut.