### PR TITLE
Fix #352 Returns error when passing pointer to RegisterStructValidation

### DIFF
--- a/validator_instance.go
+++ b/validator_instance.go
@@ -189,38 +189,31 @@ func (v *Validate) RegisterAlias(alias, tags string) {
 
 // RegisterStructValidation registers a StructLevelFunc against a number of types.
 //
-// It returns error when type being passed is a pointer.
 // NOTE:
 // - this method is not thread-safe it is intended that these all be registered prior to any validation
-func (v *Validate) RegisterStructValidation(fn StructLevelFunc, types ...interface{}) error {
-	return v.RegisterStructValidationCtx(wrapStructLevelFunc(fn), types...)
+func (v *Validate) RegisterStructValidation(fn StructLevelFunc, types ...interface{}) {
+	v.RegisterStructValidationCtx(wrapStructLevelFunc(fn), types...)
 }
 
 // RegisterStructValidationCtx registers a StructLevelFuncCtx against a number of types and allows passing
 // of contextual validation information via context.Context.
 //
-// It returns error when type being passed is a pointer.
 // NOTE:
 // - this method is not thread-safe it is intended that these all be registered prior to any validation
-func (v *Validate) RegisterStructValidationCtx(fn StructLevelFuncCtx, types ...interface{}) error {
+func (v *Validate) RegisterStructValidationCtx(fn StructLevelFuncCtx, types ...interface{}) {
 
 	if v.structLevelFuncs == nil {
 		v.structLevelFuncs = make(map[reflect.Type]StructLevelFuncCtx)
 	}
 
 	for _, t := range types {
-		if reflect.ValueOf(t).Kind() == reflect.Ptr {
-			return fmt.Errorf(
-				"Type must be a non-pointer, %s is a pointer",
-				reflect.TypeOf(t))
+		tv := reflect.ValueOf(t)
+		if tv.Kind() == reflect.Ptr {
+			t = reflect.Indirect(tv).Interface()
 		}
-	}
 
-	for _, t := range types {
 		v.structLevelFuncs[reflect.TypeOf(t)] = fn
 	}
-
-	return nil
 }
 
 // RegisterCustomTypeFunc registers a CustomTypeFunc against a number of types

--- a/validator_test.go
+++ b/validator_test.go
@@ -8152,12 +8152,13 @@ func TestKeyOrs(t *testing.T) {
 
 func TestStructLevelValidationsPointerPassing(t *testing.T) {
 	v1 := New()
-	err1 := v1.RegisterStructValidation(StructValidationTestStruct, &TestStruct{})
-	NotEqual(t, err1, nil)
-	Equal(t, err1.Error(),
-		"Type must be a non-pointer, *validator.TestStruct is a pointer")
+	v1.RegisterStructValidation(StructValidationTestStruct, &TestStruct{})
 
-	v2 := New()
-	err2 := v2.RegisterStructValidation(StructValidationTestStruct, TestStruct{})
-	Equal(t, err2, nil)
+	tst := &TestStruct{
+		String: "good value",
+	}
+
+	errs := v1.Struct(tst)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TestStruct.StringVal", "TestStruct.String", "StringVal", "String", "badvalueteststruct")
 }


### PR DESCRIPTION
Fixes #352.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:
- Returns error on pointer type detection at RegisterStructValidationCtx
- Returns error at RegisterStructValidation


@go-playground/admins