### PR TITLE
Allow ValidationErrors type to be used externally

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -44,11 +44,11 @@ func (ve ValidationErrors) Error() string {
 
 	buff := bytes.NewBufferString("")
 
-	var fe *fieldError
+	var fe FieldError
 
 	for i := 0; i < len(ve); i++ {
 
-		fe = ve[i].(*fieldError)
+		fe = ve[i].(FieldError)
 		buff.WriteString(fe.Error())
 		buff.WriteString("\n")
 	}
@@ -61,10 +61,10 @@ func (ve ValidationErrors) Translate(ut ut.Translator) ValidationErrorsTranslati
 
 	trans := make(ValidationErrorsTranslations)
 
-	var fe *fieldError
+	var fe FieldError
 
 	for i := 0; i < len(ve); i++ {
-		fe = ve[i].(*fieldError)
+		fe = ve[i].(FieldError)
 
 		// // in case an Anonymous struct was used, ensure that the key
 		// // would be 'Username' instead of ".Username"
@@ -155,6 +155,9 @@ type FieldError interface {
 	// NOTE: is not registered translation can be found it returns the same
 	// as calling fe.Error()
 	Translate(ut ut.Translator) string
+
+	// Error returns the FieldError's error message
+	Error() string
 }
 
 // compile time interface checks

--- a/errors.go
+++ b/errors.go
@@ -61,10 +61,10 @@ func (ve ValidationErrors) Translate(ut ut.Translator) ValidationErrorsTranslati
 
 	trans := make(ValidationErrorsTranslations)
 
-	var fe FieldError
+	var fe *fieldError
 
 	for i := 0; i < len(ve); i++ {
-		fe = ve[i].(FieldError)
+		fe = ve[i].(*fieldError)
 
 		// // in case an Anonymous struct was used, ensure that the key
 		// // would be 'Username' instead of ".Username"


### PR DESCRIPTION
The `ValidationErrors` type is public, but inside its 2 functions it casts to the private `fieldError`. Since there is no way to access the `fieldError` outside this package it meant creating and using `ValidationErrors` outside this package was impossible.

My use case is for testing, I'm trying to test how my code behaves when various `ValidationErrors` are returned without needing to actually setup data to fail in the various ways.

Fixes Or Enhances # .

**Make sure that you've checked the boxes below before you submit PR:**
- [ ] Tests exist or have been written that cover this particular change.

Change Details:

- 
- 
- 


@go-playground/admins