### PR TITLE
Extending unique to ensure uniqueness of a specific field in a slices of struct

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -224,14 +224,28 @@ func isOneOf(fl FieldLevel) bool {
 func isUnique(fl FieldLevel) bool {
 
 	field := fl.Field()
+	param := fl.Param()
 	v := reflect.ValueOf(struct{}{})
 
 	switch field.Kind() {
 	case reflect.Slice, reflect.Array:
-		m := reflect.MakeMap(reflect.MapOf(field.Type().Elem(), v.Type()))
+		if param == "" {
+			m := reflect.MakeMap(reflect.MapOf(field.Type().Elem(), v.Type()))
 
+			for i := 0; i < field.Len(); i++ {
+				m.SetMapIndex(field.Index(i), v)
+			}
+			return field.Len() == m.Len()
+		}
+
+		sf, ok := field.Type().Elem().FieldByName(param)
+		if !ok {
+			panic(fmt.Sprintf("Bad field name %s", param))
+		}
+
+		m := reflect.MakeMap(reflect.MapOf(sf.Type, v.Type()))
 		for i := 0; i < field.Len(); i++ {
-			m.SetMapIndex(field.Index(i), v)
+			m.SetMapIndex(field.Index(i).FieldByName(param), v)
 		}
 		return field.Len() == m.Len()
 	case reflect.Map:

--- a/doc.go
+++ b/doc.go
@@ -585,8 +585,14 @@ Unique
 
 For arrays & slices, unique will ensure that there are no duplicates.
 For maps, unique will ensure that there are no duplicate values.
+For slices of struct, unique will ensure that there are no duplicate values
+in a field of the struct specified via a parameter.
 
+	// For arrays, slices, and maps:
 	Usage: unique
+
+	// For slices of struct:
+	Usage: unique=field
 
 Alpha Only
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -8160,6 +8160,49 @@ func TestUniqueValidation(t *testing.T) {
 	PanicMatches(t, func() { validate.Var(1.0, "unique") }, "Bad field type float64")
 }
 
+func TestUniqueValidationStructSlice(t *testing.T) {
+	testStructs := []struct {
+		A string
+		B string
+	}{
+		{A: "one", B: "two"},
+		{A: "one", B: "three"},
+	}
+
+	tests := []struct {
+		target   interface{}
+		param    string
+		expected bool
+	}{
+		{testStructs, "unique", true},
+		{testStructs, "unique=A", false},
+		{testStructs, "unique=B", true},
+	}
+
+	validate := New()
+
+	for i, test := range tests {
+
+		errs := validate.Var(test.target, test.param)
+
+		if test.expected {
+			if !IsEqual(errs, nil) {
+				t.Fatalf("Index: %d unique failed Error: %v", i, errs)
+			}
+		} else {
+			if IsEqual(errs, nil) {
+				t.Fatalf("Index: %d unique failed Error: %v", i, errs)
+			} else {
+				val := getError(errs, "", "")
+				if val.Tag() != "unique" {
+					t.Fatalf("Index: %d unique failed Error: %v", i, errs)
+				}
+			}
+		}
+	}
+	PanicMatches(t, func() { validate.Var(testStructs, "unique=C") }, "Bad field name C")
+}
+
 func TestHTMLValidation(t *testing.T) {
 	tests := []struct {
 		param    string


### PR DESCRIPTION
Fixes Or Enhances # .

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:

Hi, wonder if you think it makes sense to include this in the package:

Let's say we have a struct like the following,
```go
type People struct {
	Name string
	Email string
}
```
which will be constructed into `[]People{....}`. And we want to check if all the values in the `Name` fields are unique. This PR allows us to do that by extending the `unique` functionality: `unique=Name`.

Thank you for taking your time to review this PR :heart: 


@go-playground/admins