### PR TITLE
Go 1.8 context supports for struct validation

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -1,6 +1,7 @@
 package validator
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/url"
@@ -16,6 +17,14 @@ import (
 // fieldType     = fields
 // param         = parameter used in validation i.e. gt=0 param would be 0
 type Func func(fl FieldLevel) bool
+type FuncCtx func(ctx context.Context, fl FieldLevel) bool
+
+// wrapFunc make Func compatible with FuncCtx
+func wrapFunc(fn Func) FuncCtx {
+	return func(ctx context.Context, fl FieldLevel) bool {
+		return fn(fl)
+	}
+}
 
 var (
 	restrictedTags = map[string]struct{}{

--- a/cache.go
+++ b/cache.go
@@ -90,7 +90,7 @@ type cTag struct {
 	hasAlias       bool
 	typeof         tagType
 	hasTag         bool
-	fn             Func
+	fn             FuncCtx
 	next           *cTag
 }
 

--- a/validator.go
+++ b/validator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"context"
 )
 
 // per validate contruct
@@ -34,7 +35,7 @@ type validate struct {
 }
 
 // parent and current will be the same the first run of validateStruct
-func (v *validate) validateStruct(parent reflect.Value, current reflect.Value, typ reflect.Type, ns []byte, structNs []byte, ct *cTag) {
+func (v *validate) validateStruct(ctx context.Context, parent reflect.Value, current reflect.Value, typ reflect.Type, ns []byte, structNs []byte, ct *cTag) {
 
 	cs, ok := v.v.structCache.Get(typ)
 	if !ok {
@@ -78,7 +79,7 @@ func (v *validate) validateStruct(parent reflect.Value, current reflect.Value, t
 				}
 			}
 
-			v.traverseField(parent, current.Field(f.idx), ns, structNs, f, f.cTags)
+			v.traverseField(ctx, parent, current.Field(f.idx), ns, structNs, f, f.cTags)
 		}
 	}
 
@@ -97,7 +98,7 @@ func (v *validate) validateStruct(parent reflect.Value, current reflect.Value, t
 }
 
 // traverseField validates any field, be it a struct or single field, ensures it's validity and passes it along to be validated via it's tag options
-func (v *validate) traverseField(parent reflect.Value, current reflect.Value, ns []byte, structNs []byte, cf *cField, ct *cTag) {
+func (v *validate) traverseField(ctx context.Context, parent reflect.Value, current reflect.Value, ns []byte, structNs []byte, cf *cField, ct *cTag) {
 
 	var typ reflect.Type
 	var kind reflect.Kind
@@ -192,7 +193,7 @@ func (v *validate) traverseField(parent reflect.Value, current reflect.Value, ns
 				structNs = append(append(structNs, cf.name...), '.')
 			}
 
-			v.validateStruct(current, current, typ, ns, structNs, ct)
+			v.validateStruct(ctx, current, current, typ, ns, structNs, ct)
 			return
 		}
 	}
@@ -261,7 +262,7 @@ OUTER:
 						reusableCF.altName = string(v.misc)
 					}
 
-					v.traverseField(parent, current.Index(i), ns, structNs, reusableCF, ct)
+					v.traverseField(ctx, parent, current.Index(i), ns, structNs, reusableCF, ct)
 				}
 
 			case reflect.Map:
@@ -291,7 +292,7 @@ OUTER:
 						reusableCF.altName = string(v.misc)
 					}
 
-					v.traverseField(parent, current.MapIndex(key), ns, structNs, reusableCF, ct)
+					v.traverseField(ctx, parent, current.MapIndex(key), ns, structNs, reusableCF, ct)
 				}
 
 			default:
@@ -314,7 +315,7 @@ OUTER:
 				v.cf = cf
 				v.ct = ct
 
-				if ct.fn(v) {
+				if ct.fn(ctx, v) {
 
 					// drain rest of the 'or' values, then continue or leave
 					for {
@@ -407,7 +408,7 @@ OUTER:
 			// v.ns = ns
 			// v.actualNs = structNs
 
-			if !ct.fn(v) {
+			if !ct.fn(ctx, v) {
 
 				v.str1 = string(append(ns, cf.altName...))
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
@@ -5127,6 +5128,10 @@ func TestAddFunctions(t *testing.T) {
 		return true
 	}
 
+	fnCtx := func(ctx context.Context, fl FieldLevel) bool {
+		return true
+	}
+
 	validate := New()
 
 	errs := validate.RegisterValidation("new", fn)
@@ -5139,6 +5144,9 @@ func TestAddFunctions(t *testing.T) {
 	NotEqual(t, errs, nil)
 
 	errs = validate.RegisterValidation("new", fn)
+	Equal(t, errs, nil)
+
+	errs = validate.RegisterValidationCtx("new", fnCtx)
 	Equal(t, errs, nil)
 
 	PanicMatches(t, func() { validate.RegisterValidation("dive", fn) }, "Tag 'dive' either contains restricted characters or is the same as a restricted tag needed for normal operation")


### PR DESCRIPTION
Enhances #292.

**Make sure that you've checked the boxes below before you submit PR:**
- [ x] Tests exist or have been written that cover this particular change.

Change Details:
- Add StructCtx(ctx context.Context, s interface{}) which receives a context.Context as a param
- FuncCtx(ctx context.Context, fl FieldLevel) custom validation which receives a context.Context as a param


@go-playground/admins