### PR TITLE
Let validators see current fields paths

### DIFF
--- a/field_level.go
+++ b/field_level.go
@@ -23,6 +23,13 @@ type FieldLevel interface {
 	// returns the struct field's name
 	StructFieldName() string
 
+	// returns the field's path with tag names
+	// taking precedence over fields actual names
+	Path() string
+
+	// returns the struct field's path
+	StructPath() string
+
 	// returns param for validation against current field
 	Param() string
 
@@ -56,6 +63,17 @@ func (v *validate) FieldName() string {
 // StructFieldName returns the struct field's name
 func (v *validate) StructFieldName() string {
 	return v.cf.name
+}
+
+// Path returns the field's path with tag names
+// taking precedence over fields actual names.
+func (v *validate) Path() string {
+	return v.str1
+}
+
+// StructPath returns the struct field's path
+func (v *validate) StructPath() string {
+	return v.str2
 }
 
 // Param returns param for validation against current field

--- a/validator.go
+++ b/validator.go
@@ -175,15 +175,15 @@ func (v *validate) traverseField(ctx context.Context, parent reflect.Value, curr
 					v.cf = cf
 					v.ct = ct
 
+					v.str1 = string(append(ns, cf.altName...))
+
+					if v.v.hasTagNameFunc {
+						v.str2 = string(append(structNs, cf.name...))
+					} else {
+						v.str2 = v.str1
+					}
+
 					if !ct.fn(ctx, v) {
-						v.str1 = string(append(ns, cf.altName...))
-
-						if v.v.hasTagNameFunc {
-							v.str2 = string(append(structNs, cf.name...))
-						} else {
-							v.str2 = v.str1
-						}
-
 						v.errs = append(v.errs,
 							&fieldError{
 								v:              v.v,
@@ -440,16 +440,14 @@ OUTER:
 			v.cf = cf
 			v.ct = ct
 
+			v.str1 = string(append(ns, cf.altName...))
+
+			if v.v.hasTagNameFunc {
+				v.str2 = string(append(structNs, cf.name...))
+			} else {
+				v.str2 = v.str1
+			}
 			if !ct.fn(ctx, v) {
-
-				v.str1 = string(append(ns, cf.altName...))
-
-				if v.v.hasTagNameFunc {
-					v.str2 = string(append(structNs, cf.name...))
-				} else {
-					v.str2 = v.str1
-				}
-
 				v.errs = append(v.errs,
 					&fieldError{
 						v:              v.v,

--- a/validator_test.go
+++ b/validator_test.go
@@ -8775,22 +8775,22 @@ func TestPaths(t *testing.T) {
 		return true
 	})
 	val.RegisterTagNameFunc(func(fld reflect.StructField) string {
-			name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
-			if name == "-" {
-					return ""
-			}
-			return name
+		name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
+		if name == "-" {
+			return ""
+		}
+		return name
 	})
 	type SInner struct {
 		Name string `json:"name" validate:"my"`
 	}
 
 	type TStruct struct {
-		Inner     *SInner `json:"inner" validate:"my"`
-		CreatedAt *time.Time `json:"created_at" validate:"my"`
+		Inner     SInner    `json:"inner" validate:"my"`
+		CreatedAt time.Time `json:"created_at" validate:"my"`
 	}
 
-	val.Struct(&TStruct{Inner:&SInner{}})
+	val.Struct(&TStruct{Inner: SInner{}})
 
 	Equal(t, []string{"TStruct.inner.name", "TStruct.created_at"}, paths)
 	Equal(t, []string{"TStruct.Inner.Name", "TStruct.CreatedAt"}, structPaths)


### PR DESCRIPTION
Fixes Or Enhances # .

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:

Currently there is no way for validators to know which fields they are checking. So validators depending not only on the value, but on the field itself (e.g. checking that the field is listed in some external source) cannot work.

This PR adds new methods Path() & StructPath() into the FieldLevel interface allowing validators to get a path (based on FieldName-s) or a struct path (based on StructFieldName-s) of the current field respectively.

@go-playground/admins