### PR TITLE
fix tag name in doc

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -665,7 +665,7 @@ Printable ASCII
 This validates that a string value contains only printable ASCII characters.
 NOTE: if the string is blank, this validates as true.
 
-	Usage: asciiprint
+	Usage: printascii
 
 Multi-Byte Characters
 


### PR DESCRIPTION
Fix typo.
I found incorrect tag name in doc when I used v8, and fixed.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:

- I change asciiprint to printascii.


@go-playground/admins