### PR TITLE
Perform validations on nil pointers

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -185,15 +185,27 @@ func parseOneOfParam2(s string) []string {
 }
 
 func isURLEncoded(fl FieldLevel) bool {
-	return uRLEncodedRegex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return uRLEncodedRegex.MatchString(field.String())
 }
 
 func isHTMLEncoded(fl FieldLevel) bool {
-	return hTMLEncodedRegex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return hTMLEncodedRegex.MatchString(field.String())
 }
 
 func isHTML(fl FieldLevel) bool {
-	return hTMLRegex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return hTMLRegex.MatchString(field.String())
 }
 
 func isOneOf(fl FieldLevel) bool {
@@ -209,6 +221,8 @@ func isOneOf(fl FieldLevel) bool {
 		v = strconv.FormatInt(field.Int(), 10)
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		v = strconv.FormatUint(field.Uint(), 10)
+	case reflect.Ptr: // nil
+		return false
 	default:
 		panic(fmt.Sprintf("Bad field type %T", field.Interface()))
 	}
@@ -241,6 +255,8 @@ func isUnique(fl FieldLevel) bool {
 			m.SetMapIndex(field.MapIndex(k), v)
 		}
 		return field.Len() == m.Len()
+	case reflect.Ptr:
+		return true
 	default:
 		panic(fmt.Sprintf("Bad field type %T", field.Interface()))
 	}
@@ -249,55 +265,83 @@ func isUnique(fl FieldLevel) bool {
 // IsMAC is the validation function for validating if the field's value is a valid MAC address.
 func isMAC(fl FieldLevel) bool {
 
-	_, err := net.ParseMAC(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	_, err := net.ParseMAC(field.String())
 
 	return err == nil
 }
 
 // IsCIDRv4 is the validation function for validating if the field's value is a valid v4 CIDR address.
 func isCIDRv4(fl FieldLevel) bool {
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
 
-	ip, _, err := net.ParseCIDR(fl.Field().String())
+	ip, _, err := net.ParseCIDR(field.String())
 
 	return err == nil && ip.To4() != nil
 }
 
 // IsCIDRv6 is the validation function for validating if the field's value is a valid v6 CIDR address.
 func isCIDRv6(fl FieldLevel) bool {
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
 
-	ip, _, err := net.ParseCIDR(fl.Field().String())
+	ip, _, err := net.ParseCIDR(field.String())
 
 	return err == nil && ip.To4() == nil
 }
 
 // IsCIDR is the validation function for validating if the field's value is a valid v4 or v6 CIDR address.
 func isCIDR(fl FieldLevel) bool {
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
 
-	_, _, err := net.ParseCIDR(fl.Field().String())
+	_, _, err := net.ParseCIDR(field.String())
 
 	return err == nil
 }
 
 // IsIPv4 is the validation function for validating if a value is a valid v4 IP address.
 func isIPv4(fl FieldLevel) bool {
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
 
-	ip := net.ParseIP(fl.Field().String())
+	ip := net.ParseIP(field.String())
 
 	return ip != nil && ip.To4() != nil
 }
 
 // IsIPv6 is the validation function for validating if the field's value is a valid v6 IP address.
 func isIPv6(fl FieldLevel) bool {
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
 
-	ip := net.ParseIP(fl.Field().String())
+	ip := net.ParseIP(field.String())
 
 	return ip != nil && ip.To4() == nil
 }
 
 // IsIP is the validation function for validating if the field's value is a valid v4 or v6 IP address.
 func isIP(fl FieldLevel) bool {
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
 
-	ip := net.ParseIP(fl.Field().String())
+	ip := net.ParseIP(field.String())
 
 	return ip != nil
 }
@@ -306,6 +350,9 @@ func isIP(fl FieldLevel) bool {
 func isSSN(fl FieldLevel) bool {
 
 	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
 
 	if field.Len() != 11 {
 		return false
@@ -330,6 +377,8 @@ func isLongitude(fl FieldLevel) bool {
 		v = strconv.FormatFloat(field.Float(), 'f', -1, 32)
 	case reflect.Float64:
 		v = strconv.FormatFloat(field.Float(), 'f', -1, 64)
+	case reflect.Ptr: // nil
+		return false
 	default:
 		panic(fmt.Sprintf("Bad field type %T", field.Interface()))
 	}
@@ -353,6 +402,8 @@ func isLatitude(fl FieldLevel) bool {
 		v = strconv.FormatFloat(field.Float(), 'f', -1, 32)
 	case reflect.Float64:
 		v = strconv.FormatFloat(field.Float(), 'f', -1, 64)
+	case reflect.Ptr: // nil
+		return false
 	default:
 		panic(fmt.Sprintf("Bad field type %T", field.Interface()))
 	}
@@ -362,8 +413,12 @@ func isLatitude(fl FieldLevel) bool {
 
 // IsDataURI is the validation function for validating if the field's value is a valid data URI.
 func isDataURI(fl FieldLevel) bool {
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
 
-	uri := strings.SplitN(fl.Field().String(), ",", 2)
+	uri := strings.SplitN(field.String(), ",", 2)
 
 	if len(uri) != 2 {
 		return false
@@ -380,6 +435,9 @@ func isDataURI(fl FieldLevel) bool {
 func hasMultiByteCharacter(fl FieldLevel) bool {
 
 	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
 
 	if field.Len() == 0 {
 		return true
@@ -390,52 +448,92 @@ func hasMultiByteCharacter(fl FieldLevel) bool {
 
 // IsPrintableASCII is the validation function for validating if the field's value is a valid printable ASCII character.
 func isPrintableASCII(fl FieldLevel) bool {
-	return printableASCIIRegex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return printableASCIIRegex.MatchString(field.String())
 }
 
 // IsASCII is the validation function for validating if the field's value is a valid ASCII character.
 func isASCII(fl FieldLevel) bool {
-	return aSCIIRegex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return aSCIIRegex.MatchString(field.String())
 }
 
 // IsUUID5 is the validation function for validating if the field's value is a valid v5 UUID.
 func isUUID5(fl FieldLevel) bool {
-	return uUID5Regex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return uUID5Regex.MatchString(field.String())
 }
 
 // IsUUID4 is the validation function for validating if the field's value is a valid v4 UUID.
 func isUUID4(fl FieldLevel) bool {
-	return uUID4Regex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return uUID4Regex.MatchString(field.String())
 }
 
 // IsUUID3 is the validation function for validating if the field's value is a valid v3 UUID.
 func isUUID3(fl FieldLevel) bool {
-	return uUID3Regex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return uUID3Regex.MatchString(field.String())
 }
 
 // IsUUID is the validation function for validating if the field's value is a valid UUID of any version.
 func isUUID(fl FieldLevel) bool {
-	return uUIDRegex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return uUIDRegex.MatchString(field.String())
 }
 
 // IsUUID5RFC4122 is the validation function for validating if the field's value is a valid RFC4122 v5 UUID.
 func isUUID5RFC4122(fl FieldLevel) bool {
-	return uUID5RFC4122Regex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return uUID5RFC4122Regex.MatchString(field.String())
 }
 
 // IsUUID4RFC4122 is the validation function for validating if the field's value is a valid RFC4122 v4 UUID.
 func isUUID4RFC4122(fl FieldLevel) bool {
-	return uUID4RFC4122Regex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return uUID4RFC4122Regex.MatchString(field.String())
 }
 
 // IsUUID3RFC4122 is the validation function for validating if the field's value is a valid RFC4122 v3 UUID.
 func isUUID3RFC4122(fl FieldLevel) bool {
-	return uUID3RFC4122Regex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return uUID3RFC4122Regex.MatchString(field.String())
 }
 
 // IsUUIDRFC4122 is the validation function for validating if the field's value is a valid RFC4122 UUID of any version.
 func isUUIDRFC4122(fl FieldLevel) bool {
-	return uUIDRFC4122Regex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return uUIDRFC4122Regex.MatchString(field.String())
 }
 
 // IsISBN is the validation function for validating if the field's value is a valid v10 or v13 ISBN.
@@ -445,8 +543,12 @@ func isISBN(fl FieldLevel) bool {
 
 // IsISBN13 is the validation function for validating if the field's value is a valid v13 ISBN.
 func isISBN13(fl FieldLevel) bool {
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
 
-	s := strings.Replace(strings.Replace(fl.Field().String(), "-", "", 4), " ", "", 4)
+	s := strings.Replace(strings.Replace(field.String(), "-", "", 4), " ", "", 4)
 
 	if !iSBN13Regex.MatchString(s) {
 		return false
@@ -466,8 +568,12 @@ func isISBN13(fl FieldLevel) bool {
 
 // IsISBN10 is the validation function for validating if the field's value is a valid v10 ISBN.
 func isISBN10(fl FieldLevel) bool {
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
 
-	s := strings.Replace(strings.Replace(fl.Field().String(), "-", "", 3), " ", "", 3)
+	s := strings.Replace(strings.Replace(field.String(), "-", "", 3), " ", "", 3)
 
 	if !iSBN10Regex.MatchString(s) {
 		return false
@@ -491,7 +597,11 @@ func isISBN10(fl FieldLevel) bool {
 
 // IsEthereumAddress is the validation function for validating if the field's value is a valid ethereum address based currently only on the format
 func isEthereumAddress(fl FieldLevel) bool {
-	address := fl.Field().String()
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	address := field.String()
 
 	if !ethAddressRegex.MatchString(address) {
 		return false
@@ -508,7 +618,11 @@ func isEthereumAddress(fl FieldLevel) bool {
 
 // IsBitcoinAddress is the validation function for validating if the field's value is a valid btc address
 func isBitcoinAddress(fl FieldLevel) bool {
-	address := fl.Field().String()
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	address := field.String()
 
 	if !btcAddressRegex.MatchString(address) {
 		return false
@@ -545,7 +659,11 @@ func isBitcoinAddress(fl FieldLevel) bool {
 
 // IsBitcoinBech32Address is the validation function for validating if the field's value is a valid bech32 btc address
 func isBitcoinBech32Address(fl FieldLevel) bool {
-	address := fl.Field().String()
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	address := field.String()
 
 	if !btcLowerAddressRegexBech32.MatchString(address) && !btcUpperAddressRegexBech32.MatchString(address) {
 		return false
@@ -640,39 +758,62 @@ func excludes(fl FieldLevel) bool {
 
 // ContainsRune is the validation function for validating that the field's value contains the rune specified within the param.
 func containsRune(fl FieldLevel) bool {
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
 
 	r, _ := utf8.DecodeRuneInString(fl.Param())
 
-	return strings.ContainsRune(fl.Field().String(), r)
+	return strings.ContainsRune(field.String(), r)
 }
 
 // ContainsAny is the validation function for validating that the field's value contains any of the characters specified within the param.
 func containsAny(fl FieldLevel) bool {
-	return strings.ContainsAny(fl.Field().String(), fl.Param())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return strings.ContainsAny(field.String(), fl.Param())
 }
 
 // Contains is the validation function for validating that the field's value contains the text specified within the param.
 func contains(fl FieldLevel) bool {
-	return strings.Contains(fl.Field().String(), fl.Param())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return strings.Contains(field.String(), fl.Param())
 }
 
 // StartsWith is the validation function for validating that the field's value starts with the text specified within the param.
 func startsWith(fl FieldLevel) bool {
-	return strings.HasPrefix(fl.Field().String(), fl.Param())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return strings.HasPrefix(field.String(), fl.Param())
 }
 
 // EndsWith is the validation function for validating that the field's value ends with the text specified within the param.
 func endsWith(fl FieldLevel) bool {
-	return strings.HasSuffix(fl.Field().String(), fl.Param())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return strings.HasSuffix(field.String(), fl.Param())
 }
 
 // FieldContains is the validation function for validating if the current field's value contains the field specified by the param's value.
 func fieldContains(fl FieldLevel) bool {
 	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
 
 	currentField, _, ok := fl.GetStructFieldOK()
 
-	if !ok {
+	if !ok || currentField.Kind() != reflect.String {
 		return false
 	}
 
@@ -682,10 +823,13 @@ func fieldContains(fl FieldLevel) bool {
 // FieldExcludes is the validation function for validating if the current field's value excludes the field specified by the param's value.
 func fieldExcludes(fl FieldLevel) bool {
 	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
 
 	currentField, _, ok := fl.GetStructFieldOK()
-	if !ok {
-		return true
+	if !ok || currentField.Kind() != reflect.String {
+		return true // since a string cannot contain non-string elements
 	}
 
 	return !strings.Contains(field.String(), currentField.String())
@@ -734,6 +878,8 @@ func isNeField(fl FieldLevel) bool {
 			return !fieldTime.Equal(t)
 		}
 
+	case reflect.Ptr: // nils
+		return true
 	}
 
 	// default reflect.String:
@@ -786,6 +932,8 @@ func isLteCrossStructField(fl FieldLevel) bool {
 
 			return fieldTime.Before(topTime) || fieldTime.Equal(topTime)
 		}
+	case reflect.Ptr: // nils
+		return true
 	}
 
 	// default reflect.String:
@@ -834,6 +982,8 @@ func isLtCrossStructField(fl FieldLevel) bool {
 
 			return fieldTime.Before(topTime)
 		}
+	case reflect.Ptr: // nils
+		return false
 	}
 
 	// default reflect.String:
@@ -881,6 +1031,8 @@ func isGteCrossStructField(fl FieldLevel) bool {
 
 			return fieldTime.After(topTime) || fieldTime.Equal(topTime)
 		}
+	case reflect.Ptr: // nils
+		return true
 	}
 
 	// default reflect.String:
@@ -928,6 +1080,8 @@ func isGtCrossStructField(fl FieldLevel) bool {
 
 			return fieldTime.After(topTime)
 		}
+	case reflect.Ptr: // nils
+		return false
 	}
 
 	// default reflect.String:
@@ -975,6 +1129,8 @@ func isNeCrossStructField(fl FieldLevel) bool {
 
 			return !fieldTime.Equal(t)
 		}
+	case reflect.Ptr: // nils
+		return false
 	}
 
 	// default reflect.String:
@@ -1022,6 +1178,8 @@ func isEqCrossStructField(fl FieldLevel) bool {
 
 			return fieldTime.Equal(t)
 		}
+	case reflect.Ptr: // nils
+		return true
 	}
 
 	// default reflect.String:
@@ -1069,7 +1227,8 @@ func isEqField(fl FieldLevel) bool {
 
 			return fieldTime.Equal(t)
 		}
-
+	case reflect.Ptr: // nils
+		return true
 	}
 
 	// default reflect.String:
@@ -1106,6 +1265,9 @@ func isEq(fl FieldLevel) bool {
 		p := asFloat(param)
 
 		return field.Float() == p
+
+	case reflect.Ptr: // nil
+		return false
 	}
 
 	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
@@ -1113,185 +1275,228 @@ func isEq(fl FieldLevel) bool {
 
 // IsBase64 is the validation function for validating if the current field's value is a valid base 64.
 func isBase64(fl FieldLevel) bool {
-	return base64Regex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return base64Regex.MatchString(field.String())
 }
 
 // IsBase64URL is the validation function for validating if the current field's value is a valid base64 URL safe string.
 func isBase64URL(fl FieldLevel) bool {
-	return base64URLRegex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return base64URLRegex.MatchString(field.String())
 }
 
 // IsURI is the validation function for validating if the current field's value is a valid URI.
 func isURI(fl FieldLevel) bool {
-
 	field := fl.Field()
-
-	switch field.Kind() {
-
-	case reflect.String:
-
-		s := field.String()
-
-		// checks needed as of Go 1.6 because of change https://github.com/golang/go/commit/617c93ce740c3c3cc28cdd1a0d712be183d0b328#diff-6c2d018290e298803c0c9419d8739885L195
-		// emulate browser and strip the '#' suffix prior to validation. see issue-#237
-		if i := strings.Index(s, "#"); i > -1 {
-			s = s[:i]
-		}
-
-		if len(s) == 0 {
-			return false
-		}
-
-		_, err := url.ParseRequestURI(s)
-
-		return err == nil
+	if field.Kind() != reflect.String {
+		return false
 	}
 
-	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
+	s := field.String()
+
+	// checks needed as of Go 1.6 because of change https://github.com/golang/go/commit/617c93ce740c3c3cc28cdd1a0d712be183d0b328#diff-6c2d018290e298803c0c9419d8739885L195
+	// emulate browser and strip the '#' suffix prior to validation. see issue-#237
+	if i := strings.Index(s, "#"); i > -1 {
+		s = s[:i]
+	}
+
+	if len(s) == 0 {
+		return false
+	}
+
+	_, err := url.ParseRequestURI(s)
+
+	return err == nil
 }
 
 // IsURL is the validation function for validating if the current field's value is a valid URL.
 func isURL(fl FieldLevel) bool {
 
 	field := fl.Field()
-
-	switch field.Kind() {
-
-	case reflect.String:
-
-		var i int
-		s := field.String()
-
-		// checks needed as of Go 1.6 because of change https://github.com/golang/go/commit/617c93ce740c3c3cc28cdd1a0d712be183d0b328#diff-6c2d018290e298803c0c9419d8739885L195
-		// emulate browser and strip the '#' suffix prior to validation. see issue-#237
-		if i = strings.Index(s, "#"); i > -1 {
-			s = s[:i]
-		}
-
-		if len(s) == 0 {
-			return false
-		}
-
-		url, err := url.ParseRequestURI(s)
-
-		if err != nil || url.Scheme == "" {
-			return false
-		}
-
-		return err == nil
+	if field.Kind() != reflect.String {
+		return false
 	}
 
-	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
+	var i int
+	s := field.String()
+
+	// checks needed as of Go 1.6 because of change https://github.com/golang/go/commit/617c93ce740c3c3cc28cdd1a0d712be183d0b328#diff-6c2d018290e298803c0c9419d8739885L195
+	// emulate browser and strip the '#' suffix prior to validation. see issue-#237
+	if i = strings.Index(s, "#"); i > -1 {
+		s = s[:i]
+	}
+
+	if len(s) == 0 {
+		return false
+	}
+
+	url, err := url.ParseRequestURI(s)
+
+	if err != nil || url.Scheme == "" {
+		return false
+	}
+
+	return err == nil
 }
 
 // isUrnRFC2141 is the validation function for validating if the current field's value is a valid URN as per RFC 2141.
 func isUrnRFC2141(fl FieldLevel) bool {
 	field := fl.Field()
-
-	switch field.Kind() {
-
-	case reflect.String:
-
-		str := field.String()
-
-		_, match := urn.Parse([]byte(str))
-
-		return match
+	if field.Kind() != reflect.String {
+		return false
 	}
 
-	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
+	str := field.String()
+	_, match := urn.Parse([]byte(str))
+	return match
 }
 
 // IsFile is the validation function for validating if the current field's value is a valid file path.
 func isFile(fl FieldLevel) bool {
 	field := fl.Field()
-
-	switch field.Kind() {
-	case reflect.String:
-		fileInfo, err := os.Stat(field.String())
-		if err != nil {
-			return false
-		}
-
-		return !fileInfo.IsDir()
+	if field.Kind() != reflect.String {
+		return false
 	}
 
-	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
+	fileInfo, err := os.Stat(field.String())
+	if err != nil {
+		return false
+	}
+
+	return !fileInfo.IsDir()
 }
 
 // IsEmail is the validation function for validating if the current field's value is a valid email address.
 func isEmail(fl FieldLevel) bool {
-	return emailRegex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return emailRegex.MatchString(field.String())
 }
 
 // IsHSLA is the validation function for validating if the current field's value is a valid HSLA color.
 func isHSLA(fl FieldLevel) bool {
-	return hslaRegex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return hslaRegex.MatchString(field.String())
 }
 
 // IsHSL is the validation function for validating if the current field's value is a valid HSL color.
 func isHSL(fl FieldLevel) bool {
-	return hslRegex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return hslRegex.MatchString(field.String())
 }
 
 // IsRGBA is the validation function for validating if the current field's value is a valid RGBA color.
 func isRGBA(fl FieldLevel) bool {
-	return rgbaRegex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return rgbaRegex.MatchString(field.String())
 }
 
 // IsRGB is the validation function for validating if the current field's value is a valid RGB color.
 func isRGB(fl FieldLevel) bool {
-	return rgbRegex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return rgbRegex.MatchString(field.String())
 }
 
 // IsHEXColor is the validation function for validating if the current field's value is a valid HEX color.
 func isHEXColor(fl FieldLevel) bool {
-	return hexcolorRegex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return hexcolorRegex.MatchString(field.String())
 }
 
 // IsHexadecimal is the validation function for validating if the current field's value is a valid hexadecimal.
 func isHexadecimal(fl FieldLevel) bool {
-	return hexadecimalRegex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return hexadecimalRegex.MatchString(field.String())
 }
 
 // IsNumber is the validation function for validating if the current field's value is a valid number.
 func isNumber(fl FieldLevel) bool {
-	switch fl.Field().Kind() {
+	field := fl.Field()
+
+	switch field.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr, reflect.Float32, reflect.Float64:
 		return true
+	case reflect.String:
+		return numberRegex.MatchString(field.String())
 	default:
-		return numberRegex.MatchString(fl.Field().String())
+		return false
 	}
 }
 
 // IsNumeric is the validation function for validating if the current field's value is a valid numeric value.
 func isNumeric(fl FieldLevel) bool {
-	switch fl.Field().Kind() {
+	field := fl.Field()
+
+	switch field.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr, reflect.Float32, reflect.Float64:
 		return true
+	case reflect.String:
+		return numericRegex.MatchString(field.String())
 	default:
-		return numericRegex.MatchString(fl.Field().String())
+		return false
 	}
 }
 
 // IsAlphanum is the validation function for validating if the current field's value is a valid alphanumeric value.
 func isAlphanum(fl FieldLevel) bool {
-	return alphaNumericRegex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return alphaNumericRegex.MatchString(field.String())
 }
 
 // IsAlpha is the validation function for validating if the current field's value is a valid alpha value.
 func isAlpha(fl FieldLevel) bool {
-	return alphaRegex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return alphaRegex.MatchString(field.String())
 }
 
 // IsAlphanumUnicode is the validation function for validating if the current field's value is a valid alphanumeric unicode value.
 func isAlphanumUnicode(fl FieldLevel) bool {
-	return alphaUnicodeNumericRegex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return alphaUnicodeNumericRegex.MatchString(field.String())
 }
 
 // IsAlphaUnicode is the validation function for validating if the current field's value is a valid alpha unicode value.
 func isAlphaUnicode(fl FieldLevel) bool {
-	return alphaUnicodeRegex.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+	return alphaUnicodeRegex.MatchString(field.String())
 }
 
 // isDefault is the opposite of required aka hasValue
@@ -1437,6 +1642,8 @@ func isGteField(fl FieldLevel) bool {
 
 			return fieldTime.After(t) || fieldTime.Equal(t)
 		}
+	case reflect.Ptr: // nils
+		return true
 	}
 
 	// default reflect.String
@@ -1484,6 +1691,8 @@ func isGtField(fl FieldLevel) bool {
 
 			return fieldTime.After(t)
 		}
+	case reflect.Ptr: // nils
+		return false
 	}
 
 	// default reflect.String
@@ -1532,6 +1741,9 @@ func isGte(fl FieldLevel) bool {
 
 			return t.After(now) || t.Equal(now)
 		}
+
+	case reflect.Ptr: // nil
+		return false
 	}
 
 	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
@@ -1575,6 +1787,9 @@ func isGt(fl FieldLevel) bool {
 
 			return field.Interface().(time.Time).After(time.Now().UTC())
 		}
+
+	case reflect.Ptr: // nil
+		return false
 	}
 
 	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
@@ -1612,6 +1827,9 @@ func hasLengthOf(fl FieldLevel) bool {
 		p := asFloat(param)
 
 		return field.Float() == p
+
+	case reflect.Ptr: // nil
+		return false
 	}
 
 	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
@@ -1663,6 +1881,9 @@ func isLteField(fl FieldLevel) bool {
 
 			return fieldTime.Before(t) || fieldTime.Equal(t)
 		}
+
+	case reflect.Ptr: // nils
+		return true
 	}
 
 	// default reflect.String
@@ -1710,6 +1931,9 @@ func isLtField(fl FieldLevel) bool {
 
 			return fieldTime.Before(t)
 		}
+
+	case reflect.Ptr: // nils
+		return false
 	}
 
 	// default reflect.String
@@ -1758,6 +1982,9 @@ func isLte(fl FieldLevel) bool {
 
 			return t.Before(now) || t.Equal(now)
 		}
+
+	case reflect.Ptr: // nil
+		return false
 	}
 
 	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
@@ -1802,6 +2029,9 @@ func isLt(fl FieldLevel) bool {
 
 			return field.Interface().(time.Time).Before(time.Now().UTC())
 		}
+
+	case reflect.Ptr: // nil
+		return false
 	}
 
 	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
@@ -1922,14 +2152,24 @@ func isIPAddrResolvable(fl FieldLevel) bool {
 // IsUnixAddrResolvable is the validation function for validating if the field's value is a resolvable unix address.
 func isUnixAddrResolvable(fl FieldLevel) bool {
 
-	_, err := net.ResolveUnixAddr("unix", fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+
+	_, err := net.ResolveUnixAddr("unix", field.String())
 
 	return err == nil
 }
 
 func isIP4Addr(fl FieldLevel) bool {
 
-	val := fl.Field().String()
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+
+	val := field.String()
 
 	if idx := strings.LastIndex(val, ":"); idx != -1 {
 		val = val[0:idx]
@@ -1942,7 +2182,12 @@ func isIP4Addr(fl FieldLevel) bool {
 
 func isIP6Addr(fl FieldLevel) bool {
 
-	val := fl.Field().String()
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+
+	val := field.String()
 
 	if idx := strings.LastIndex(val, ":"); idx != -1 {
 		if idx != 0 && val[idx-1:idx] == "]" {
@@ -1956,15 +2201,30 @@ func isIP6Addr(fl FieldLevel) bool {
 }
 
 func isHostnameRFC952(fl FieldLevel) bool {
-	return hostnameRegexRFC952.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+
+	return hostnameRegexRFC952.MatchString(field.String())
 }
 
 func isHostnameRFC1123(fl FieldLevel) bool {
-	return hostnameRegexRFC1123.MatchString(fl.Field().String())
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+
+	return hostnameRegexRFC1123.MatchString(field.String())
 }
 
 func isFQDN(fl FieldLevel) bool {
-	val := fl.Field().String()
+	field := fl.Field()
+	if field.Kind() != reflect.String {
+		return false
+	}
+
+	val := field.String()
 
 	if val == "" {
 		return false
@@ -1981,15 +2241,14 @@ func isFQDN(fl FieldLevel) bool {
 // IsDir is the validation function for validating if the current field's value is a valid directory.
 func isDir(fl FieldLevel) bool {
 	field := fl.Field()
-
-	if field.Kind() == reflect.String {
-		fileInfo, err := os.Stat(field.String())
-		if err != nil {
-			return false
-		}
-
-		return fileInfo.IsDir()
+	if field.Kind() != reflect.String {
+		return false
 	}
 
-	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
+	fileInfo, err := os.Stat(field.String())
+	if err != nil {
+		return false
+	}
+
+	return fileInfo.IsDir()
 }

--- a/validator.go
+++ b/validator.go
@@ -1,8 +1,8 @@
 package validator
 
 import (
-	"context"
 	"fmt"
+	"context"
 	"reflect"
 	"strconv"
 )
@@ -139,23 +139,24 @@ func (v *validate) traverseField(ctx context.Context, parent reflect.Value, curr
 				return
 			}
 
-			v.errs = append(v.errs,
-				&fieldError{
-					v:              v.v,
-					tag:            ct.aliasTag,
-					actualTag:      ct.tag,
-					ns:             v.str1,
-					structNs:       v.str2,
-					fieldLen:       uint8(len(cf.altName)),
-					structfieldLen: uint8(len(cf.name)),
-					value:          current.Interface(),
-					param:          ct.param,
-					kind:           kind,
-					typ:            current.Type(),
-				},
-			)
-
-			return
+			if kind == reflect.Interface {
+				v.errs = append(v.errs,
+					&fieldError{
+						v:              v.v,
+						tag:            ct.aliasTag,
+						actualTag:      ct.tag,
+						ns:             v.str1,
+						structNs:       v.str2,
+						fieldLen:       uint8(len(cf.altName)),
+						structfieldLen: uint8(len(cf.name)),
+						value:          current.Interface(),
+						param:          ct.param,
+						kind:           kind,
+						typ:            current.Type(),
+					},
+				)
+				return
+			}
 		}
 
 	case reflect.Struct:

--- a/validator_test.go
+++ b/validator_test.go
@@ -723,6 +723,31 @@ func TestNilValidator(t *testing.T) {
 	PanicMatches(t, func() { val.StructPartial(ts, "Test") }, "runtime error: invalid memory address or nil pointer dereference")
 }
 
+func TestAbilityToValidateNils(t *testing.T) {
+
+	type TestStruct struct {
+		Test *string `validate:"nil"`
+	}
+
+	ts := TestStruct{}
+
+	val := New()
+
+	fn := func(fl FieldLevel) bool {
+		return fl.Field().Kind() == reflect.Ptr && fl.Field().IsNil()
+	}
+
+	val.RegisterValidation("nil", fn)
+	errs := val.Struct(ts)
+	Equal(t, errs, nil)
+
+	str := "string"
+	ts.Test = &str
+	val.RegisterValidation("nil", fn)
+	errs = val.Struct(ts)
+	NotEqual(t, errs, nil)
+}
+
 func TestStructPartial(t *testing.T) {
 
 	p1 := []string{
@@ -947,6 +972,7 @@ func TestCrossStructLteFieldValidation(t *testing.T) {
 		Uint      uint
 		Float     float64
 		Array     []string
+		PtrString *string
 	}
 
 	type Test struct {
@@ -957,6 +983,7 @@ func TestCrossStructLteFieldValidation(t *testing.T) {
 		Uint      uint       `validate:"ltecsfield=Inner.Uint"`
 		Float     float64    `validate:"ltecsfield=Inner.Float"`
 		Array     []string   `validate:"ltecsfield=Inner.Array"`
+		PtrString *string    `validate:"ltecsfield=Inner.PtrString"`
 	}
 
 	now := time.Now().UTC()
@@ -969,6 +996,7 @@ func TestCrossStructLteFieldValidation(t *testing.T) {
 		Uint:      13,
 		Float:     1.13,
 		Array:     []string{"val1", "val2"},
+		PtrString: nil,
 	}
 
 	test := &Test{
@@ -979,6 +1007,7 @@ func TestCrossStructLteFieldValidation(t *testing.T) {
 		Uint:      12,
 		Float:     1.12,
 		Array:     []string{"val1"},
+		PtrString: nil,
 	}
 
 	validate := New()
@@ -1114,6 +1143,9 @@ func TestCrossStructLtFieldValidation(t *testing.T) {
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "ltcsfield")
 
+	errs = validate.VarWithValue((*string)(nil), (*string)(nil), "ltcsfield")
+	NotEqual(t, errs, nil)
+
 	// this test is for the WARNING about unforeseen validation issues.
 	errs = validate.VarWithValue(test, now, "ltcsfield")
 	NotEqual(t, errs, nil)
@@ -1152,6 +1184,7 @@ func TestCrossStructGteFieldValidation(t *testing.T) {
 		Uint      uint
 		Float     float64
 		Array     []string
+		PtrString *string
 	}
 
 	type Test struct {
@@ -1162,6 +1195,7 @@ func TestCrossStructGteFieldValidation(t *testing.T) {
 		Uint      uint       `validate:"gtecsfield=Inner.Uint"`
 		Float     float64    `validate:"gtecsfield=Inner.Float"`
 		Array     []string   `validate:"gtecsfield=Inner.Array"`
+		PtrString *string    `validate:"gtecsfield=Inner.PtrString"`
 	}
 
 	now := time.Now().UTC()
@@ -1174,6 +1208,7 @@ func TestCrossStructGteFieldValidation(t *testing.T) {
 		Uint:      13,
 		Float:     1.13,
 		Array:     []string{"val1", "val2"},
+		PtrString: nil,
 	}
 
 	test := &Test{
@@ -1184,6 +1219,7 @@ func TestCrossStructGteFieldValidation(t *testing.T) {
 		Uint:      14,
 		Float:     1.14,
 		Array:     []string{"val1", "val2", "val3"},
+		PtrString: nil,
 	}
 
 	validate := New()
@@ -1317,6 +1353,9 @@ func TestCrossStructGtFieldValidation(t *testing.T) {
 	errs = validate.VarWithValue(1, "", "gtcsfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "gtcsfield")
+
+	errs = validate.VarWithValue((*string)(nil), (*string)(nil), "gtcsfield")
+	NotEqual(t, errs, nil)
 
 	// this test is for the WARNING about unforeseen validation issues.
 	errs = validate.VarWithValue(test, now, "gtcsfield")
@@ -1453,6 +1492,9 @@ func TestCrossStructNeFieldValidation(t *testing.T) {
 	errs = validate.VarWithValue(nil, 1, "necsfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "necsfield")
+
+	errs = validate.VarWithValue((*string)(nil), (*string)(nil), "necsfield")
+	NotEqual(t, errs, nil)
 }
 
 func TestCrossStructEqFieldValidation(t *testing.T) {
@@ -1558,6 +1600,9 @@ func TestCrossStructEqFieldValidation(t *testing.T) {
 	errs = validate.VarWithValue(nil, 1, "eqcsfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "eqcsfield")
+
+	errs = validate.VarWithValue((*string)(nil), (*string)(nil), "eqcsfield")
+	Equal(t, errs, nil)
 }
 
 func TestCrossNamespaceFieldValidation(t *testing.T) {
@@ -1966,6 +2011,8 @@ func TestMACValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "mac"), nil)
 }
 
 func TestIPValidation(t *testing.T) {
@@ -2007,6 +2054,8 @@ func TestIPValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "ip"), nil)
 }
 
 func TestIPv6Validation(t *testing.T) {
@@ -2047,6 +2096,8 @@ func TestIPv6Validation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "ipv6"), nil)
 }
 
 func TestIPv4Validation(t *testing.T) {
@@ -2087,6 +2138,8 @@ func TestIPv4Validation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "ipv4"), nil)
 }
 
 func TestCIDRValidation(t *testing.T) {
@@ -2130,6 +2183,8 @@ func TestCIDRValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "cidr"), nil)
 }
 
 func TestCIDRv6Validation(t *testing.T) {
@@ -2173,6 +2228,8 @@ func TestCIDRv6Validation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "cidrv6"), nil)
 }
 
 func TestCIDRv4Validation(t *testing.T) {
@@ -2216,6 +2273,8 @@ func TestCIDRv4Validation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "cidrv4"), nil)
 }
 
 func TestTCPAddrValidation(t *testing.T) {
@@ -2250,6 +2309,8 @@ func TestTCPAddrValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "tcp_addr"), nil)
 }
 
 func TestTCP6AddrValidation(t *testing.T) {
@@ -2284,6 +2345,8 @@ func TestTCP6AddrValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "tcp6_addr"), nil)
 }
 
 func TestTCP4AddrValidation(t *testing.T) {
@@ -2490,6 +2553,8 @@ func TestIP6AddrValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "ip6_addr"), nil)
 }
 
 func TestIP4AddrValidation(t *testing.T) {
@@ -2525,6 +2590,8 @@ func TestIP4AddrValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "ip4_addr"), nil)
 }
 
 func TestUnixAddrValidation(t *testing.T) {
@@ -2556,6 +2623,8 @@ func TestUnixAddrValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "unix_addr"), nil)
 }
 
 func TestSliceMapArrayChanFuncPtrInterfaceRequiredValidation(t *testing.T) {
@@ -3331,6 +3400,8 @@ func TestSSNValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "ssn"), nil)
 }
 
 func TestLongitudeValidation(t *testing.T) {
@@ -3372,6 +3443,7 @@ func TestLongitudeValidation(t *testing.T) {
 		}
 	}
 
+	NotEqual(t, validate.Var((*string)(nil), "longitude"), nil)
 	PanicMatches(t, func() { validate.Var(true, "longitude") }, "Bad field type bool")
 }
 
@@ -3414,6 +3486,7 @@ func TestLatitudeValidation(t *testing.T) {
 		}
 	}
 
+	NotEqual(t, validate.Var((*string)(nil), "latitude"), nil)
 	PanicMatches(t, func() { validate.Var(true, "latitude") }, "Bad field type bool")
 }
 
@@ -3457,6 +3530,8 @@ func TestDataURIValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "datauri"), nil)
 }
 
 func TestMultibyteValidation(t *testing.T) {
@@ -3497,6 +3572,7 @@ func TestMultibyteValidation(t *testing.T) {
 			}
 		}
 	}
+	NotEqual(t, validate.Var(3, "multibyte"), nil)
 }
 
 func TestPrintableASCIIValidation(t *testing.T) {
@@ -3538,6 +3614,8 @@ func TestPrintableASCIIValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "printascii"), nil)
 }
 
 func TestASCIIValidation(t *testing.T) {
@@ -3578,6 +3656,8 @@ func TestASCIIValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "ascii"), nil)
 }
 
 func TestUUID5Validation(t *testing.T) {
@@ -3615,6 +3695,8 @@ func TestUUID5Validation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "uuid5"), nil)
 }
 
 func TestUUID4Validation(t *testing.T) {
@@ -3651,6 +3733,8 @@ func TestUUID4Validation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(4, "uuid4"), nil)
 }
 
 func TestUUID3Validation(t *testing.T) {
@@ -3686,6 +3770,8 @@ func TestUUID3Validation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(4, "uuid3"), nil)
 }
 
 func TestUUIDValidation(t *testing.T) {
@@ -3724,6 +3810,8 @@ func TestUUIDValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(4, "uuid"), nil)
 }
 
 func TestUUID5RFC4122Validation(t *testing.T) {
@@ -3761,6 +3849,8 @@ func TestUUID5RFC4122Validation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(4, "uuid5_rfc4122"), nil)
 }
 
 func TestUUID4RFC4122Validation(t *testing.T) {
@@ -3797,6 +3887,8 @@ func TestUUID4RFC4122Validation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(4, "uuid4_rfc4122"), nil)
 }
 
 func TestUUID3RFC4122Validation(t *testing.T) {
@@ -3832,6 +3924,8 @@ func TestUUID3RFC4122Validation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(4, "uuid3_rfc4122"), nil)
 }
 
 func TestUUIDRFC4122Validation(t *testing.T) {
@@ -3870,6 +3964,8 @@ func TestUUIDRFC4122Validation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(4, "uuid_rfc4122"), nil)
 }
 
 func TestISBNValidation(t *testing.T) {
@@ -3949,6 +4045,8 @@ func TestISBN13Validation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(4, "isbn13"), nil)
 }
 
 func TestISBN10Validation(t *testing.T) {
@@ -3989,6 +4087,8 @@ func TestISBN10Validation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(4, "isbn10"), nil)
 }
 
 func TestExcludesRuneValidation(t *testing.T) {
@@ -4119,6 +4219,8 @@ func TestContainsRuneValidation(t *testing.T) {
 			t.Fatalf("Index: %d failed Error: %s", i, errs)
 		}
 	}
+
+	NotEqual(t, validate.Var(4, "containsrune=☻"), nil)
 }
 
 func TestContainsAnyValidation(t *testing.T) {
@@ -4147,6 +4249,8 @@ func TestContainsAnyValidation(t *testing.T) {
 			t.Fatalf("Index: %d failed Error: %s", i, errs)
 		}
 	}
+
+	NotEqual(t, validate.Var(4, "containsany=423"), nil)
 }
 
 func TestContainsValidation(t *testing.T) {
@@ -4175,6 +4279,8 @@ func TestContainsValidation(t *testing.T) {
 			t.Fatalf("Index: %d failed Error: %s", i, errs)
 		}
 	}
+
+	NotEqual(t, validate.Var(4, "contains=4"), nil)
 }
 
 func TestIsNeFieldValidation(t *testing.T) {
@@ -4250,6 +4356,9 @@ func TestIsNeFieldValidation(t *testing.T) {
 	errs = validate.VarWithValue(nil, 1, "nefield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "nefield")
+
+	errs = validate.VarWithValue((*int)(nil), (*int)(nil), "nefield")
+	Equal(t, errs, nil)
 
 	errs = validate.VarWithValue(sv, now, "nefield")
 	Equal(t, errs, nil)
@@ -4393,6 +4502,9 @@ func TestIsEqFieldValidation(t *testing.T) {
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "eqfield")
 
+	errs = validate.VarWithValue((*string)(nil), (*string)(nil), "eqfield")
+	Equal(t, errs, nil)
+
 	channel := make(chan string)
 	errs = validate.VarWithValue(5, channel, "eqfield")
 	NotEqual(t, errs, nil)
@@ -4471,6 +4583,9 @@ func TestIsEqValidation(t *testing.T) {
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "eq")
 
+	errs = validate.Var((*int)(nil), "eq=2")
+	NotEqual(t, errs, nil)
+
 	PanicMatches(t, func() { validate.Var(now, "eq=now") }, "Bad field type time.Time")
 }
 
@@ -4521,6 +4636,7 @@ func TestOneOfValidation(t *testing.T) {
 		{f: uint16(5), t: "oneof=red green"},
 		{f: uint32(5), t: "oneof=red green"},
 		{f: uint64(5), t: "oneof=red green"},
+		{f: (*string)(nil), t: "oneof=red green"},
 	}
 
 	for _, spec := range failSpecs {
@@ -4556,6 +4672,8 @@ func TestBase64Validation(t *testing.T) {
 	errs = validate.Var(s, "base64")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "base64")
+
+	NotEqual(t, validate.Var(3, "base64"), nil)
 }
 
 func TestBase64URLValidation(t *testing.T) {
@@ -4603,6 +4721,8 @@ func TestBase64URLValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "base64url"), nil)
 }
 
 func TestFileValidation(t *testing.T) {
@@ -4633,9 +4753,7 @@ func TestFileValidation(t *testing.T) {
 		}
 	}
 
-	PanicMatches(t, func() {
-		validate.Var(6, "file")
-	}, "Bad field type int")
+	NotEqual(t, validate.Var(6, "file"), nil)
 }
 
 func TestEthereumAddressValidation(t *testing.T) {
@@ -4672,6 +4790,8 @@ func TestEthereumAddressValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(4, "eth_addr"), nil)
 }
 
 func TestBitcoinAddressValidation(t *testing.T) {
@@ -4782,6 +4902,8 @@ func TestBitcoinAddressValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(4, "btc_addr"), nil)
 }
 
 func TestBitcoinBech32AddressValidation(t *testing.T) {
@@ -4833,6 +4955,8 @@ func TestBitcoinBech32AddressValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(4, "btc_addr_bech32"), nil)
 }
 
 func TestNoStructLevelValidation(t *testing.T) {
@@ -5079,6 +5203,10 @@ func TestGtField(t *testing.T) {
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "gtfield")
 
+	errs = validate.VarWithValue((*int)(nil), (*int)(nil), "gtfield")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "gtfield")
+
 	errs = validate.VarWithValue(5, "T", "gtfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "gtfield")
@@ -5255,6 +5383,10 @@ func TestLtField(t *testing.T) {
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "ltfield")
 
+	errs = validate.VarWithValue((*int)(nil), (*int)(nil), "ltfield")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "ltfield")
+
 	errs = validate.VarWithValue(1, "T", "ltfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "ltfield")
@@ -5325,6 +5457,20 @@ func TestFieldContains(t *testing.T) {
 	errs = validate.Struct(stringTestMissingField)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "StringTestMissingField.Foo", "StringTestMissingField.Foo", "Foo", "Foo", "fieldcontains")
+
+	type FooIntTest struct {
+		Foo int `validate:"fieldcontains=Bar"`
+		Bar string
+	}
+	errs = validate.Struct(&FooIntTest{Foo:10, Bar:"1"})
+	NotEqual(t, errs, nil)
+
+	type BarIntTest struct {
+		Foo string `validate:"fieldcontains=Bar"`
+		Bar int
+	}
+	errs = validate.Struct(&BarIntTest{Foo:"10", Bar:1})
+	NotEqual(t, errs, nil)
 }
 
 func TestFieldExcludes(t *testing.T) {
@@ -5372,6 +5518,20 @@ func TestFieldExcludes(t *testing.T) {
 
 	errs = validate.Struct(stringTestMissingField)
 	Equal(t, errs, nil)
+
+	type FooIntTest struct {
+		Foo int `validate:"fieldexcludes=Bar"`
+		Bar string
+	}
+	errs = validate.Struct(&FooIntTest{Foo:10, Bar:"2"})
+	NotEqual(t, errs, nil)
+
+	type BarIntTest struct {
+		Foo string `validate:"fieldexcludes=Bar"`
+		Bar int
+	}
+	errs = validate.Struct(&BarIntTest{Foo:"10", Bar:1})
+	Equal(t, errs, nil) // since a string cannot contain non-string elements
 }
 
 func TestContainsAndExcludes(t *testing.T) {
@@ -5538,6 +5698,9 @@ func TestLteField(t *testing.T) {
 	errs = validate.VarWithValue(nil, 5, "ltefield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "ltefield")
+
+	errs = validate.VarWithValue((*int)(nil), (*int)(nil), "ltefield")
+	Equal(t, errs, nil)
 
 	errs = validate.VarWithValue(1, "T", "ltefield")
 	NotEqual(t, errs, nil)
@@ -5721,6 +5884,9 @@ func TestGteField(t *testing.T) {
 	errs = validate.Struct(timeTest2)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeTest2.End", "TimeTest2.End", "End", "End", "gtefield")
+
+	errs = validate.VarWithValue((*int)(nil), (*int)(nil), "gtefield")
+	Equal(t, errs, nil)
 }
 
 func TestValidateByTagAndValue(t *testing.T) {
@@ -5845,6 +6011,8 @@ func TestLength(t *testing.T) {
 
 	i := true
 	PanicMatches(t, func() { validate.Var(i, "len") }, "Bad field type bool")
+
+	NotEqual(t, validate.Var((*string)(nil), "len=0"), nil)
 }
 
 func TestIsGt(t *testing.T) {
@@ -5897,6 +6065,9 @@ func TestIsGt(t *testing.T) {
 	errs = validate.Struct(s)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "Test.Now", "Test.Now", "Now", "Now", "gt")
+
+	errs = validate.Var((*int)(nil), "gt=-1")
+	NotEqual(t, errs, nil)
 }
 
 func TestIsGte(t *testing.T) {
@@ -5935,6 +6106,9 @@ func TestIsGte(t *testing.T) {
 	errs = validate.Struct(s)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "Test.Now", "Test.Now", "Now", "Now", "gte")
+
+	errs = validate.Var((*int)(nil), "gte=0")
+	NotEqual(t, errs, nil)
 }
 
 func TestIsLt(t *testing.T) {
@@ -5989,6 +6163,9 @@ func TestIsLt(t *testing.T) {
 	errs = validate.Struct(s)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "Test.Now", "Test.Now", "Now", "Now", "lt")
+
+	errs = validate.Var((*int)(nil), "lt=1")
+	NotEqual(t, errs, nil)
 }
 
 func TestIsLte(t *testing.T) {
@@ -6026,6 +6203,9 @@ func TestIsLte(t *testing.T) {
 	}
 
 	errs = validate.Struct(s)
+	NotEqual(t, errs, nil)
+
+	errs = validate.Var((*int)(nil), "lte=0")
 	NotEqual(t, errs, nil)
 }
 
@@ -6103,7 +6283,7 @@ func TestUrnRFC2141(t *testing.T) {
 	}
 
 	i := 1
-	PanicMatches(t, func() { validate.Var(i, tag) }, "Bad field type int")
+	NotEqual(t, validate.Var(i, tag), nil)
 }
 
 func TestUrl(t *testing.T) {
@@ -6171,7 +6351,7 @@ func TestUrl(t *testing.T) {
 	}
 
 	i := 1
-	PanicMatches(t, func() { validate.Var(i, "url") }, "Bad field type int")
+	NotEqual(t, validate.Var(i, "url"), nil)
 }
 
 func TestUri(t *testing.T) {
@@ -6238,7 +6418,7 @@ func TestUri(t *testing.T) {
 	}
 
 	i := 1
-	PanicMatches(t, func() { validate.Var(i, "uri") }, "Bad field type int")
+	NotEqual(t, validate.Var(i, "uri"), nil)
 }
 
 func TestOrTag(t *testing.T) {
@@ -6643,6 +6823,8 @@ func TestNumber(t *testing.T) {
 	i := 1
 	errs = validate.Var(i, "number")
 	Equal(t, errs, nil)
+
+	NotEqual(t, validate.Var((*int)(nil), "number"), nil)
 }
 
 func TestNumeric(t *testing.T) {
@@ -6686,6 +6868,8 @@ func TestNumeric(t *testing.T) {
 	i := 1
 	errs = validate.Var(i, "numeric")
 	Equal(t, errs, nil)
+
+	NotEqual(t, validate.Var((*int)(nil), "numeric"), nil)
 }
 
 func TestAlphaNumeric(t *testing.T) {
@@ -7640,6 +7824,8 @@ func TestAlphaUnicodeValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "alphaunicode"), nil)
 }
 
 func TestAlphanumericUnicodeValidation(t *testing.T) {
@@ -7683,6 +7869,8 @@ func TestAlphanumericUnicodeValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "alphanumunicode"), nil)
 }
 
 func TestArrayStructNamespace(t *testing.T) {
@@ -7891,6 +8079,8 @@ func TestHostnameRFC952Validation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "hostname"), nil)
 }
 
 func TestHostnameRFC1123Validation(t *testing.T) {
@@ -7939,6 +8129,8 @@ func TestHostnameRFC1123Validation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "hostname_rfc1123"), nil)
 }
 
 func TestHostnameRFC1123AliasValidation(t *testing.T) {
@@ -8036,6 +8228,8 @@ func TestFQDNValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "fqdn"), nil)
 }
 
 func TestIsDefault(t *testing.T) {
@@ -8134,6 +8328,8 @@ func TestUniqueValidation(t *testing.T) {
 		{map[string]string{"one": "a", "two": "a"}, false},
 		{map[string]interface{}{"one": "a", "two": "a"}, false},
 		{map[string]interface{}{"one": "a", "two": 1, "three": "b", "four": 1}, false},
+		// Nil
+		{(*[]string)(nil), true},
 	}
 
 	validate := New()
@@ -8197,6 +8393,8 @@ func TestHTMLValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "html"), nil)
 }
 
 func TestHTMLEncodedValidation(t *testing.T) {
@@ -8243,6 +8441,8 @@ func TestHTMLEncodedValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "html_encoded"), nil)
 }
 
 func TestURLEncodedValidation(t *testing.T) {
@@ -8281,6 +8481,8 @@ func TestURLEncodedValidation(t *testing.T) {
 			}
 		}
 	}
+
+	NotEqual(t, validate.Var(3, "url_encoded"), nil)
 }
 
 func TestKeys(t *testing.T) {
@@ -8561,9 +8763,7 @@ func TestDirValidation(t *testing.T) {
 		}
 	}
 
-	PanicMatches(t, func() {
-		validate.Var(2, "dir")
-	}, "Bad field type int")
+	NotEqual(t, validate.Var(2, "dir"), nil) // not a string
 }
 
 func TestStartsWithValidation(t *testing.T) {
@@ -8591,6 +8791,8 @@ func TestStartsWithValidation(t *testing.T) {
 			t.Fatalf("Index: %d failed Error: %s", i, errs)
 		}
 	}
+
+	NotEqual(t, validate.Var(4, "startswith=4"), nil)
 }
 
 func TestEndsWithValidation(t *testing.T) {
@@ -8618,6 +8820,8 @@ func TestEndsWithValidation(t *testing.T) {
 			t.Fatalf("Index: %d failed Error: %s", i, errs)
 		}
 	}
+
+	NotEqual(t, validate.Var(4, "endswith=4"), nil)
 }
 
 func TestRequiredWith(t *testing.T) {


### PR DESCRIPTION
Fixes Or Enhances # .

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:

Currently for pointer-type fields with nil values all the validations are skipped and an error mentioning to the first validation on the list is added. But what if we want to consider nil-values valid? For example, in our program we have a list of fields provided by user and, when we validate a form, we want to add errors for missing required fields, but not for nil fields that are given.

This PR allows to make fields with nil values valid and perform validations on them.

@go-playground/admins