### PR TITLE
Make it compatible with some mock library such as go-sqlmock

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -549,7 +550,17 @@ func (v *Validate) tranverseStruct(topStruct reflect.Value, currentStruct reflec
 	// if present
 	if first || ct == nil || ct.typeof != typeStructOnly {
 
-		for _, f := range cs.fields {
+		//By hxmhlt @2018.11.9
+		// Modify range map to range sorted mapKey slice for sorting the struct field , promise my custom validation call ordered to make it compatible with some mock library such as gp-sqlmock
+		var keys []int
+		for k := range cs.fields {
+			keys = append(keys, k)
+		}
+		sort.Ints(keys)
+
+		for _, k := range keys {
+
+			f := cs.fields[k]
 
 			if partial {
 

--- a/validator.go
+++ b/validator.go
@@ -551,7 +551,7 @@ func (v *Validate) tranverseStruct(topStruct reflect.Value, currentStruct reflec
 	if first || ct == nil || ct.typeof != typeStructOnly {
 
 		//By hxmhlt @2018.11.9
-		// Modify range map to range sorted mapKey slice for sorting the struct field , promise my custom validation call ordered to make it compatible with some mock library such as gp-sqlmock
+		// Modify range map to range sorted mapKey slice for sorting the struct field , promise my custom validation call ordered to make it compatible with some mock library such as go-sqlmock
 		var keys []int
 		for k := range cs.fields {
 			keys = append(keys, k)


### PR DESCRIPTION

Change Details:
When I use some mock library such as go-sqlmock.It will expect some db operations in order.
But when I mock my project include some my own validator with validator.v8(custom validator tag) , some error occured.

Because code in here is range the struct field map and you know map in golang is out-of-order , I can not make it compatible with the mock sql in-order.

**So I change the  range of struct field map to range sorted mapKey slice and it solved.**


@go-playground/admins