### PR TITLE
Allow latitude/longitude validation for numeric values

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -304,12 +304,12 @@ func isSSN(fl FieldLevel) bool {
 
 // IsLongitude is the validation function for validating if the field's value is a valid longitude coordinate.
 func isLongitude(fl FieldLevel) bool {
-	return longitudeRegex.MatchString(fl.Field().String())
+	return longitudeRegex.MatchString(fmt.Sprint(fl.Field().Interface()))
 }
 
 // IsLatitude is the validation function for validating if the field's value is a valid latitude coordinate.
 func isLatitude(fl FieldLevel) bool {
-	return latitudeRegex.MatchString(fl.Field().String())
+	return latitudeRegex.MatchString(fmt.Sprint(fl.Field().Interface()))
 }
 
 // IsDataURI is the validation function for validating if the field's value is a valid data URI.

--- a/baked_in.go
+++ b/baked_in.go
@@ -304,12 +304,48 @@ func isSSN(fl FieldLevel) bool {
 
 // IsLongitude is the validation function for validating if the field's value is a valid longitude coordinate.
 func isLongitude(fl FieldLevel) bool {
-	return longitudeRegex.MatchString(fmt.Sprint(fl.Field().Interface()))
+	field := fl.Field()
+
+	var v string
+	switch field.Kind() {
+	case reflect.String:
+		v = field.String()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v = strconv.FormatInt(field.Int(), 10)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v = strconv.FormatUint(field.Uint(), 10)
+	case reflect.Float32:
+		v = strconv.FormatFloat(field.Float(), 'f', -1, 32)
+	case reflect.Float64:
+		v = strconv.FormatFloat(field.Float(), 'f', -1, 64)
+	default:
+		panic(fmt.Sprintf("Bad field type %T", field.Interface()))
+	}
+
+	return longitudeRegex.MatchString(v)
 }
 
 // IsLatitude is the validation function for validating if the field's value is a valid latitude coordinate.
 func isLatitude(fl FieldLevel) bool {
-	return latitudeRegex.MatchString(fmt.Sprint(fl.Field().Interface()))
+	field := fl.Field()
+
+	var v string
+	switch field.Kind() {
+	case reflect.String:
+		v = field.String()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v = strconv.FormatInt(field.Int(), 10)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v = strconv.FormatUint(field.Uint(), 10)
+	case reflect.Float32:
+		v = strconv.FormatFloat(field.Float(), 'f', -1, 32)
+	case reflect.Float64:
+		v = strconv.FormatFloat(field.Float(), 'f', -1, 64)
+	default:
+		panic(fmt.Sprintf("Bad field type %T", field.Interface()))
+	}
+
+	return latitudeRegex.MatchString(v)
 }
 
 // IsDataURI is the validation function for validating if the field's value is a valid data URI.

--- a/validator_test.go
+++ b/validator_test.go
@@ -3335,7 +3335,7 @@ func TestSSNValidation(t *testing.T) {
 
 func TestLongitudeValidation(t *testing.T) {
 	tests := []struct {
-		param    string
+		param    interface{}
 		expected bool
 	}{
 		{"", false},
@@ -3344,6 +3344,8 @@ func TestLongitudeValidation(t *testing.T) {
 		{"+73.234", true},
 		{"+382.3811", false},
 		{"23.11111111", true},
+		{-180, true},
+		{180.1, false},
 	}
 
 	validate := New()
@@ -3371,7 +3373,7 @@ func TestLongitudeValidation(t *testing.T) {
 
 func TestLatitudeValidation(t *testing.T) {
 	tests := []struct {
-		param    string
+		param    interface{}
 		expected bool
 	}{
 		{"", false},
@@ -3380,6 +3382,8 @@ func TestLatitudeValidation(t *testing.T) {
 		{"47.1231231", true},
 		{"+99.9", false},
 		{"108", false},
+		{-90, true},
+		{90, true},
 	}
 
 	validate := New()

--- a/validator_test.go
+++ b/validator_test.go
@@ -3344,6 +3344,8 @@ func TestLongitudeValidation(t *testing.T) {
 		{"+73.234", true},
 		{"+382.3811", false},
 		{"23.11111111", true},
+		{uint(180), true},
+		{float32(-180.0), true},
 		{-180, true},
 		{180.1, false},
 	}
@@ -3369,6 +3371,8 @@ func TestLongitudeValidation(t *testing.T) {
 			}
 		}
 	}
+
+	PanicMatches(t, func() { validate.Var(true, "longitude") }, "Bad field type bool")
 }
 
 func TestLatitudeValidation(t *testing.T) {
@@ -3382,8 +3386,10 @@ func TestLatitudeValidation(t *testing.T) {
 		{"47.1231231", true},
 		{"+99.9", false},
 		{"108", false},
+		{uint(90), true},
+		{float32(-90.0), true},
 		{-90, true},
-		{90, true},
+		{90.1, false},
 	}
 
 	validate := New()
@@ -3407,6 +3413,8 @@ func TestLatitudeValidation(t *testing.T) {
 			}
 		}
 	}
+
+	PanicMatches(t, func() { validate.Var(true, "latitude") }, "Bad field type bool")
 }
 
 func TestDataURIValidation(t *testing.T) {

--- a/validator_test.go
+++ b/validator_test.go
@@ -3366,7 +3366,7 @@ func TestLongitudeValidation(t *testing.T) {
 			} else {
 				val := getError(errs, "", "")
 				if val.Tag() != "longitude" {
-					t.Fatalf("Index: %d Latitude failed Error: %s", i, errs)
+					t.Fatalf("Index: %d Longitude failed Error: %s", i, errs)
 				}
 			}
 		}


### PR DESCRIPTION
**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:
- Make latitude/longitude validation work with types other than `string`s.

@go-playground/admins