### PR TITLE
Correct consecutive or logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Package validator
 ================
 <img align="right" src="https://raw.githubusercontent.com/go-playground/validator/v9/logo.png">[![Join the chat at https://gitter.im/go-playground/validator](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/go-playground/validator?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-![Project status](https://img.shields.io/badge/version-9.9.0-green.svg)
+![Project status](https://img.shields.io/badge/version-9.9.1-green.svg)
 [![Build Status](https://semaphoreci.com/api/v1/joeybloggs/validator/branches/v9/badge.svg)](https://semaphoreci.com/joeybloggs/validator)
 [![Coverage Status](https://coveralls.io/repos/go-playground/validator/badge.svg?branch=v9&service=github)](https://coveralls.io/github/go-playground/validator?branch=v9)
 [![Go Report Card](https://goreportcard.com/badge/github.com/go-playground/validator)](https://goreportcard.com/report/github.com/go-playground/validator)

--- a/cache.go
+++ b/cache.go
@@ -96,6 +96,8 @@ type cTag struct {
 	next           *cTag
 	hasTag         bool
 	hasAlias       bool
+	hasParam       bool // true if parameter used eg. eq= where the equal sign has been set
+	isBlockEnd     bool // indicates the current tag represents the last validation in the block
 	fn             FuncCtx
 }
 
@@ -291,6 +293,7 @@ func (v *Validate) parseFieldTagsRecursive(tag string, fieldName string, alias s
 					current.next = &cTag{aliasTag: alias, actualAliasTag: current.actualAliasTag, hasAlias: hasAlias, hasTag: true}
 					current = current.next
 				}
+				current.hasParam = len(vals) > 1
 
 				current.tag = vals[0]
 				if len(current.tag) == 0 {
@@ -309,6 +312,7 @@ func (v *Validate) parseFieldTagsRecursive(tag string, fieldName string, alias s
 					current.param = strings.Replace(strings.Replace(vals[1], utf8HexComma, ",", -1), utf8Pipe, "|", -1)
 				}
 			}
+			current.isBlockEnd = true
 		}
 	}
 

--- a/validator.go
+++ b/validator.go
@@ -378,14 +378,13 @@ OUTER:
 				v.misc = append(v.misc, '|')
 				v.misc = append(v.misc, ct.tag...)
 
-				if len(ct.param) > 0 {
+				if ct.hasParam {
 					v.misc = append(v.misc, '=')
 					v.misc = append(v.misc, ct.param...)
 				}
 
-				if ct.next == nil || ct.next.typeof != typeOr { // ct.typeof != typeOr
+				if ct.isBlockEnd || ct.next == nil {
 					// if we get here, no valid 'or' value and no more tags
-
 					v.str1 = string(append(ns, cf.altName...))
 
 					if v.v.hasTagNameFunc {

--- a/validator_test.go
+++ b/validator_test.go
@@ -5585,6 +5585,13 @@ func TestOrTag(t *testing.T) {
 	errs = validate.Var(s, "omitempty,rgb|rgba")
 	Equal(t, errs, nil)
 
+	s = "green"
+	errs = validate.Var(s, "eq=|eq=blue,rgb|rgba") //should fail on first validation block
+	NotEqual(t, errs, nil)
+	ve := errs.(ValidationErrors)
+	Equal(t, len(ve), 1)
+	Equal(t, ve[0].Tag(), "eq=|eq=blue")
+
 	s = "this is right, but a blank or isn't"
 
 	PanicMatches(t, func() { validate.Var(s, "rgb||len=13") }, "Invalid validation tag on field ''")


### PR DESCRIPTION
This PR corrects checking of consecutive or blocks; the way it was checking for the end of an or validation block was incorrect.

**NOTE:** This bug only affected validation with consecutive or validation blocks eg.
```
block1 = tag1|tag2=
block2 = tag3|tag4
validate:"tag1|tag2=,tag3|tag4"
```

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Fixes #329 

@go-playground/admins