### PR TITLE
Correct Var tagCache locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Package validator
 ================
 <img align="right" src="https://raw.githubusercontent.com/go-playground/validator/v9/logo.png">[![Join the chat at https://gitter.im/go-playground/validator](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/go-playground/validator?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-![Project status](https://img.shields.io/badge/version-9.9.2-green.svg)
+![Project status](https://img.shields.io/badge/version-9.9.3-green.svg)
 [![Build Status](https://semaphoreci.com/api/v1/joeybloggs/validator/branches/v9/badge.svg)](https://semaphoreci.com/joeybloggs/validator)
 [![Coverage Status](https://coveralls.io/repos/go-playground/validator/badge.svg?branch=v9&service=github)](https://coveralls.io/github/go-playground/validator?branch=v9)
 [![Go Report Card](https://goreportcard.com/badge/github.com/go-playground/validator)](https://goreportcard.com/report/github.com/go-playground/validator)

--- a/cache.go
+++ b/cache.go
@@ -315,6 +315,23 @@ func (v *Validate) parseFieldTagsRecursive(tag string, fieldName string, alias s
 			current.isBlockEnd = true
 		}
 	}
-
 	return
+}
+
+func (v *Validate) fetchCacheTag(tag string) *cTag {
+	// find cached tag
+	ctag, found := v.tagCache.Get(tag)
+	if !found {
+		v.tagCache.lock.Lock()
+		defer v.tagCache.lock.Unlock()
+
+		// could have been multiple trying to access, but once first is done this ensures tag
+		// isn't parsed again.
+		ctag, found = v.tagCache.Get(tag)
+		if !found {
+			ctag, _ = v.parseFieldTagsRecursive(tag, "", "", false)
+			v.tagCache.Set(tag, ctag)
+		}
+	}
+	return ctag
 }

--- a/validator.go
+++ b/validator.go
@@ -473,9 +473,7 @@ OUTER:
 				)
 
 				return
-
 			}
-
 			ct = ct.next
 		}
 	}

--- a/validator_instance.go
+++ b/validator_instance.go
@@ -524,7 +524,6 @@ func (v *Validate) VarCtx(ctx context.Context, field interface{}, tag string) (e
 	ctag, ok := v.tagCache.Get(tag)
 	if !ok {
 		v.tagCache.lock.Lock()
-		defer v.tagCache.lock.Unlock()
 
 		// could have been multiple trying to access, but once first is done this ensures tag
 		// isn't parsed again.
@@ -533,6 +532,7 @@ func (v *Validate) VarCtx(ctx context.Context, field interface{}, tag string) (e
 			ctag, _ = v.parseFieldTagsRecursive(tag, "", "", false)
 			v.tagCache.Set(tag, ctag)
 		}
+		v.tagCache.lock.Unlock()
 	}
 
 	val := reflect.ValueOf(field)
@@ -540,7 +540,6 @@ func (v *Validate) VarCtx(ctx context.Context, field interface{}, tag string) (e
 	vd := v.pool.Get().(*validate)
 	vd.top = val
 	vd.isPartial = false
-
 	vd.traverseField(ctx, val, val, vd.ns[0:0], vd.actualNs[0:0], defaultCField, ctag)
 
 	if len(vd.errs) > 0 {
@@ -595,7 +594,6 @@ func (v *Validate) VarWithValueCtx(ctx context.Context, field interface{}, other
 	ctag, ok := v.tagCache.Get(tag)
 	if !ok {
 		v.tagCache.lock.Lock()
-		defer v.tagCache.lock.Unlock()
 
 		// could have been multiple trying to access, but once first is done this ensures tag
 		// isn't parsed again.
@@ -604,6 +602,7 @@ func (v *Validate) VarWithValueCtx(ctx context.Context, field interface{}, other
 			ctag, _ = v.parseFieldTagsRecursive(tag, "", "", false)
 			v.tagCache.Set(tag, ctag)
 		}
+		v.tagCache.lock.Unlock()
 	}
 
 	otherVal := reflect.ValueOf(other)


### PR DESCRIPTION
Fixes Or Enhances # .

PR fixes Var tagCache locking defering until the end of the function instead of sooner.

**Make sure that you've checked the boxes below before you submit PR:**
- [] ~Tests exist or have been written that cover this particular change.~
