### PR TITLE
fix tag name

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -413,10 +413,10 @@ Here is a list of the current built in validators:
 		NOTE: if the string is blank, this validates as true.
 		(Usage: ascii)
 
-	asciiprint
+	printascii
 		This validates that a string value contains only printable ASCII characters.
 		NOTE: if the string is blank, this validates as true.
-		(Usage: asciiprint)
+		(Usage: printascii)
 
 	multibyte
 		This validates that a string value contains one or more multibyte characters.


### PR DESCRIPTION
Fix typo.
I found incorrect tag name in doc when I use v8, and fix.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:

- I change `asciiprint` to `printascii`.


@go-playground/admins