### PR TITLE
Add oneof validation

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -6,7 +6,9 @@ import (
 	"net"
 	"net/url"
 	"reflect"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 )
@@ -135,8 +137,43 @@ var (
 		"hostname_rfc1123": isHostnameRFC1123, // RFC 1123
 		"fqdn":             isFQDN,
 		"unique":           isUnique,
+		"oneof":            isOneOf,
 	}
 )
+
+var oneofValCache = map[string][]string{}
+var oneofValCacheLock = sync.Mutex{}
+
+func isOneOf(fl FieldLevel) bool {
+	param := fl.Param()
+	oneofValCacheLock.Lock()
+	vals, ok := oneofValCache[param]
+	if !ok {
+		vals = strings.Fields(param)
+		oneofValCache[param] = vals
+	}
+	oneofValCacheLock.Unlock()
+
+	field := fl.Field()
+
+	var v string
+	switch field.Kind() {
+	case reflect.String:
+		v = field.String()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v = strconv.FormatInt(field.Int(), 10)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v = strconv.FormatUint(field.Uint(), 10)
+	default:
+		panic(fmt.Sprintf("Bad field type %T", field.Interface()))
+	}
+	for i := 0; i < len(vals); i++ {
+		if vals[i] == v {
+			return true
+		}
+	}
+	return false
+}
 
 // isUnique is the validation function for validating if each array|slice element is unique
 func isUnique(fl FieldLevel) bool {

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -1184,3 +1184,27 @@ func BenchmarkStructComplexFailureParallel(b *testing.B) {
 		}
 	})
 }
+
+type TestOneof struct {
+	Color string `validate:"oneof=red green"`
+}
+
+func BenchmarkOneof(b *testing.B) {
+	w := &TestOneof{Color: "green"}
+	val := New()
+	for i := 0; i < b.N; i++ {
+		val.Struct(w)
+	}
+}
+
+func BenchmarkOneofParallel(b *testing.B) {
+	w := &TestOneof{Color: "green"}
+	val := New()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			val.Struct(w)
+		}
+	})
+}

--- a/doc.go
+++ b/doc.go
@@ -295,6 +295,16 @@ validates the number of items.
 
 	Usage: ne=10
 
+One Of
+
+For strings, ints, and uints, oneof will ensure that the value
+is one of the values in the parameter.  The parameter should be
+a list of values separated by whitespace.  Values may be
+strings or numbers.
+
+    Usage: oneof=red green
+           oneof=5 7 9
+
 Greater Than
 
 For numbers, this will ensure that the value is greater than the

--- a/translations/en/en.go
+++ b/translations/en/en.go
@@ -1294,6 +1294,19 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0} must be a valid color",
 			override:    false,
 		},
+		{
+			tag:         "oneof",
+			translation: "{0} must be one of [{1}]",
+			override:    false,
+			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
+				s, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
+				if err != nil {
+					log.Printf("warning: error translating FieldError: %#v", fe)
+					return fe.(error).Error()
+				}
+				return s
+			},
+		},
 	}
 
 	for _, t := range translations {

--- a/translations/en/en_test.go
+++ b/translations/en/en_test.go
@@ -136,6 +136,8 @@ func TestTranslations(t *testing.T) {
 		StrPtrLte         *string   `validate:"lte=1"`
 		StrPtrGt          *string   `validate:"gt=10"`
 		StrPtrGte         *string   `validate:"gte=10"`
+		OneOfString       string    `validate:"oneof=red green"`
+		OneOfInt          int       `validate:"oneof=5 63"`
 	}
 
 	var test Test
@@ -603,6 +605,14 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.StrPtrGte",
 			expected: "StrPtrGte must be at least 10 characters in length",
+		},
+		{
+			ns:       "Test.OneOfString",
+			expected: "OneOfString must be one of [red green]",
+		},
+		{
+			ns:       "Test.OneOfInt",
+			expected: "OneOfInt must be one of [5 63]",
 		},
 	}
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -4314,6 +4314,66 @@ func TestIsEqValidation(t *testing.T) {
 	PanicMatches(t, func() { validate.Var(now, "eq=now") }, "Bad field type time.Time")
 }
 
+func TestOneOfValidation(t *testing.T) {
+	validate := New()
+
+	passSpecs := []struct {
+		f interface{}
+		t string
+	}{
+		{f: "red", t: "oneof=red green"},
+		{f: "green", t: "oneof=red green"},
+		{f: 5, t: "oneof=5 6"},
+		{f: 6, t: "oneof=5 6"},
+		{f: int8(6), t: "oneof=5 6"},
+		{f: int16(6), t: "oneof=5 6"},
+		{f: int32(6), t: "oneof=5 6"},
+		{f: int64(6), t: "oneof=5 6"},
+		{f: uint(6), t: "oneof=5 6"},
+		{f: uint8(6), t: "oneof=5 6"},
+		{f: uint16(6), t: "oneof=5 6"},
+		{f: uint32(6), t: "oneof=5 6"},
+		{f: uint64(6), t: "oneof=5 6"},
+	}
+
+	for _, spec := range passSpecs {
+		t.Logf("%#v", spec)
+		errs := validate.Var(spec.f, spec.t)
+		Equal(t, errs, nil)
+	}
+
+	failSpecs := []struct {
+		f interface{}
+		t string
+	}{
+		{f: "", t: "oneof=red green"},
+		{f: "yellow", t: "oneof=red green"},
+		{f: 5, t: "oneof=red green"},
+		{f: 6, t: "oneof=red green"},
+		{f: 6, t: "oneof=7"},
+		{f: uint(6), t: "oneof=7"},
+		{f: int8(5), t: "oneof=red green"},
+		{f: int16(5), t: "oneof=red green"},
+		{f: int32(5), t: "oneof=red green"},
+		{f: int64(5), t: "oneof=red green"},
+		{f: uint(5), t: "oneof=red green"},
+		{f: uint8(5), t: "oneof=red green"},
+		{f: uint16(5), t: "oneof=red green"},
+		{f: uint32(5), t: "oneof=red green"},
+		{f: uint64(5), t: "oneof=red green"},
+	}
+
+	for _, spec := range failSpecs {
+		t.Logf("%#v", spec)
+		errs := validate.Var(spec.f, spec.t)
+		AssertError(t, errs, "", "", "", "", "oneof")
+	}
+
+	PanicMatches(t, func() {
+		validate.Var(3.14, "oneof=red green")
+	}, "Bad field type float64")
+}
+
 func TestBase64Validation(t *testing.T) {
 
 	validate := New()


### PR DESCRIPTION
**Make sure that you've checked the boxes below before you submit PR:**
- [X] Tests exist or have been written that cover this particular change.

Change Details:

Validates that a string or number value equals one of a set of allowed values.  Examples:

    validator.Var(“red”, “oneof=red green”)
    validator.Var(6, “oneof=6 7 8”)

Handles values of type string, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, and uint64.

The translation reads "Color must be one of [red green]".

When the field value is a numeric type, it's converted to a string before comparison.  So the param values are always treated as strings.

The param values are parsed using strings.Fields() (which splits by whitespace).  To speed it up, there is an internal cache of parsed params, protected by a mutex.  Benchmarking demonstrated this cut eval time in half, from 500 ns to 250 ns.  They are both pretty negligible, so if you're prefer less complexity, it's not a big deal to lose the cache.

For comparison, I also benchmarked using the sync.Map type rather than a mutex, but that was slower.

Also benchmarked using slice iteration vs a map lookup for testing the field against the param values.  slice iteration proved faster when the number of param values was 10.  I don't expect more values than that.
- 
- 
- 


@go-playground/admins