### PR TITLE
Document RegisterTagNameFunc more

### DIFF
--- a/validator_instance.go
+++ b/validator_instance.go
@@ -119,8 +119,17 @@ func (v *Validate) SetTagName(name string) {
 	v.tagName = name
 }
 
-// RegisterTagNameFunc registers a function to get another name from the
-// StructField eg. the JSON name
+// RegisterTagNameFunc registers a function to get alternate names for StructFields.
+//
+// eg. to use the names which have been specified for JSON representations of structs, rather than normal Go field names:
+//
+//    validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
+//        name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
+//        if name == "-" {
+//            return ""
+//        }
+//        return name
+//    })
 func (v *Validate) RegisterTagNameFunc(fn TagNameFunc) {
 	v.tagNameFunc = fn
 	v.hasTagNameFunc = true


### PR DESCRIPTION
**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

I noticed a code snippet was often being copy-pasted in the issue tracker, in response to questions about how to get JSON key names to show in error messages rather than Go field names. This PR puts that snippet right into the GoDoc for `RegisterTagNameFunc` so that it is more discoverable.

@go-playground/admins