### PR TITLE
Added boolean type support for “eq” validator

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -1106,6 +1106,11 @@ func isEq(fl FieldLevel) bool {
 		p := asFloat(param)
 
 		return field.Float() == p
+
+	case reflect.Bool:
+		p := asBool(param)
+
+		return field.Bool() == p
 	}
 
 	panic(fmt.Sprintf("Bad field type %T", field.Interface()))

--- a/util.go
+++ b/util.go
@@ -249,6 +249,16 @@ func asFloat(param string) float64 {
 	return i
 }
 
+// asBool returns the parameter as a bool
+// or panics if it can't convert
+func asBool(param string) bool {
+
+	i, err := strconv.ParseBool(param)
+	panicIf(err)
+
+	return i
+}
+
 func panicIf(err error) {
 	if err != nil {
 		panic(err.Error())

--- a/validator_test.go
+++ b/validator_test.go
@@ -7191,6 +7191,25 @@ func TestRequired(t *testing.T) {
 	AssertError(t, err.(ValidationErrors), "Test.Value", "Test.Value", "Value", "Value", "required")
 }
 
+func TestBoolEqual(t *testing.T) {
+
+	validate := New()
+
+	type Test struct {
+		Value bool `validate:"eq=true"`
+	}
+
+	var test Test
+
+	err := validate.Struct(test)
+	NotEqual(t, err, nil)
+	AssertError(t, err.(ValidationErrors), "Test.Value", "Test.Value", "Value", "Value", "eq")
+
+	test.Value = true
+	err = validate.Struct(test)
+	Equal(t, err, nil)
+}
+
 func TestTranslations(t *testing.T) {
 	en := en.New()
 	uni := ut.New(en, en, fr.New())


### PR DESCRIPTION
Fixes Or Enhances # .
Added boolean type support for “eq” validator

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:
added asBool function to convert string to boolean


@go-playground/admins