### PR TITLE
Adds ability to validate oneof for space separated strings

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -177,7 +178,8 @@ func parseOneOfParam2(s string) []string {
 	oneofValsCacheRWLock.RUnlock()
 	if !ok {
 		oneofValsCacheRWLock.Lock()
-		vals = strings.Fields(s)
+		re := regexp.MustCompile(`'[^']*'|\S+`)
+		vals = re.FindAllString(s, -1)
 		oneofValsCache[s] = vals
 		oneofValsCacheRWLock.Unlock()
 	}
@@ -213,7 +215,8 @@ func isOneOf(fl FieldLevel) bool {
 		panic(fmt.Sprintf("Bad field type %T", field.Interface()))
 	}
 	for i := 0; i < len(vals); i++ {
-		if vals[i] == v {
+		val := strings.Replace(vals[i], "'", "", -1)
+		if val == v {
 			return true
 		}
 	}

--- a/baked_in.go
+++ b/baked_in.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"reflect"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -178,8 +177,10 @@ func parseOneOfParam2(s string) []string {
 	oneofValsCacheRWLock.RUnlock()
 	if !ok {
 		oneofValsCacheRWLock.Lock()
-		re := regexp.MustCompile(`'[^']*'|\S+`)
-		vals = re.FindAllString(s, -1)
+		vals = splitParamsRegex.FindAllString(s, -1)
+		for i := 0; i < len(vals); i++ {
+			vals[i] = strings.Replace(vals[i], "'", "", -1)
+		}
 		oneofValsCache[s] = vals
 		oneofValsCacheRWLock.Unlock()
 	}
@@ -215,8 +216,7 @@ func isOneOf(fl FieldLevel) bool {
 		panic(fmt.Sprintf("Bad field type %T", field.Interface()))
 	}
 	for i := 0; i < len(vals); i++ {
-		val := strings.Replace(vals[i], "'", "", -1)
-		if val == v {
+		if vals[i] == v {
 			return true
 		}
 	}

--- a/doc.go
+++ b/doc.go
@@ -361,10 +361,12 @@ One Of
 
 For strings, ints, and uints, oneof will ensure that the value
 is one of the values in the parameter.  The parameter should be
-a list of values separated by whitespace.  Values may be
-strings or numbers.
+a list of values separated by whitespace. Values may be
+strings or numbers. To match strings with spaces in them, include
+the target string between single quotes.
 
     Usage: oneof=red green
+           oneof='red green' 'blue yellow'
            oneof=5 7 9
 
 Greater Than

--- a/regexes.go
+++ b/regexes.go
@@ -46,6 +46,7 @@ const (
 	uRLEncodedRegexString            = `(%[A-Fa-f0-9]{2})`
 	hTMLEncodedRegexString           = `&#[x]?([0-9a-fA-F]{2})|(&gt)|(&lt)|(&quot)|(&amp)+[;]?`
 	hTMLRegexString                  = `<[/]?([a-zA-Z]+).*?>`
+	splitParamsRegexString           = `'[^']*'|\S+`
 )
 
 var (
@@ -92,4 +93,5 @@ var (
 	uRLEncodedRegex            = regexp.MustCompile(uRLEncodedRegexString)
 	hTMLEncodedRegex           = regexp.MustCompile(hTMLEncodedRegexString)
 	hTMLRegex                  = regexp.MustCompile(hTMLRegexString)
+	splitParamsRegex           = regexp.MustCompile(splitParamsRegexString)
 )

--- a/validator_test.go
+++ b/validator_test.go
@@ -14,11 +14,11 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/go-playground/assert/v2"
 	"github.com/go-playground/locales/en"
 	"github.com/go-playground/locales/fr"
 	"github.com/go-playground/locales/nl"
 	ut "github.com/go-playground/universal-translator"
-	. "github.com/go-playground/assert/v2"
 )
 
 // NOTES:
@@ -4484,6 +4484,8 @@ func TestOneOfValidation(t *testing.T) {
 	}{
 		{f: "red", t: "oneof=red green"},
 		{f: "green", t: "oneof=red green"},
+		{f: "red green", t: "oneof='red green' blue"},
+		{f: "blue", t: "oneof='red green' blue"},
 		{f: 5, t: "oneof=5 6"},
 		{f: 6, t: "oneof=5 6"},
 		{f: int8(6), t: "oneof=5 6"},
@@ -4509,6 +4511,7 @@ func TestOneOfValidation(t *testing.T) {
 	}{
 		{f: "", t: "oneof=red green"},
 		{f: "yellow", t: "oneof=red green"},
+		{f: "green", t: "oneof='red green' blue"},
 		{f: 5, t: "oneof=red green"},
 		{f: 6, t: "oneof=red green"},
 		{f: 6, t: "oneof=7"},


### PR DESCRIPTION
Fixes Or Enhances https://github.com/go-playground/validator/issues/525.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:

* Adds the ability to match on space separated strings when using the
`oneof` validation. Space separted strings must be surrounded by single
quotes to be validated as one string. For example:

```
oneof='Awaiting Verification' 'Verified' 'Failed Verification'
```

passes validation for a field that is exactly `Failed Verification`
(though just `Failed` would...fail).

@go-playground/admins