### PR TITLE
Update main.go

### DIFF
--- a/_examples/struct-level/main.go
+++ b/_examples/struct-level/main.go
@@ -105,5 +105,5 @@ func UserStructLevelValidation(sl validator.StructLevel) {
 		sl.ReportError(user.LastName, "LastName", "lname", "fnameorlname", "")
 	}
 
-	// plus can to more, even with different tag than "fnameorlname"
+	// plus can do more, even with different tag than "fnameorlname"
 }


### PR DESCRIPTION
Just a typo.

- [ x ] Tests exist or have been written that cover this particular change.

Change Details:

- Just a typo fix in the structLevel-validation example.

@go-playground/admins