### PR TITLE
better SSN regex

### DIFF
--- a/regexes.go
+++ b/regexes.go
@@ -34,7 +34,7 @@ const (
 	dataURIRegexString               = "^data:.+\\/(.+);base64$"
 	latitudeRegexString              = "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?)$"
 	longitudeRegexString             = "^[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
-	sSNRegexString                   = `^\d{3}[- ]?\d{2}[- ]?\d{4}$`
+	sSNRegexString                   = `^[0-9]{3}[ -]?(0[1-9]|[1-9][0-9])[ -]?([1-9][0-9]{3}|[0-9][1-9][0-9]{2}|[0-9]{2}[1-9][0-9]|[0-9]{3}[1-9])$`
 	hostnameRegexStringRFC952        = `^[a-zA-Z][a-zA-Z0-9\-\.]+[a-z-Az0-9]$`    // https://tools.ietf.org/html/rfc952
 	hostnameRegexStringRFC1123       = `^[a-zA-Z0-9][a-zA-Z0-9\-\.]+[a-z-Az0-9]$` // accepts hostname starting with a digit https://tools.ietf.org/html/rfc1123
 	btcAddressRegexString            = `^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$`        // bitcoin address


### PR DESCRIPTION
Enhances SSN Validation.

* does not allow 00 group number
* does not allow 0000 serial number

More Info:

https://www.ssa.gov/employer/randomization.html
> Previously unassigned area numbers were introduced for assignment excluding area numbers 000, 666 and 900-999.

https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch04s12.html

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:

- 
- 
- 


@go-playground/admins