### PR TITLE
Add baked in validators for containsfield and excludesfield

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -83,6 +83,8 @@ var (
 		"gtfield":          isGtField,
 		"ltefield":         isLteField,
 		"ltfield":          isLtField,
+		"containsfield":    containsField,
+		"excludesfield":    excludesField,
 		"alpha":            isAlpha,
 		"alphanum":         isAlphanum,
 		"alphaunicode":     isAlphaUnicode,
@@ -582,6 +584,31 @@ func containsAny(fl FieldLevel) bool {
 // Contains is the validation function for validating that the field's value contains the text specified within the param.
 func contains(fl FieldLevel) bool {
 	return strings.Contains(fl.Field().String(), fl.Param())
+}
+
+// ContainsField is the validation function for validating if the current field's value contains the field specified by the param's value.
+func containsField(fl FieldLevel) bool {
+	field := fl.Field()
+
+	currentField, _, ok := fl.GetStructFieldOK()
+
+	if !ok {
+		return false
+	}
+
+	return strings.Contains(field.String(), currentField.String())
+}
+
+// ExcludesField is the validation function for validating if the current field's value excludes the field specified by the param's value.
+func excludesField(fl FieldLevel) bool {
+	field := fl.Field()
+
+	currentField, _, ok := fl.GetStructFieldOK()
+	if !ok {
+		return true
+	}
+
+	return !strings.Contains(field.String(), currentField.String())
 }
 
 // IsNeField is the validation function for validating if the current field's value is not equal to the field specified by the param's value.

--- a/baked_in.go
+++ b/baked_in.go
@@ -83,8 +83,8 @@ var (
 		"gtfield":          isGtField,
 		"ltefield":         isLteField,
 		"ltfield":          isLtField,
-		"containsfield":    containsField,
-		"excludesfield":    excludesField,
+		"fieldcontains":    fieldContains,
+		"fieldexcludes":    fieldExcludes,
 		"alpha":            isAlpha,
 		"alphanum":         isAlphanum,
 		"alphaunicode":     isAlphaUnicode,
@@ -586,8 +586,8 @@ func contains(fl FieldLevel) bool {
 	return strings.Contains(fl.Field().String(), fl.Param())
 }
 
-// ContainsField is the validation function for validating if the current field's value contains the field specified by the param's value.
-func containsField(fl FieldLevel) bool {
+// FieldContains is the validation function for validating if the current field's value contains the field specified by the param's value.
+func fieldContains(fl FieldLevel) bool {
 	field := fl.Field()
 
 	currentField, _, ok := fl.GetStructFieldOK()
@@ -599,8 +599,8 @@ func containsField(fl FieldLevel) bool {
 	return strings.Contains(field.String(), currentField.String())
 }
 
-// ExcludesField is the validation function for validating if the current field's value excludes the field specified by the param's value.
-func excludesField(fl FieldLevel) bool {
+// FieldExcludes is the validation function for validating if the current field's value excludes the field specified by the param's value.
+func fieldExcludes(fl FieldLevel) bool {
 	field := fl.Field()
 
 	currentField, _, ok := fl.GetStructFieldOK()

--- a/doc.go
+++ b/doc.go
@@ -503,6 +503,22 @@ to the top level struct.
 
 	Usage: ltecsfield=InnerStructField.Field
 
+Field Contains Another Field
+
+This does the same as contains except for struct fields. It should only be used
+with string types. See the behavior of reflect.Value.String() for behavior on
+other types.
+
+	Usage: containsfield=InnerStructField.Field
+
+Field Excludes Another Field
+
+This does the same as excludes except for struct fields. It should only be used
+with string types. See the behavior of reflect.Value.String() for behavior on
+other types.
+
+	Usage: excludesfield=InnerStructField.Field
+
 Unique
 
 For arrays & slices, unique will ensure that there are no duplicates.

--- a/validator_test.go
+++ b/validator_test.go
@@ -5146,9 +5146,11 @@ func TestContainsField(t *testing.T) {
 	AssertError(t, errs, "StringTest.Foo", "StringTest.Foo", "Foo", "Foo", "containsfield")
 
 	errs = validate.VarWithValue("foo", "bar", "containsfield")
+	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "containsfield")
 
 	errs = validate.VarWithValue("bar", "foobarfoo", "containsfield")
+	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "containsfield")
 
 	errs = validate.VarWithValue("foobarfoo", "bar", "containsfield")
@@ -5187,6 +5189,7 @@ func TestExcludesField(t *testing.T) {
 	Equal(t, errs, nil)
 
 	errs = validate.VarWithValue("foobarfoo", "bar", "excludesfield")
+	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "excludesfield")
 }
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -5120,11 +5120,11 @@ func TestLtField(t *testing.T) {
 	AssertError(t, errs, "TimeTest2.End", "TimeTest2.End", "End", "End", "ltfield")
 }
 
-func TestContainsField(t *testing.T) {
+func TestFieldContains(t *testing.T) {
 	validate := New()
 
 	type StringTest struct {
-		Foo string `validate:"containsfield=Bar"`
+		Foo string `validate:"fieldcontains=Bar"`
 		Bar string
 	}
 
@@ -5143,21 +5143,21 @@ func TestContainsField(t *testing.T) {
 
 	errs = validate.Struct(stringTest)
 	NotEqual(t, errs, nil)
-	AssertError(t, errs, "StringTest.Foo", "StringTest.Foo", "Foo", "Foo", "containsfield")
+	AssertError(t, errs, "StringTest.Foo", "StringTest.Foo", "Foo", "Foo", "fieldcontains")
 
-	errs = validate.VarWithValue("foo", "bar", "containsfield")
+	errs = validate.VarWithValue("foo", "bar", "fieldcontains")
 	NotEqual(t, errs, nil)
-	AssertError(t, errs, "", "", "", "", "containsfield")
+	AssertError(t, errs, "", "", "", "", "fieldcontains")
 
-	errs = validate.VarWithValue("bar", "foobarfoo", "containsfield")
+	errs = validate.VarWithValue("bar", "foobarfoo", "fieldcontains")
 	NotEqual(t, errs, nil)
-	AssertError(t, errs, "", "", "", "", "containsfield")
+	AssertError(t, errs, "", "", "", "", "fieldcontains")
 
-	errs = validate.VarWithValue("foobarfoo", "bar", "containsfield")
+	errs = validate.VarWithValue("foobarfoo", "bar", "fieldcontains")
 	Equal(t, errs, nil)
 
 	type StringTestMissingField struct {
-		Foo string `validate:"containsfield=Bar"`
+		Foo string `validate:"fieldcontains=Bar"`
 	}
 
 	stringTestMissingField := &StringTestMissingField{
@@ -5166,14 +5166,14 @@ func TestContainsField(t *testing.T) {
 
 	errs = validate.Struct(stringTestMissingField)
 	NotEqual(t, errs, nil)
-	AssertError(t, errs, "StringTestMissingField.Foo", "StringTestMissingField.Foo", "Foo", "Foo", "containsfield")
+	AssertError(t, errs, "StringTestMissingField.Foo", "StringTestMissingField.Foo", "Foo", "Foo", "fieldcontains")
 }
 
-func TestExcludesField(t *testing.T) {
+func TestFieldExcludes(t *testing.T) {
 	validate := New()
 
 	type StringTest struct {
-		Foo string `validate:"excludesfield=Bar"`
+		Foo string `validate:"fieldexcludes=Bar"`
 		Bar string
 	}
 
@@ -5184,7 +5184,7 @@ func TestExcludesField(t *testing.T) {
 
 	errs := validate.Struct(stringTest)
 	NotEqual(t, errs, nil)
-	AssertError(t, errs, "StringTest.Foo", "StringTest.Foo", "Foo", "Foo", "excludesfield")
+	AssertError(t, errs, "StringTest.Foo", "StringTest.Foo", "Foo", "Foo", "fieldexcludes")
 
 	stringTest = &StringTest{
 		Foo: "foo",
@@ -5194,18 +5194,18 @@ func TestExcludesField(t *testing.T) {
 	errs = validate.Struct(stringTest)
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue("foo", "bar", "excludesfield")
+	errs = validate.VarWithValue("foo", "bar", "fieldexcludes")
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue("bar", "foobarfoo", "excludesfield")
+	errs = validate.VarWithValue("bar", "foobarfoo", "fieldexcludes")
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue("foobarfoo", "bar", "excludesfield")
+	errs = validate.VarWithValue("foobarfoo", "bar", "fieldexcludes")
 	NotEqual(t, errs, nil)
-	AssertError(t, errs, "", "", "", "", "excludesfield")
+	AssertError(t, errs, "", "", "", "", "fieldexcludes")
 
 	type StringTestMissingField struct {
-		Foo string `validate:"excludesfield=Bar"`
+		Foo string `validate:"fieldexcludes=Bar"`
 	}
 
 	stringTestMissingField := &StringTestMissingField{
@@ -5220,8 +5220,8 @@ func TestContainsAndExcludes(t *testing.T) {
 	validate := New()
 
 	type ImpossibleStringTest struct {
-		Foo string `validate:"containsfield=Bar"`
-		Bar string `validate:"excludesfield=Foo"`
+		Foo string `validate:"fieldcontains=Bar"`
+		Bar string `validate:"fieldexcludes=Foo"`
 	}
 
 	impossibleStringTest := &ImpossibleStringTest{
@@ -5231,7 +5231,7 @@ func TestContainsAndExcludes(t *testing.T) {
 
 	errs := validate.Struct(impossibleStringTest)
 	NotEqual(t, errs, nil)
-	AssertError(t, errs, "ImpossibleStringTest.Foo", "ImpossibleStringTest.Foo", "Foo", "Foo", "containsfield")
+	AssertError(t, errs, "ImpossibleStringTest.Foo", "ImpossibleStringTest.Foo", "Foo", "Foo", "fieldcontains")
 
 	impossibleStringTest = &ImpossibleStringTest{
 		Foo: "bar",
@@ -5240,7 +5240,7 @@ func TestContainsAndExcludes(t *testing.T) {
 
 	errs = validate.Struct(impossibleStringTest)
 	NotEqual(t, errs, nil)
-	AssertError(t, errs, "ImpossibleStringTest.Foo", "ImpossibleStringTest.Foo", "Foo", "Foo", "containsfield")
+	AssertError(t, errs, "ImpossibleStringTest.Foo", "ImpossibleStringTest.Foo", "Foo", "Foo", "fieldcontains")
 }
 
 func TestLteField(t *testing.T) {

--- a/validator_test.go
+++ b/validator_test.go
@@ -5190,6 +5190,33 @@ func TestExcludesField(t *testing.T) {
 	AssertError(t, errs, "", "", "", "", "excludesfield")
 }
 
+func TestContainsAndExcludes(t *testing.T) {
+	validate := New()
+
+	type ImpossibleStringTest struct {
+		Foo string `validate:"containsfield=Bar"`
+		Bar string `validate:"excludesfield=Foo"`
+	}
+
+	impossibleStringTest := &ImpossibleStringTest{
+		Foo: "foo",
+		Bar: "bar",
+	}
+
+	errs := validate.Struct(impossibleStringTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "ImpossibleStringTest.Foo", "ImpossibleStringTest.Foo", "Foo", "Foo", "containsfield")
+
+	impossibleStringTest = &ImpossibleStringTest{
+		Foo: "bar",
+		Bar: "foo",
+	}
+
+	errs = validate.Struct(impossibleStringTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "ImpossibleStringTest.Foo", "ImpossibleStringTest.Foo", "Foo", "Foo", "containsfield")
+}
+
 func TestLteField(t *testing.T) {
 
 	validate := New()

--- a/validator_test.go
+++ b/validator_test.go
@@ -5120,6 +5120,76 @@ func TestLtField(t *testing.T) {
 	AssertError(t, errs, "TimeTest2.End", "TimeTest2.End", "End", "End", "ltfield")
 }
 
+func TestContainsField(t *testing.T) {
+	validate := New()
+
+	type StringTest struct {
+		Foo string `validate:"containsfield=Bar"`
+		Bar string
+	}
+
+	stringTest := &StringTest{
+		Foo: "foobar",
+		Bar: "bar",
+	}
+
+	errs := validate.Struct(stringTest)
+	Equal(t, errs, nil)
+
+	stringTest = &StringTest{
+		Foo: "foo",
+		Bar: "bar",
+	}
+
+	errs = validate.Struct(stringTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "StringTest.Foo", "StringTest.Foo", "Foo", "Foo", "containsfield")
+
+	errs = validate.VarWithValue("foo", "bar", "containsfield")
+	AssertError(t, errs, "", "", "", "", "containsfield")
+
+	errs = validate.VarWithValue("bar", "foobarfoo", "containsfield")
+	AssertError(t, errs, "", "", "", "", "containsfield")
+
+	errs = validate.VarWithValue("foobarfoo", "bar", "containsfield")
+	Equal(t, errs, nil)
+}
+
+func TestExcludesField(t *testing.T) {
+	validate := New()
+
+	type StringTest struct {
+		Foo string `validate:"excludesfield=Bar"`
+		Bar string
+	}
+
+	stringTest := &StringTest{
+		Foo: "foobar",
+		Bar: "bar",
+	}
+
+	errs := validate.Struct(stringTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "StringTest.Foo", "StringTest.Foo", "Foo", "Foo", "excludesfield")
+
+	stringTest = &StringTest{
+		Foo: "foo",
+		Bar: "bar",
+	}
+
+	errs = validate.Struct(stringTest)
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue("foo", "bar", "excludesfield")
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue("bar", "foobarfoo", "excludesfield")
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue("foobarfoo", "bar", "excludesfield")
+	AssertError(t, errs, "", "", "", "", "excludesfield")
+}
+
 func TestLteField(t *testing.T) {
 
 	validate := New()

--- a/validator_test.go
+++ b/validator_test.go
@@ -5155,6 +5155,18 @@ func TestContainsField(t *testing.T) {
 
 	errs = validate.VarWithValue("foobarfoo", "bar", "containsfield")
 	Equal(t, errs, nil)
+
+	type StringTestMissingField struct {
+		Foo string `validate:"containsfield=Bar"`
+	}
+
+	stringTestMissingField := &StringTestMissingField{
+		Foo: "foo",
+	}
+
+	errs = validate.Struct(stringTestMissingField)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "StringTestMissingField.Foo", "StringTestMissingField.Foo", "Foo", "Foo", "containsfield")
 }
 
 func TestExcludesField(t *testing.T) {
@@ -5191,6 +5203,17 @@ func TestExcludesField(t *testing.T) {
 	errs = validate.VarWithValue("foobarfoo", "bar", "excludesfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "excludesfield")
+
+	type StringTestMissingField struct {
+		Foo string `validate:"excludesfield=Bar"`
+	}
+
+	stringTestMissingField := &StringTestMissingField{
+		Foo: "foo",
+	}
+
+	errs = validate.Struct(stringTestMissingField)
+	Equal(t, errs, nil)
 }
 
 func TestContainsAndExcludes(t *testing.T) {


### PR DESCRIPTION
- [x] Tests exist or have been written that cover this particular change.

Change Details:

- Adds containsfield baked in validator, as well as tests and documentation for containsfield.
- Adds excludesfield baked in validator, as well as tests and documentation for excludesfield.


@go-playground/admins