### PR TITLE
Add e.164 support

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -103,6 +103,7 @@ var (
 		"rgba":                 isRGBA,
 		"hsl":                  isHSL,
 		"hsla":                 isHSLA,
+		"e164":                 isE164,
 		"email":                isEmail,
 		"url":                  isURL,
 		"uri":                  isURI,
@@ -1217,6 +1218,11 @@ func isFile(fl FieldLevel) bool {
 	}
 
 	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
+}
+
+// IsE164 is the validation function for validating if the current field's value is a valid e.164 formatted phone number.
+func isE164(fl FieldLevel) bool {
+	return e164Regex.MatchString(fl.Field().String())
 }
 
 // IsEmail is the validation function for validating if the current field's value is a valid email address.

--- a/regexes.go
+++ b/regexes.go
@@ -16,6 +16,7 @@ const (
 	hslRegexString                   = "^hsl\\(\\s*(?:0|[1-9]\\d?|[12]\\d\\d|3[0-5]\\d|360)\\s*,\\s*(?:(?:0|[1-9]\\d?|100)%)\\s*,\\s*(?:(?:0|[1-9]\\d?|100)%)\\s*\\)$"
 	hslaRegexString                  = "^hsla\\(\\s*(?:0|[1-9]\\d?|[12]\\d\\d|3[0-5]\\d|360)\\s*,\\s*(?:(?:0|[1-9]\\d?|100)%)\\s*,\\s*(?:(?:0|[1-9]\\d?|100)%)\\s*,\\s*(?:(?:0.[1-9]*)|[01])\\s*\\)$"
 	emailRegexString                 = "^(?:(?:(?:(?:[a-zA-Z]|\\d|[!#\\$%&'\\*\\+\\-\\/=\\?\\^_`{\\|}~]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])+(?:\\.([a-zA-Z]|\\d|[!#\\$%&'\\*\\+\\-\\/=\\?\\^_`{\\|}~]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])+)*)|(?:(?:\\x22)(?:(?:(?:(?:\\x20|\\x09)*(?:\\x0d\\x0a))?(?:\\x20|\\x09)+)?(?:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x7f]|\\x21|[\\x23-\\x5b]|[\\x5d-\\x7e]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])|(?:(?:[\\x01-\\x09\\x0b\\x0c\\x0d-\\x7f]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}]))))*(?:(?:(?:\\x20|\\x09)*(?:\\x0d\\x0a))?(\\x20|\\x09)+)?(?:\\x22))))@(?:(?:(?:[a-zA-Z]|\\d|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])|(?:(?:[a-zA-Z]|\\d|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])(?:[a-zA-Z]|\\d|-|\\.|~|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])*(?:[a-zA-Z]|\\d|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])))\\.)+(?:(?:[a-zA-Z]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])|(?:(?:[a-zA-Z]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])(?:[a-zA-Z]|\\d|-|\\.|~|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])*(?:[a-zA-Z]|[\\x{00A0}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFEF}])))\\.?$"
+	e164RegexString                  = "^\\+[1-9]?[0-9]{7,14}$"
 	base64RegexString                = "^(?:[A-Za-z0-9+\\/]{4})*(?:[A-Za-z0-9+\\/]{2}==|[A-Za-z0-9+\\/]{3}=|[A-Za-z0-9+\\/]{4})$"
 	base64URLRegexString             = "^(?:[A-Za-z0-9-_]{4})*(?:[A-Za-z0-9-_]{2}==|[A-Za-z0-9-_]{3}=|[A-Za-z0-9-_]{4})$"
 	iSBN10RegexString                = "^(?:[0-9]{9}X|[0-9]{10})$"
@@ -61,6 +62,7 @@ var (
 	rgbaRegex                  = regexp.MustCompile(rgbaRegexString)
 	hslRegex                   = regexp.MustCompile(hslRegexString)
 	hslaRegex                  = regexp.MustCompile(hslaRegexString)
+	e164Regex                  = regexp.MustCompile(e164RegexString)
 	emailRegex                 = regexp.MustCompile(emailRegexString)
 	base64Regex                = regexp.MustCompile(base64RegexString)
 	base64URLRegex             = regexp.MustCompile(base64URLRegexString)

--- a/translations/en/en.go
+++ b/translations/en/en.go
@@ -1044,6 +1044,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "e164",
+			translation: "{0} must be a valid E.164 formatted phone number",
+			override:    false,
+		},
+		{
 			tag:         "email",
 			translation: "{0} must be a valid email address",
 			override:    false,

--- a/validator_test.go
+++ b/validator_test.go
@@ -4911,6 +4911,7 @@ func TestStructOnlyValidation(t *testing.T) {
 		FirstName      string     `json:"fname"`
 		LastName       string     `json:"lname"`
 		Age            uint8      `validate:"gte=0,lte=130"`
+		Number         string     `validate:"required,e164"`
 		Email          string     `validate:"required,email"`
 		FavouriteColor string     `validate:"hexcolor|rgb|rgba"`
 		Addresses      []*Address `validate:"required"`   // a person can have a home and cottage...
@@ -4928,6 +4929,7 @@ func TestStructOnlyValidation(t *testing.T) {
 		FirstName:      "",
 		LastName:       "",
 		Age:            45,
+		Number:         "+1123456789",
 		Email:          "Badger.Smith@gmail.com",
 		FavouriteColor: "#000",
 		Addresses:      []*Address{address},


### PR DESCRIPTION
Fixes Or Enhances # .
Add support for the [E.164](https://en.wikipedia.org/wiki/E.164) format for phone numbers
**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:

- 
- 
- 


@go-playground/admins