### PR TITLE
Add `startswith` and `endswith` validators

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -112,6 +112,8 @@ var (
 		"excludes":         excludes,
 		"excludesall":      excludesAll,
 		"excludesrune":     excludesRune,
+		"startswith":       startsWith,
+		"endswith":         endsWith,
 		"isbn":             isISBN,
 		"isbn10":           isISBN10,
 		"isbn13":           isISBN13,
@@ -648,6 +650,16 @@ func containsAny(fl FieldLevel) bool {
 // Contains is the validation function for validating that the field's value contains the text specified within the param.
 func contains(fl FieldLevel) bool {
 	return strings.Contains(fl.Field().String(), fl.Param())
+}
+
+// StartsWith is the validation function for validating that the field's value starts with the text specified within the param.
+func startsWith(fl FieldLevel) bool {
+	return strings.HasPrefix(fl.Field().String(), fl.Param())
+}
+
+// EndsWith is the validation function for validating that the field's value ends with the text specified within the param.
+func endsWith(fl FieldLevel) bool {
+	return strings.HasSuffix(fl.Field().String(), fl.Param())
 }
 
 // FieldContains is the validation function for validating if the current field's value contains the field specified by the param's value.

--- a/doc.go
+++ b/doc.go
@@ -714,6 +714,18 @@ This validates that a string value does not contain the supplied rune value.
 
 	Usage: excludesrune=@
 
+Starts With
+
+This validates that a string value starts with the supplied string value
+
+	Usage: startswith=hello
+
+Ends With
+
+This validates that a string value ends with the supplied string value
+
+	Usage: endswith=goodbye
+
 International Standard Book Number
 
 This validates that a string value contains a valid isbn10 or isbn13 value.

--- a/validator_test.go
+++ b/validator_test.go
@@ -8555,3 +8555,59 @@ func TestDirValidation(t *testing.T) {
 		validate.Var(2, "dir")
 	}, "Bad field type int")
 }
+
+func TestStartsWithValidation(t *testing.T) {
+	tests := []struct {
+		Value       string `validate:"startswith=(/^ヮ^)/*:・ﾟ✧"`
+		Tag         string
+		ExpectedNil bool
+	}{
+		{Value: "(/^ヮ^)/*:・ﾟ✧ glitter", Tag: "startswith=(/^ヮ^)/*:・ﾟ✧", ExpectedNil: true},
+		{Value: "abcd",  Tag: "startswith=(/^ヮ^)/*:・ﾟ✧", ExpectedNil: false},
+	}
+
+	validate := New()
+
+	for i, s := range tests {
+		errs := validate.Var(s.Value, s.Tag)
+
+		if (s.ExpectedNil && errs != nil) || (!s.ExpectedNil && errs == nil) {
+			t.Fatalf("Index: %d failed Error: %s", i, errs)
+		}
+
+		errs = validate.Struct(s)
+
+		if (s.ExpectedNil && errs != nil) || (!s.ExpectedNil && errs == nil) {
+			t.Fatalf("Index: %d failed Error: %s", i, errs)
+		}
+	}
+}
+
+func TestEndsWithValidation(t *testing.T) {
+	tests := []struct {
+		Value       string `validate:"endswith=(/^ヮ^)/*:・ﾟ✧"`
+		Tag         string
+		ExpectedNil bool
+	}{
+		{Value: "glitter (/^ヮ^)/*:・ﾟ✧", Tag: "endswith=(/^ヮ^)/*:・ﾟ✧", ExpectedNil: true},
+		{Value: "(/^ヮ^)/*:・ﾟ✧ glitter", Tag: "endswith=(/^ヮ^)/*:・ﾟ✧", ExpectedNil: false},
+	}
+
+	validate := New()
+
+	for i, s := range tests {
+		errs := validate.Var(s.Value, s.Tag)
+
+		if (s.ExpectedNil && errs != nil) || (!s.ExpectedNil && errs == nil) {
+			t.Fatalf("Index: %d failed Error: %s", i, errs)
+		}
+
+		errs = validate.Struct(s)
+
+		if (s.ExpectedNil && errs != nil) || (!s.ExpectedNil && errs == nil) {
+			t.Fatalf("Index: %d failed Error: %s", i, errs)
+		}
+	}
+}
+
+


### PR DESCRIPTION
**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:
- Add `startswith` and `endswith` validators
- Provides general and useful functionality that seems to align with other validators
- A very small wrapper around `strings.HasPrefix` and `strings.HasSuffix`
- Enhances functionality vs `contains` validator
- Was about to implement this in my own project, decided to make a pull request instead.

@go-playground/admins