### PR TITLE
Add `required_with`, `required_with_all`, `required_without`, `required_without_all` validators

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -62,108 +62,109 @@ var (
 	// you can add, remove or even replace items to suite your needs,
 	// or even disregard and use your own map if so desired.
 	bakedInValidators = map[string]Func{
-		"required":          hasValue,
-		"required_with":     requiredWith,
-		"required_with_all": requiredWithAll,
-		"required_without":  requiredWithout,
-		"isdefault":         isDefault,
-		"len":               hasLengthOf,
-		"min":               hasMinOf,
-		"max":               hasMaxOf,
-		"eq":                isEq,
-		"ne":                isNe,
-		"lt":                isLt,
-		"lte":               isLte,
-		"gt":                isGt,
-		"gte":               isGte,
-		"eqfield":           isEqField,
-		"eqcsfield":         isEqCrossStructField,
-		"necsfield":         isNeCrossStructField,
-		"gtcsfield":         isGtCrossStructField,
-		"gtecsfield":        isGteCrossStructField,
-		"ltcsfield":         isLtCrossStructField,
-		"ltecsfield":        isLteCrossStructField,
-		"nefield":           isNeField,
-		"gtefield":          isGteField,
-		"gtfield":           isGtField,
-		"ltefield":          isLteField,
-		"ltfield":           isLtField,
-		"fieldcontains":     fieldContains,
-		"fieldexcludes":     fieldExcludes,
-		"alpha":             isAlpha,
-		"alphanum":          isAlphanum,
-		"alphaunicode":      isAlphaUnicode,
-		"alphanumunicode":   isAlphanumUnicode,
-		"numeric":           isNumeric,
-		"number":            isNumber,
-		"hexadecimal":       isHexadecimal,
-		"hexcolor":          isHEXColor,
-		"rgb":               isRGB,
-		"rgba":              isRGBA,
-		"hsl":               isHSL,
-		"hsla":              isHSLA,
-		"email":             isEmail,
-		"url":               isURL,
-		"uri":               isURI,
-		"urn_rfc2141":       isUrnRFC2141, // RFC 2141
-		"file":              isFile,
-		"base64":            isBase64,
-		"base64url":         isBase64URL,
-		"contains":          contains,
-		"containsany":       containsAny,
-		"containsrune":      containsRune,
-		"excludes":          excludes,
-		"excludesall":       excludesAll,
-		"excludesrune":      excludesRune,
-		"startswith":        startsWith,
-		"endswith":          endsWith,
-		"isbn":              isISBN,
-		"isbn10":            isISBN10,
-		"isbn13":            isISBN13,
-		"eth_addr":          isEthereumAddress,
-		"btc_addr":          isBitcoinAddress,
-		"btc_addr_bech32":   isBitcoinBech32Address,
-		"uuid":              isUUID,
-		"uuid3":             isUUID3,
-		"uuid4":             isUUID4,
-		"uuid5":             isUUID5,
-		"uuid_rfc4122":      isUUIDRFC4122,
-		"uuid3_rfc4122":     isUUID3RFC4122,
-		"uuid4_rfc4122":     isUUID4RFC4122,
-		"uuid5_rfc4122":     isUUID5RFC4122,
-		"ascii":             isASCII,
-		"printascii":        isPrintableASCII,
-		"multibyte":         hasMultiByteCharacter,
-		"datauri":           isDataURI,
-		"latitude":          isLatitude,
-		"longitude":         isLongitude,
-		"ssn":               isSSN,
-		"ipv4":              isIPv4,
-		"ipv6":              isIPv6,
-		"ip":                isIP,
-		"cidrv4":            isCIDRv4,
-		"cidrv6":            isCIDRv6,
-		"cidr":              isCIDR,
-		"tcp4_addr":         isTCP4AddrResolvable,
-		"tcp6_addr":         isTCP6AddrResolvable,
-		"tcp_addr":          isTCPAddrResolvable,
-		"udp4_addr":         isUDP4AddrResolvable,
-		"udp6_addr":         isUDP6AddrResolvable,
-		"udp_addr":          isUDPAddrResolvable,
-		"ip4_addr":          isIP4AddrResolvable,
-		"ip6_addr":          isIP6AddrResolvable,
-		"ip_addr":           isIPAddrResolvable,
-		"unix_addr":         isUnixAddrResolvable,
-		"mac":               isMAC,
-		"hostname":          isHostnameRFC952,  // RFC 952
-		"hostname_rfc1123":  isHostnameRFC1123, // RFC 1123
-		"fqdn":              isFQDN,
-		"unique":            isUnique,
-		"oneof":             isOneOf,
-		"html":              isHTML,
-		"html_encoded":      isHTMLEncoded,
-		"url_encoded":       isURLEncoded,
-		"dir":               isDir,
+		"required":             hasValue,
+		"required_with":        requiredWith,
+		"required_with_all":    requiredWithAll,
+		"required_without":     requiredWithout,
+		"required_without_all": requiredWithoutAll,
+		"isdefault":            isDefault,
+		"len":                  hasLengthOf,
+		"min":                  hasMinOf,
+		"max":                  hasMaxOf,
+		"eq":                   isEq,
+		"ne":                   isNe,
+		"lt":                   isLt,
+		"lte":                  isLte,
+		"gt":                   isGt,
+		"gte":                  isGte,
+		"eqfield":              isEqField,
+		"eqcsfield":            isEqCrossStructField,
+		"necsfield":            isNeCrossStructField,
+		"gtcsfield":            isGtCrossStructField,
+		"gtecsfield":           isGteCrossStructField,
+		"ltcsfield":            isLtCrossStructField,
+		"ltecsfield":           isLteCrossStructField,
+		"nefield":              isNeField,
+		"gtefield":             isGteField,
+		"gtfield":              isGtField,
+		"ltefield":             isLteField,
+		"ltfield":              isLtField,
+		"fieldcontains":        fieldContains,
+		"fieldexcludes":        fieldExcludes,
+		"alpha":                isAlpha,
+		"alphanum":             isAlphanum,
+		"alphaunicode":         isAlphaUnicode,
+		"alphanumunicode":      isAlphanumUnicode,
+		"numeric":              isNumeric,
+		"number":               isNumber,
+		"hexadecimal":          isHexadecimal,
+		"hexcolor":             isHEXColor,
+		"rgb":                  isRGB,
+		"rgba":                 isRGBA,
+		"hsl":                  isHSL,
+		"hsla":                 isHSLA,
+		"email":                isEmail,
+		"url":                  isURL,
+		"uri":                  isURI,
+		"urn_rfc2141":          isUrnRFC2141, // RFC 2141
+		"file":                 isFile,
+		"base64":               isBase64,
+		"base64url":            isBase64URL,
+		"contains":             contains,
+		"containsany":          containsAny,
+		"containsrune":         containsRune,
+		"excludes":             excludes,
+		"excludesall":          excludesAll,
+		"excludesrune":         excludesRune,
+		"startswith":           startsWith,
+		"endswith":             endsWith,
+		"isbn":                 isISBN,
+		"isbn10":               isISBN10,
+		"isbn13":               isISBN13,
+		"eth_addr":             isEthereumAddress,
+		"btc_addr":             isBitcoinAddress,
+		"btc_addr_bech32":      isBitcoinBech32Address,
+		"uuid":                 isUUID,
+		"uuid3":                isUUID3,
+		"uuid4":                isUUID4,
+		"uuid5":                isUUID5,
+		"uuid_rfc4122":         isUUIDRFC4122,
+		"uuid3_rfc4122":        isUUID3RFC4122,
+		"uuid4_rfc4122":        isUUID4RFC4122,
+		"uuid5_rfc4122":        isUUID5RFC4122,
+		"ascii":                isASCII,
+		"printascii":           isPrintableASCII,
+		"multibyte":            hasMultiByteCharacter,
+		"datauri":              isDataURI,
+		"latitude":             isLatitude,
+		"longitude":            isLongitude,
+		"ssn":                  isSSN,
+		"ipv4":                 isIPv4,
+		"ipv6":                 isIPv6,
+		"ip":                   isIP,
+		"cidrv4":               isCIDRv4,
+		"cidrv6":               isCIDRv6,
+		"cidr":                 isCIDR,
+		"tcp4_addr":            isTCP4AddrResolvable,
+		"tcp6_addr":            isTCP6AddrResolvable,
+		"tcp_addr":             isTCPAddrResolvable,
+		"udp4_addr":            isUDP4AddrResolvable,
+		"udp6_addr":            isUDP6AddrResolvable,
+		"udp_addr":             isUDPAddrResolvable,
+		"ip4_addr":             isIP4AddrResolvable,
+		"ip6_addr":             isIP6AddrResolvable,
+		"ip_addr":              isIPAddrResolvable,
+		"unix_addr":            isUnixAddrResolvable,
+		"mac":                  isMAC,
+		"hostname":             isHostnameRFC952,  // RFC 952
+		"hostname_rfc1123":     isHostnameRFC1123, // RFC 1123
+		"fqdn":                 isFQDN,
+		"unique":               isUnique,
+		"oneof":                isOneOf,
+		"html":                 isHTML,
+		"html_encoded":         isHTMLEncoded,
+		"url_encoded":          isURLEncoded,
+		"dir":                  isDir,
 	}
 )
 
@@ -1421,6 +1422,47 @@ func requiredWithout(fl FieldLevel) bool {
 	}
 
 	if !isValidateCurrentField {
+		switch field.Kind() {
+		case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func:
+			return !field.IsNil()
+		default:
+			if fl.(*validate).fldIsPointer && field.Interface() != nil {
+				return true
+			}
+			return field.IsValid() && field.Interface() != reflect.Zero(field.Type()).Interface()
+		}
+	}
+
+	return true
+}
+
+// RequiredWithoutAll is the validation function
+// The field under validation must be present and not empty only when all of the other specified fields are not present.
+func requiredWithoutAll(fl FieldLevel) bool {
+
+	field := fl.Field()
+	isValidateCurrentField := true
+	params := parseOneOfParam2(fl.Param())
+	for _, param := range params {
+		isParamFieldPresent := false
+
+		paramField := fl.Parent().FieldByName(param)
+
+		switch paramField.Kind() {
+		case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func:
+			isParamFieldPresent = !paramField.IsNil()
+		default:
+			if fl.(*validate).fldIsPointer && paramField.Interface() != nil {
+				isParamFieldPresent = true
+			}
+			isParamFieldPresent = paramField.IsValid() && paramField.Interface() != reflect.Zero(field.Type()).Interface()
+		}
+		if isParamFieldPresent {
+			isValidateCurrentField = !isParamFieldPresent
+		}
+	}
+
+	if isValidateCurrentField {
 		switch field.Kind() {
 		case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func:
 			return !field.IsNil()

--- a/baked_in.go
+++ b/baked_in.go
@@ -1301,18 +1301,22 @@ func isDefault(fl FieldLevel) bool {
 
 // HasValue is the validation function for validating if the current field's value is not the default static value.
 func hasValue(fl FieldLevel) bool {
+	return requireCheckFieldKind(fl, "")
+}
 
+// requireCheckField is a func for check field kind
+func requireCheckFieldKind(fl FieldLevel, param string) bool {
 	field := fl.Field()
-
+	if len(param) > 0 {
+		field = fl.Parent().FieldByName(param)
+	}
 	switch field.Kind() {
 	case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func:
 		return !field.IsNil()
 	default:
-
 		if fl.(*validate).fldIsPointer && field.Interface() != nil {
 			return true
 		}
-
 		return field.IsValid() && field.Interface() != reflect.Zero(field.Type()).Interface()
 	}
 }
@@ -1321,33 +1325,11 @@ func hasValue(fl FieldLevel) bool {
 // The field under validation must be present and not empty only if any of the other specified fields are present.
 func requiredWith(fl FieldLevel) bool {
 
-	field := fl.Field()
 	params := parseOneOfParam2(fl.Param())
 	for _, param := range params {
-		isParamFieldPresent := false
 
-		paramField := fl.Parent().FieldByName(param)
-
-		switch paramField.Kind() {
-		case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func:
-			isParamFieldPresent = !paramField.IsNil()
-		default:
-			if fl.(*validate).fldIsPointer && paramField.Interface() != nil {
-				isParamFieldPresent = true
-			}
-			isParamFieldPresent = paramField.IsValid() && paramField.Interface() != reflect.Zero(field.Type()).Interface()
-		}
-
-		if isParamFieldPresent {
-			switch field.Kind() {
-			case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func:
-				return !field.IsNil()
-			default:
-				if fl.(*validate).fldIsPointer && field.Interface() != nil {
-					return true
-				}
-				return field.IsValid() && field.Interface() != reflect.Zero(field.Type()).Interface()
-			}
+		if requireCheckFieldKind(fl, param) {
+			return requireCheckFieldKind(fl, "")
 		}
 	}
 
@@ -1358,38 +1340,17 @@ func requiredWith(fl FieldLevel) bool {
 // The field under validation must be present and not empty only if all of the other specified fields are present.
 func requiredWithAll(fl FieldLevel) bool {
 
-	field := fl.Field()
 	isValidateCurrentField := true
 	params := parseOneOfParam2(fl.Param())
 	for _, param := range params {
-		isParamFieldPresent := false
 
-		paramField := fl.Parent().FieldByName(param)
-
-		switch paramField.Kind() {
-		case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func:
-			isParamFieldPresent = !paramField.IsNil()
-		default:
-			if fl.(*validate).fldIsPointer && paramField.Interface() != nil {
-				isParamFieldPresent = true
-			}
-			isParamFieldPresent = paramField.IsValid() && paramField.Interface() != reflect.Zero(field.Type()).Interface()
-		}
-		if !isParamFieldPresent {
-			isValidateCurrentField = isParamFieldPresent
+		if !requireCheckFieldKind(fl, param) {
+			isValidateCurrentField = false
 		}
 	}
 
 	if isValidateCurrentField {
-		switch field.Kind() {
-		case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func:
-			return !field.IsNil()
-		default:
-			if fl.(*validate).fldIsPointer && field.Interface() != nil {
-				return true
-			}
-			return field.IsValid() && field.Interface() != reflect.Zero(field.Type()).Interface()
-		}
+		return requireCheckFieldKind(fl, "")
 	}
 
 	return true
@@ -1399,38 +1360,17 @@ func requiredWithAll(fl FieldLevel) bool {
 // The field under validation must be present and not empty only when any of the other specified fields are not present.
 func requiredWithout(fl FieldLevel) bool {
 
-	field := fl.Field()
 	isValidateCurrentField := false
 	params := parseOneOfParam2(fl.Param())
 	for _, param := range params {
-		isParamFieldPresent := false
 
-		paramField := fl.Parent().FieldByName(param)
-
-		switch paramField.Kind() {
-		case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func:
-			isParamFieldPresent = !paramField.IsNil()
-		default:
-			if fl.(*validate).fldIsPointer && paramField.Interface() != nil {
-				isParamFieldPresent = true
-			}
-			isParamFieldPresent = paramField.IsValid() && paramField.Interface() != reflect.Zero(field.Type()).Interface()
-		}
-		if isParamFieldPresent {
-			isValidateCurrentField = isParamFieldPresent
+		if requireCheckFieldKind(fl, param) {
+			isValidateCurrentField = true
 		}
 	}
 
 	if !isValidateCurrentField {
-		switch field.Kind() {
-		case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func:
-			return !field.IsNil()
-		default:
-			if fl.(*validate).fldIsPointer && field.Interface() != nil {
-				return true
-			}
-			return field.IsValid() && field.Interface() != reflect.Zero(field.Type()).Interface()
-		}
+		return requireCheckFieldKind(fl, "")
 	}
 
 	return true
@@ -1440,38 +1380,17 @@ func requiredWithout(fl FieldLevel) bool {
 // The field under validation must be present and not empty only when all of the other specified fields are not present.
 func requiredWithoutAll(fl FieldLevel) bool {
 
-	field := fl.Field()
 	isValidateCurrentField := true
 	params := parseOneOfParam2(fl.Param())
 	for _, param := range params {
-		isParamFieldPresent := false
 
-		paramField := fl.Parent().FieldByName(param)
-
-		switch paramField.Kind() {
-		case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func:
-			isParamFieldPresent = !paramField.IsNil()
-		default:
-			if fl.(*validate).fldIsPointer && paramField.Interface() != nil {
-				isParamFieldPresent = true
-			}
-			isParamFieldPresent = paramField.IsValid() && paramField.Interface() != reflect.Zero(field.Type()).Interface()
-		}
-		if isParamFieldPresent {
-			isValidateCurrentField = !isParamFieldPresent
+		if requireCheckFieldKind(fl, param) {
+			isValidateCurrentField = false
 		}
 	}
 
 	if isValidateCurrentField {
-		switch field.Kind() {
-		case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func:
-			return !field.IsNil()
-		default:
-			if fl.(*validate).fldIsPointer && field.Interface() != nil {
-				return true
-			}
-			return field.IsValid() && field.Interface() != reflect.Zero(field.Type()).Interface()
-		}
+		return requireCheckFieldKind(fl, "")
 	}
 
 	return true

--- a/baked_in.go
+++ b/baked_in.go
@@ -1314,7 +1314,8 @@ func hasValue(fl FieldLevel) bool {
 	}
 }
 
-// RequiredWith is the validation function for validating if the current field's if any of the other specified fields are present.
+// RequiredWith is the validation function
+// the field under validation must be present and not empty only if any of the other specified fields are present.
 func requiredWith(fl FieldLevel) bool {
 
 	field := fl.Field()

--- a/baked_in.go
+++ b/baked_in.go
@@ -62,106 +62,107 @@ var (
 	// you can add, remove or even replace items to suite your needs,
 	// or even disregard and use your own map if so desired.
 	bakedInValidators = map[string]Func{
-		"required":         hasValue,
-		"required_with":    requiredWith,
-		"isdefault":        isDefault,
-		"len":              hasLengthOf,
-		"min":              hasMinOf,
-		"max":              hasMaxOf,
-		"eq":               isEq,
-		"ne":               isNe,
-		"lt":               isLt,
-		"lte":              isLte,
-		"gt":               isGt,
-		"gte":              isGte,
-		"eqfield":          isEqField,
-		"eqcsfield":        isEqCrossStructField,
-		"necsfield":        isNeCrossStructField,
-		"gtcsfield":        isGtCrossStructField,
-		"gtecsfield":       isGteCrossStructField,
-		"ltcsfield":        isLtCrossStructField,
-		"ltecsfield":       isLteCrossStructField,
-		"nefield":          isNeField,
-		"gtefield":         isGteField,
-		"gtfield":          isGtField,
-		"ltefield":         isLteField,
-		"ltfield":          isLtField,
-		"fieldcontains":    fieldContains,
-		"fieldexcludes":    fieldExcludes,
-		"alpha":            isAlpha,
-		"alphanum":         isAlphanum,
-		"alphaunicode":     isAlphaUnicode,
-		"alphanumunicode":  isAlphanumUnicode,
-		"numeric":          isNumeric,
-		"number":           isNumber,
-		"hexadecimal":      isHexadecimal,
-		"hexcolor":         isHEXColor,
-		"rgb":              isRGB,
-		"rgba":             isRGBA,
-		"hsl":              isHSL,
-		"hsla":             isHSLA,
-		"email":            isEmail,
-		"url":              isURL,
-		"uri":              isURI,
-		"urn_rfc2141":      isUrnRFC2141, // RFC 2141
-		"file":             isFile,
-		"base64":           isBase64,
-		"base64url":        isBase64URL,
-		"contains":         contains,
-		"containsany":      containsAny,
-		"containsrune":     containsRune,
-		"excludes":         excludes,
-		"excludesall":      excludesAll,
-		"excludesrune":     excludesRune,
-		"startswith":       startsWith,
-		"endswith":         endsWith,
-		"isbn":             isISBN,
-		"isbn10":           isISBN10,
-		"isbn13":           isISBN13,
-		"eth_addr":         isEthereumAddress,
-		"btc_addr":         isBitcoinAddress,
-		"btc_addr_bech32":  isBitcoinBech32Address,
-		"uuid":             isUUID,
-		"uuid3":            isUUID3,
-		"uuid4":            isUUID4,
-		"uuid5":            isUUID5,
-		"uuid_rfc4122":     isUUIDRFC4122,
-		"uuid3_rfc4122":    isUUID3RFC4122,
-		"uuid4_rfc4122":    isUUID4RFC4122,
-		"uuid5_rfc4122":    isUUID5RFC4122,
-		"ascii":            isASCII,
-		"printascii":       isPrintableASCII,
-		"multibyte":        hasMultiByteCharacter,
-		"datauri":          isDataURI,
-		"latitude":         isLatitude,
-		"longitude":        isLongitude,
-		"ssn":              isSSN,
-		"ipv4":             isIPv4,
-		"ipv6":             isIPv6,
-		"ip":               isIP,
-		"cidrv4":           isCIDRv4,
-		"cidrv6":           isCIDRv6,
-		"cidr":             isCIDR,
-		"tcp4_addr":        isTCP4AddrResolvable,
-		"tcp6_addr":        isTCP6AddrResolvable,
-		"tcp_addr":         isTCPAddrResolvable,
-		"udp4_addr":        isUDP4AddrResolvable,
-		"udp6_addr":        isUDP6AddrResolvable,
-		"udp_addr":         isUDPAddrResolvable,
-		"ip4_addr":         isIP4AddrResolvable,
-		"ip6_addr":         isIP6AddrResolvable,
-		"ip_addr":          isIPAddrResolvable,
-		"unix_addr":        isUnixAddrResolvable,
-		"mac":              isMAC,
-		"hostname":         isHostnameRFC952,  // RFC 952
-		"hostname_rfc1123": isHostnameRFC1123, // RFC 1123
-		"fqdn":             isFQDN,
-		"unique":           isUnique,
-		"oneof":            isOneOf,
-		"html":             isHTML,
-		"html_encoded":     isHTMLEncoded,
-		"url_encoded":      isURLEncoded,
-		"dir":              isDir,
+		"required":          hasValue,
+		"required_with":     requiredWith,
+		"required_with_all": requiredWithAll,
+		"isdefault":         isDefault,
+		"len":               hasLengthOf,
+		"min":               hasMinOf,
+		"max":               hasMaxOf,
+		"eq":                isEq,
+		"ne":                isNe,
+		"lt":                isLt,
+		"lte":               isLte,
+		"gt":                isGt,
+		"gte":               isGte,
+		"eqfield":           isEqField,
+		"eqcsfield":         isEqCrossStructField,
+		"necsfield":         isNeCrossStructField,
+		"gtcsfield":         isGtCrossStructField,
+		"gtecsfield":        isGteCrossStructField,
+		"ltcsfield":         isLtCrossStructField,
+		"ltecsfield":        isLteCrossStructField,
+		"nefield":           isNeField,
+		"gtefield":          isGteField,
+		"gtfield":           isGtField,
+		"ltefield":          isLteField,
+		"ltfield":           isLtField,
+		"fieldcontains":     fieldContains,
+		"fieldexcludes":     fieldExcludes,
+		"alpha":             isAlpha,
+		"alphanum":          isAlphanum,
+		"alphaunicode":      isAlphaUnicode,
+		"alphanumunicode":   isAlphanumUnicode,
+		"numeric":           isNumeric,
+		"number":            isNumber,
+		"hexadecimal":       isHexadecimal,
+		"hexcolor":          isHEXColor,
+		"rgb":               isRGB,
+		"rgba":              isRGBA,
+		"hsl":               isHSL,
+		"hsla":              isHSLA,
+		"email":             isEmail,
+		"url":               isURL,
+		"uri":               isURI,
+		"urn_rfc2141":       isUrnRFC2141, // RFC 2141
+		"file":              isFile,
+		"base64":            isBase64,
+		"base64url":         isBase64URL,
+		"contains":          contains,
+		"containsany":       containsAny,
+		"containsrune":      containsRune,
+		"excludes":          excludes,
+		"excludesall":       excludesAll,
+		"excludesrune":      excludesRune,
+		"startswith":        startsWith,
+		"endswith":          endsWith,
+		"isbn":              isISBN,
+		"isbn10":            isISBN10,
+		"isbn13":            isISBN13,
+		"eth_addr":          isEthereumAddress,
+		"btc_addr":          isBitcoinAddress,
+		"btc_addr_bech32":   isBitcoinBech32Address,
+		"uuid":              isUUID,
+		"uuid3":             isUUID3,
+		"uuid4":             isUUID4,
+		"uuid5":             isUUID5,
+		"uuid_rfc4122":      isUUIDRFC4122,
+		"uuid3_rfc4122":     isUUID3RFC4122,
+		"uuid4_rfc4122":     isUUID4RFC4122,
+		"uuid5_rfc4122":     isUUID5RFC4122,
+		"ascii":             isASCII,
+		"printascii":        isPrintableASCII,
+		"multibyte":         hasMultiByteCharacter,
+		"datauri":           isDataURI,
+		"latitude":          isLatitude,
+		"longitude":         isLongitude,
+		"ssn":               isSSN,
+		"ipv4":              isIPv4,
+		"ipv6":              isIPv6,
+		"ip":                isIP,
+		"cidrv4":            isCIDRv4,
+		"cidrv6":            isCIDRv6,
+		"cidr":              isCIDR,
+		"tcp4_addr":         isTCP4AddrResolvable,
+		"tcp6_addr":         isTCP6AddrResolvable,
+		"tcp_addr":          isTCPAddrResolvable,
+		"udp4_addr":         isUDP4AddrResolvable,
+		"udp6_addr":         isUDP6AddrResolvable,
+		"udp_addr":          isUDPAddrResolvable,
+		"ip4_addr":          isIP4AddrResolvable,
+		"ip6_addr":          isIP6AddrResolvable,
+		"ip_addr":           isIPAddrResolvable,
+		"unix_addr":         isUnixAddrResolvable,
+		"mac":               isMAC,
+		"hostname":          isHostnameRFC952,  // RFC 952
+		"hostname_rfc1123":  isHostnameRFC1123, // RFC 1123
+		"fqdn":              isFQDN,
+		"unique":            isUnique,
+		"oneof":             isOneOf,
+		"html":              isHTML,
+		"html_encoded":      isHTMLEncoded,
+		"url_encoded":       isURLEncoded,
+		"dir":               isDir,
 	}
 )
 
@@ -1315,7 +1316,7 @@ func hasValue(fl FieldLevel) bool {
 }
 
 // RequiredWith is the validation function
-// the field under validation must be present and not empty only if any of the other specified fields are present.
+// The field under validation must be present and not empty only if any of the other specified fields are present.
 func requiredWith(fl FieldLevel) bool {
 
 	field := fl.Field()
@@ -1329,6 +1330,9 @@ func requiredWith(fl FieldLevel) bool {
 		case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func:
 			isParamFieldPresent = !paramField.IsNil()
 		default:
+			if fl.(*validate).fldIsPointer && paramField.Interface() != nil {
+				isParamFieldPresent = true
+			}
 			isParamFieldPresent = paramField.IsValid() && paramField.Interface() != reflect.Zero(field.Type()).Interface()
 		}
 
@@ -1342,6 +1346,47 @@ func requiredWith(fl FieldLevel) bool {
 				}
 				return field.IsValid() && field.Interface() != reflect.Zero(field.Type()).Interface()
 			}
+		}
+	}
+
+	return true
+}
+
+// RequiredWithAll is the validation function
+// The field under validation must be present and not empty only if all of the other specified fields are present.
+func requiredWithAll(fl FieldLevel) bool {
+
+	field := fl.Field()
+	isValidateCurrentField := true
+	params := parseOneOfParam2(fl.Param())
+	for _, param := range params {
+		isParamFieldPresent := false
+
+		paramField := fl.Parent().FieldByName(param)
+
+		switch paramField.Kind() {
+		case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func:
+			isParamFieldPresent = !paramField.IsNil()
+		default:
+			if fl.(*validate).fldIsPointer && paramField.Interface() != nil {
+				isParamFieldPresent = true
+			}
+			isParamFieldPresent = paramField.IsValid() && paramField.Interface() != reflect.Zero(field.Type()).Interface()
+		}
+		if !isParamFieldPresent {
+			isValidateCurrentField = isParamFieldPresent
+		}
+	}
+
+	if isValidateCurrentField {
+		switch field.Kind() {
+		case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func:
+			return !field.IsNil()
+		default:
+			if fl.(*validate).fldIsPointer && field.Interface() != nil {
+				return true
+			}
+			return field.IsValid() && field.Interface() != reflect.Zero(field.Type()).Interface()
 		}
 	}
 

--- a/doc.go
+++ b/doc.go
@@ -271,10 +271,27 @@ ensures the value is not nil.
 
 	Usage: required_with_all
 
-Examples:
+Example:
 
 	// require the field if the Field1 and Field2 is present:
 	Usage: required_with_all=Field1 Field2
+
+Required Without
+
+The field under validation must be present and not empty only when any
+of the other specified fields are not present. For strings ensures value is
+not "". For slices, maps, pointers, interfaces, channels and functions
+ensures the value is not nil.
+
+	Usage: required_without
+
+Examples:
+
+	// require the field if the Field1 is not present:
+	Usage: required_without=Field1
+
+	// require the field if the Field1 or Field2 is not present:
+	Usage: required_without=Field1 Field2
 
 Is Default
 

--- a/doc.go
+++ b/doc.go
@@ -293,6 +293,20 @@ Examples:
 	// require the field if the Field1 or Field2 is not present:
 	Usage: required_without=Field1 Field2
 
+Required Without All
+
+The field under validation must be present and not empty only when all
+of the other specified fields are not present. For strings ensures value is
+not "". For slices, maps, pointers, interfaces, channels and functions
+ensures the value is not nil.
+
+	Usage: required_without_all
+
+Example:
+
+	// require the field if the Field1 and Field2 is not present:
+	Usage: required_without_all=Field1 Field2
+
 Is Default
 
 This validates that the value is the default value and is almost the

--- a/doc.go
+++ b/doc.go
@@ -256,11 +256,25 @@ ensures the value is not nil.
 
 Examples:
 
-	// require the field if the Field1 is not present:
+	// require the field if the Field1 is present:
 	Usage: required_with=Field1
 
-	// require the field if the Field1 and Field2 is not present:
+	// require the field if the Field1 or Field2 is present:
 	Usage: required_with=Field1 Field2
+
+Required With All
+
+The field under validation must be present and not empty only if all
+of the other specified fields are present. For strings ensures value is
+not "". For slices, maps, pointers, interfaces, channels and functions
+ensures the value is not nil.
+
+	Usage: required_with_all
+
+Examples:
+
+	// require the field if the Field1 and Field2 is present:
+	Usage: required_with_all=Field1 Field2
 
 Is Default
 

--- a/doc.go
+++ b/doc.go
@@ -245,6 +245,23 @@ ensures the value is not nil.
 
 	Usage: required
 
+Required With
+
+The field under validation must be present and not empty only if any
+of the other specified fields are present. For strings ensures value is
+not "". For slices, maps, pointers, interfaces, channels and functions
+ensures the value is not nil.
+
+	Usage: required_with
+
+Examples:
+
+	// require the field if the Field1 is not present:
+	Usage: required_with=Field1
+
+	// require the field if the Field1 and Field2 is not present:
+	Usage: required_with=Field1 Field2
+
 Is Default
 
 This validates that the value is the default value and is almost the

--- a/validator_test.go
+++ b/validator_test.go
@@ -8620,14 +8620,21 @@ func TestEndsWithValidation(t *testing.T) {
 }
 
 func TestRequiredWith(t *testing.T) {
-
+	fieldVal := "test"
 	test := struct {
-		Field1 *string  `validate:"omitempty" json:"field_1"`
-		Field2 []string `validate:"omitempty" json:"field_2"`
-		Field3 string   `validate:"required_with=Field1 Field2" json:"field_3"`
+		FieldE  string            `validate:"omitempty" json:"field_e"`
+		FieldER string            `validate:"required_with=FieldE" json:"field_er"`
+		Field1  string            `validate:"omitempty" json:"field_1"`
+		Field2  *string           `validate:"required_with=Field1" json:"field_2"`
+		Field3  map[string]string `validate:"required_with=Field2" json:"field_3"`
+		Field4  interface{}       `validate:"required_with=Field3" json:"field_4"`
+		Field5  string            `validate:"required_with=Field3" json:"field_5"`
 	}{
-		Field2: []string{"test_field2"},
-		Field3: "test_field3",
+		Field1: "test_field1",
+		Field2: &fieldVal,
+		Field3: map[string]string{"key": "val"},
+		Field4: "test",
+		Field5: "test",
 	}
 
 	validate := New()
@@ -8641,14 +8648,21 @@ func TestRequiredWith(t *testing.T) {
 
 func TestRequiredWithAll(t *testing.T) {
 
+	fieldVal := "test"
 	test := struct {
-		Field1 string   `validate:"omitempty" json:"field_1"`
-		Field2 []string `validate:"omitempty" json:"field_2"`
-		Field3 string   `validate:"required_with_all=Field1 Field2" json:"field_3"`
+		FieldE  string            `validate:"omitempty" json:"field_e"`
+		FieldER string            `validate:"required_with_all=FieldE" json:"field_er"`
+		Field1  string            `validate:"omitempty" json:"field_1"`
+		Field2  *string           `validate:"required_with_all=Field1" json:"field_2"`
+		Field3  map[string]string `validate:"required_with_all=Field2" json:"field_3"`
+		Field4  interface{}       `validate:"required_with_all=Field3" json:"field_4"`
+		Field5  string            `validate:"required_with_all=Field3" json:"field_5"`
 	}{
 		Field1: "test_field1",
-		Field2: []string{"test_field2"},
-		Field3: "test_field3",
+		Field2: &fieldVal,
+		Field3: map[string]string{"key": "val"},
+		Field4: "test",
+		Field5: "test",
 	}
 
 	validate := New()
@@ -8662,12 +8676,18 @@ func TestRequiredWithAll(t *testing.T) {
 
 func TestRequiredWithout(t *testing.T) {
 
+	fieldVal := "test"
 	test := struct {
-		Field1 *string  `validate:"omitempty" json:"field_1"`
-		Field2 []string `validate:"omitempty" json:"field_2"`
-		Field3 string   `validate:"required_without=Field1 Field2" json:"field_3"`
+		Field1 string            `validate:"omitempty" json:"field_1"`
+		Field2 *string           `validate:"required_without=Field1" json:"field_2"`
+		Field3 map[string]string `validate:"required_without=Field2" json:"field_3"`
+		Field4 interface{}       `validate:"required_without=Field3" json:"field_4"`
+		Field5 string            `validate:"required_without=Field3" json:"field_5"`
 	}{
-		Field3: "test_field3",
+		Field2: &fieldVal,
+		Field3: map[string]string{"key": "val"},
+		Field4: "test",
+		Field5: "test",
 	}
 
 	validate := New()
@@ -8677,16 +8697,42 @@ func TestRequiredWithout(t *testing.T) {
 	if errs != nil {
 		t.Fatalf("failed Error: %s", errs)
 	}
+
+	test2 := struct {
+		Field1 string            `validate:"omitempty" json:"field_1"`
+		Field2 *string           `validate:"required_without=Field1" json:"field_2"`
+		Field3 map[string]string `validate:"required_without=Field2" json:"field_3"`
+		Field4 interface{}       `validate:"required_without=Field3" json:"field_4"`
+		Field5 string            `validate:"required_without=Field3" json:"field_5"`
+		Field6 string            `validate:"required_without=Field1" json:"field_6"`
+	}{
+		Field3: map[string]string{"key": "val"},
+		Field4: "test",
+		Field5: "test",
+	}
+
+	errs = validate.Struct(test2)
+
+	if errs == nil {
+		t.Fatalf("failed Error: %s", errs)
+	}
 }
 
 func TestRequiredWithoutAll(t *testing.T) {
 
+	fieldVal := "test"
 	test := struct {
-		Field1 *string  `validate:"omitempty" json:"field_1"`
-		Field2 []string `validate:"omitempty" json:"field_2"`
-		Field3 string   `validate:"required_without_all=Field1 Field2" json:"field_3"`
+		Field1 string            `validate:"omitempty" json:"field_1"`
+		Field2 *string           `validate:"required_without_all=Field1" json:"field_2"`
+		Field3 map[string]string `validate:"required_without_all=Field2" json:"field_3"`
+		Field4 interface{}       `validate:"required_without_all=Field3" json:"field_4"`
+		Field5 string            `validate:"required_without_all=Field3" json:"field_5"`
 	}{
-		Field3: "test_field3",
+		Field1: "",
+		Field2: &fieldVal,
+		Field3: map[string]string{"key": "val"},
+		Field4: "test",
+		Field5: "test",
 	}
 
 	validate := New()
@@ -8694,6 +8740,25 @@ func TestRequiredWithoutAll(t *testing.T) {
 	errs := validate.Struct(test)
 
 	if errs != nil {
+		t.Fatalf("failed Error: %s", errs)
+	}
+
+	test2 := struct {
+		Field1 string            `validate:"omitempty" json:"field_1"`
+		Field2 *string           `validate:"required_without_all=Field1" json:"field_2"`
+		Field3 map[string]string `validate:"required_without_all=Field2" json:"field_3"`
+		Field4 interface{}       `validate:"required_without_all=Field3" json:"field_4"`
+		Field5 string            `validate:"required_without_all=Field3" json:"field_5"`
+		Field6 string            `validate:"required_without_all=Field1" json:"field_6"`
+	}{
+		Field3: map[string]string{"key": "val"},
+		Field4: "test",
+		Field5: "test",
+	}
+
+	errs = validate.Struct(test2)
+
+	if errs == nil {
 		t.Fatalf("failed Error: %s", errs)
 	}
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -8639,3 +8639,24 @@ func TestRequiredWith(t *testing.T) {
 		t.Fatalf("failed Error: %s", errs)
 	}
 }
+
+func TestRequiredWithAll(t *testing.T) {
+
+	test := struct {
+		Field1 string `validate:"omitempty" json:"field_1"`
+		Field2 string `validate:"omitempty" json:"field_2"`
+		Field3 string `validate:"required_with_all=Field1 Field2" json:"field_3"`
+	}{
+		Field1: "test_field1",
+		Field2: "test_field2",
+		Field3: "test_field3",
+	}
+
+	validate := New()
+
+	errs := validate.Struct(test)
+
+	if errs != nil {
+		t.Fatalf("failed Error: %s", errs)
+	}
+}

--- a/validator_test.go
+++ b/validator_test.go
@@ -8572,7 +8572,7 @@ func TestStartsWithValidation(t *testing.T) {
 		ExpectedNil bool
 	}{
 		{Value: "(/^ヮ^)/*:・ﾟ✧ glitter", Tag: "startswith=(/^ヮ^)/*:・ﾟ✧", ExpectedNil: true},
-		{Value: "abcd",  Tag: "startswith=(/^ヮ^)/*:・ﾟ✧", ExpectedNil: false},
+		{Value: "abcd", Tag: "startswith=(/^ヮ^)/*:・ﾟ✧", ExpectedNil: false},
 	}
 
 	validate := New()
@@ -8619,4 +8619,23 @@ func TestEndsWithValidation(t *testing.T) {
 	}
 }
 
+func TestRequiredWith(t *testing.T) {
 
+	test := struct {
+		Field1 string `validate:"omitempty" json:"field_1"`
+		Field2 string `validate:"omitempty" json:"field_2"`
+		Field3 string `validate:"required_with=Field1 Field2" json:"field_3"`
+	}{
+		Field1: "test_field1",
+		Field2: "test_field2",
+		Field3: "test_field3",
+	}
+
+	validate := New()
+
+	errs := validate.Struct(test)
+
+	if errs != nil {
+		t.Fatalf("failed Error: %s", errs)
+	}
+}

--- a/validator_test.go
+++ b/validator_test.go
@@ -8622,11 +8622,11 @@ func TestEndsWithValidation(t *testing.T) {
 func TestRequiredWith(t *testing.T) {
 
 	test := struct {
-		Field1 string `validate:"omitempty" json:"field_1"`
-		Field2 string `validate:"omitempty" json:"field_2"`
-		Field3 string `validate:"required_with=Field1 Field2" json:"field_3"`
+		Field1 *string  `validate:"omitempty" json:"field_1"`
+		Field2 []string `validate:"omitempty" json:"field_2"`
+		Field3 string   `validate:"required_with=Field1 Field2" json:"field_3"`
 	}{
-		Field1: "test_field1",
+		Field2: []string{"test_field2"},
 		Field3: "test_field3",
 	}
 
@@ -8642,12 +8642,12 @@ func TestRequiredWith(t *testing.T) {
 func TestRequiredWithAll(t *testing.T) {
 
 	test := struct {
-		Field1 string `validate:"omitempty" json:"field_1"`
-		Field2 string `validate:"omitempty" json:"field_2"`
-		Field3 string `validate:"required_with_all=Field1 Field2" json:"field_3"`
+		Field1 string   `validate:"omitempty" json:"field_1"`
+		Field2 []string `validate:"omitempty" json:"field_2"`
+		Field3 string   `validate:"required_with_all=Field1 Field2" json:"field_3"`
 	}{
 		Field1: "test_field1",
-		Field2: "test_field2",
+		Field2: []string{"test_field2"},
 		Field3: "test_field3",
 	}
 
@@ -8663,9 +8663,9 @@ func TestRequiredWithAll(t *testing.T) {
 func TestRequiredWithout(t *testing.T) {
 
 	test := struct {
-		Field1 string `validate:"omitempty" json:"field_1"`
-		Field2 string `validate:"omitempty" json:"field_2"`
-		Field3 string `validate:"required_without=Field1 Field2" json:"field_3"`
+		Field1 *string  `validate:"omitempty" json:"field_1"`
+		Field2 []string `validate:"omitempty" json:"field_2"`
+		Field3 string   `validate:"required_without=Field1 Field2" json:"field_3"`
 	}{
 		Field3: "test_field3",
 	}
@@ -8682,9 +8682,9 @@ func TestRequiredWithout(t *testing.T) {
 func TestRequiredWithoutAll(t *testing.T) {
 
 	test := struct {
-		Field1 string `validate:"omitempty" json:"field_1"`
-		Field2 string `validate:"omitempty" json:"field_2"`
-		Field3 string `validate:"required_without_all=Field1 Field2" json:"field_3"`
+		Field1 *string  `validate:"omitempty" json:"field_1"`
+		Field2 []string `validate:"omitempty" json:"field_2"`
+		Field3 string   `validate:"required_without_all=Field1 Field2" json:"field_3"`
 	}{
 		Field3: "test_field3",
 	}

--- a/validator_test.go
+++ b/validator_test.go
@@ -8627,7 +8627,6 @@ func TestRequiredWith(t *testing.T) {
 		Field3 string `validate:"required_with=Field1 Field2" json:"field_3"`
 	}{
 		Field1: "test_field1",
-		Field2: "test_field2",
 		Field3: "test_field3",
 	}
 
@@ -8649,6 +8648,25 @@ func TestRequiredWithAll(t *testing.T) {
 	}{
 		Field1: "test_field1",
 		Field2: "test_field2",
+		Field3: "test_field3",
+	}
+
+	validate := New()
+
+	errs := validate.Struct(test)
+
+	if errs != nil {
+		t.Fatalf("failed Error: %s", errs)
+	}
+}
+
+func TestRequiredWithout(t *testing.T) {
+
+	test := struct {
+		Field1 string `validate:"omitempty" json:"field_1"`
+		Field2 string `validate:"omitempty" json:"field_2"`
+		Field3 string `validate:"required_without=Field1 Field2" json:"field_3"`
+	}{
 		Field3: "test_field3",
 	}
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -8678,3 +8678,22 @@ func TestRequiredWithout(t *testing.T) {
 		t.Fatalf("failed Error: %s", errs)
 	}
 }
+
+func TestRequiredWithoutAll(t *testing.T) {
+
+	test := struct {
+		Field1 string `validate:"omitempty" json:"field_1"`
+		Field2 string `validate:"omitempty" json:"field_2"`
+		Field3 string `validate:"required_without_all=Field1 Field2" json:"field_3"`
+	}{
+		Field3: "test_field3",
+	}
+
+	validate := New()
+
+	errs := validate.Struct(test)
+
+	if errs != nil {
+		t.Fatalf("failed Error: %s", errs)
+	}
+}


### PR DESCRIPTION

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:
add these validators
- **required_with**: The field under validation must be present and not empty only if any of the other specified fields are not empty, (required_with:field1,field2);
- **required_with_all**: The field under validation must be present and not empty only if all of the other specified fields are not empty, (required_with_all:field1,field2);
- **required_without**: The field under validation must be present and not empty only when any of the other specified fields are empty, (required_without:field1,field2);
- **required_without_all**: The field under validation must be present and not empty only when all of the other specified fields are empty, (required_without_all:field1,field2).


@go-playground/admins