### PR TITLE
Don't include type name in ReportValidationErrors

### DIFF
--- a/struct_level.go
+++ b/struct_level.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"context"
 	"reflect"
+	"strings"
 )
 
 // StructLevelFunc accepts all values needed for struct level validation
@@ -170,8 +171,33 @@ func (v *validate) ReportValidationErrors(relativeNamespace, relativeStructNames
 	for i := 0; i < len(errs); i++ {
 
 		err = errs[i].(*fieldError)
-		err.ns = string(append(append(v.ns, relativeNamespace...), err.ns...))
-		err.structNs = string(append(append(v.actualNs, relativeStructNamespace...), err.structNs...))
+
+		ns := err.ns
+		prefix := append(v.ns, relativeNamespace...)
+		if len(prefix) > 0 {
+			// Strip out type name
+			idx := strings.Index(ns, ".")
+			if idx == -1 {
+				ns = ""
+			} else {
+				ns = ns[idx+1:]
+			}
+		}
+		err.ns = string(append(prefix, ns...))
+
+		structNs := err.structNs
+		structPrefix := append(v.actualNs, relativeStructNamespace...)
+		if len(structPrefix) > 0 {
+			// Strip out type name
+			idx := strings.Index(structNs, ".")
+			if idx == -1 {
+				structNs = ""
+			} else {
+				structNs = structNs[idx+1:]
+			}
+		}
+
+		err.structNs = string(append(structPrefix, structNs...))
 
 		v.errs = append(v.errs, err)
 	}

--- a/validator_test.go
+++ b/validator_test.go
@@ -279,24 +279,24 @@ func StructValidationTestStructReturnValidationErrors(sl StructLevel) {
 
 	s := sl.Current().Interface().(TestStructReturnValidationErrors)
 
-	errs := sl.Validator().Struct(s.Inner1.Inner2)
+	errs := sl.Validator().Struct(s.Inner1.Inner2Field)
 	if errs == nil {
 		return
 	}
 
-	sl.ReportValidationErrors("Inner1.", "Inner1.", errs.(ValidationErrors))
+	sl.ReportValidationErrors("Inner1.Inner2Field.", "Inner1.Inner2Field.", errs.(ValidationErrors))
 }
 
 func StructValidationTestStructReturnValidationErrors2(sl StructLevel) {
 
 	s := sl.Current().Interface().(TestStructReturnValidationErrors)
 
-	errs := sl.Validator().Struct(s.Inner1.Inner2)
+	errs := sl.Validator().Struct(s.Inner1.Inner2Field)
 	if errs == nil {
 		return
 	}
 
-	sl.ReportValidationErrors("Inner1JSON.", "Inner1.", errs.(ValidationErrors))
+	sl.ReportValidationErrors("Inner1JSON.Inner2FieldJSON.", "Inner1.Inner2Field.", errs.(ValidationErrors))
 }
 
 type TestStructReturnValidationErrorsInner2 struct {
@@ -304,7 +304,7 @@ type TestStructReturnValidationErrorsInner2 struct {
 }
 
 type TestStructReturnValidationErrorsInner1 struct {
-	Inner2 *TestStructReturnValidationErrorsInner2
+	Inner2Field *TestStructReturnValidationErrorsInner2 `json:"Inner2FieldJSON"`
 }
 
 type TestStructReturnValidationErrors struct {
@@ -519,7 +519,7 @@ func TestStructLevelReturnValidationErrors(t *testing.T) {
 	}
 
 	inner1 := &TestStructReturnValidationErrorsInner1{
-		Inner2: inner2,
+		Inner2Field: inner2,
 	}
 
 	val := &TestStructReturnValidationErrors{
@@ -534,9 +534,9 @@ func TestStructLevelReturnValidationErrors(t *testing.T) {
 	errs = validate.Struct(val)
 	NotEqual(t, errs, nil)
 	Equal(t, len(errs.(ValidationErrors)), 2)
-	AssertError(t, errs, "TestStructReturnValidationErrors.Inner1.Inner2.String", "TestStructReturnValidationErrors.Inner1.Inner2.String", "String", "String", "required")
+	AssertError(t, errs, "TestStructReturnValidationErrors.Inner1.Inner2Field.String", "TestStructReturnValidationErrors.Inner1.Inner2Field.String", "String", "String", "required")
 	// this is an extra error reported from struct validation
-	AssertError(t, errs, "TestStructReturnValidationErrors.Inner1.TestStructReturnValidationErrorsInner2.String", "TestStructReturnValidationErrors.Inner1.TestStructReturnValidationErrorsInner2.String", "String", "String", "required")
+	AssertError(t, errs, "TestStructReturnValidationErrors.Inner1.Inner2Field.String", "TestStructReturnValidationErrors.Inner1.Inner2Field.String", "String", "String", "required")
 }
 
 func TestStructLevelReturnValidationErrorsWithJSON(t *testing.T) {
@@ -558,7 +558,7 @@ func TestStructLevelReturnValidationErrorsWithJSON(t *testing.T) {
 	}
 
 	inner1 := &TestStructReturnValidationErrorsInner1{
-		Inner2: inner2,
+		Inner2Field: inner2,
 	}
 
 	val := &TestStructReturnValidationErrors{
@@ -573,27 +573,27 @@ func TestStructLevelReturnValidationErrorsWithJSON(t *testing.T) {
 	errs = validate.Struct(val)
 	NotEqual(t, errs, nil)
 	Equal(t, len(errs.(ValidationErrors)), 2)
-	AssertError(t, errs, "TestStructReturnValidationErrors.Inner1JSON.Inner2.JSONString", "TestStructReturnValidationErrors.Inner1.Inner2.String", "JSONString", "String", "required")
+	AssertError(t, errs, "TestStructReturnValidationErrors.Inner1JSON.Inner2FieldJSON.JSONString", "TestStructReturnValidationErrors.Inner1.Inner2Field.String", "JSONString", "String", "required")
 	// this is an extra error reported from struct validation, it's a badly formatted one, but on purpose
-	AssertError(t, errs, "TestStructReturnValidationErrors.Inner1JSON.TestStructReturnValidationErrorsInner2.JSONString", "TestStructReturnValidationErrors.Inner1.TestStructReturnValidationErrorsInner2.String", "JSONString", "String", "required")
+	AssertError(t, errs, "TestStructReturnValidationErrors.Inner1JSON.Inner2FieldJSON.JSONString", "TestStructReturnValidationErrors.Inner1.Inner2Field.String", "JSONString", "String", "required")
 
-	fe := getError(errs, "TestStructReturnValidationErrors.Inner1JSON.Inner2.JSONString", "TestStructReturnValidationErrors.Inner1.Inner2.String")
+	fe := getError(errs, "TestStructReturnValidationErrors.Inner1JSON.Inner2FieldJSON.JSONString", "TestStructReturnValidationErrors.Inner1.Inner2Field.String")
 	NotEqual(t, fe, nil)
 
 	// check for proper JSON namespace
 	Equal(t, fe.Field(), "JSONString")
 	Equal(t, fe.StructField(), "String")
-	Equal(t, fe.Namespace(), "TestStructReturnValidationErrors.Inner1JSON.Inner2.JSONString")
-	Equal(t, fe.StructNamespace(), "TestStructReturnValidationErrors.Inner1.Inner2.String")
+	Equal(t, fe.Namespace(), "TestStructReturnValidationErrors.Inner1JSON.Inner2FieldJSON.JSONString")
+	Equal(t, fe.StructNamespace(), "TestStructReturnValidationErrors.Inner1.Inner2Field.String")
 
-	fe = getError(errs, "TestStructReturnValidationErrors.Inner1JSON.TestStructReturnValidationErrorsInner2.JSONString", "TestStructReturnValidationErrors.Inner1.TestStructReturnValidationErrorsInner2.String")
+	fe = getError(errs, "TestStructReturnValidationErrors.Inner1JSON.Inner2FieldJSON.JSONString", "TestStructReturnValidationErrors.Inner1.Inner2Field.String")
 	NotEqual(t, fe, nil)
 
 	// check for proper JSON namespace
 	Equal(t, fe.Field(), "JSONString")
 	Equal(t, fe.StructField(), "String")
-	Equal(t, fe.Namespace(), "TestStructReturnValidationErrors.Inner1JSON.TestStructReturnValidationErrorsInner2.JSONString")
-	Equal(t, fe.StructNamespace(), "TestStructReturnValidationErrors.Inner1.TestStructReturnValidationErrorsInner2.String")
+	Equal(t, fe.Namespace(), "TestStructReturnValidationErrors.Inner1JSON.Inner2FieldJSON.JSONString")
+	Equal(t, fe.StructNamespace(), "TestStructReturnValidationErrors.Inner1.Inner2Field.String")
 }
 
 func TestStructLevelValidations(t *testing.T) {


### PR DESCRIPTION
Using ReportValidationErrors produces a distorted field path because the
type name from the errors is included. This can cause a "namespace"
like:

    Struct1Name.Field1Name.Field2Name.Struct2Name.Field3Name

This change strips out the type name from the errors when they are being
appended to an existing namespace.

I would prefer for the struct name to never be included (I have to work around this in my application), but I suspect this would be a more disruptive change.

@go-playground/admins