### PR TITLE
Fix FieldError doc

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -122,7 +122,7 @@ type FieldError interface {
 	// fields actual name.
 	//
 	// eq. JSON name "fname"
-	// see ActualField for comparison
+	// see StructField for comparison
 	Field() string
 
 	// returns the fields actual name from the struct, when able to determine.


### PR DESCRIPTION
Hello,

Seems like `ActualField` was renamed to `StructField` but doc mentions old name

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:

- Change doc for FieldError interface


@go-playground/admins