### PR TITLE
Issue #521: Non-standard validators import path fix

### DIFF
--- a/non-standard/validators/notblank.go
+++ b/non-standard/validators/notblank.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/andreiavrammsd/validator"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 // NotBlank is the validation function for validating if the current field

--- a/non-standard/validators/notblank_test.go
+++ b/non-standard/validators/notblank_test.go
@@ -3,7 +3,7 @@ package validators
 import (
 	"testing"
 
-	"github.com/andreiavrammsd/validator"
+	"gopkg.in/go-playground/validator.v9"
 	"gopkg.in/go-playground/assert.v1"
 )
 


### PR DESCRIPTION
Fixes Or Enhances # .

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:

- In the non-standard validators, changed the import path of validator package from `github.com/andreiavrammsd/validator` to `gopkg.in/go-playground/validator.v9`

@go-playground/admins