### PR TITLE
Improves accuracy of datauri regex

### DIFF
--- a/regexes.go
+++ b/regexes.go
@@ -31,7 +31,7 @@ const (
 	aSCIIRegexString                 = "^[\x00-\x7F]*$"
 	printableASCIIRegexString        = "^[\x20-\x7E]*$"
 	multibyteRegexString             = "[^\x00-\x7F]"
-	dataURIRegexString               = "^data:.+\\/(.+);base64$"
+	dataURIRegexString               = `^data:((?:\w+\/(?:([^;]|;[^;]).)+)?)`
 	latitudeRegexString              = "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?)$"
 	longitudeRegexString             = "^[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
 	sSNRegexString                   = `^[0-9]{3}[ -]?(0[1-9]|[1-9][0-9])[ -]?([1-9][0-9]{3}|[0-9][1-9][0-9]{2}|[0-9]{2}[1-9][0-9]|[0-9]{3}[1-9])$`

--- a/validator_test.go
+++ b/validator_test.go
@@ -3435,12 +3435,15 @@ func TestDataURIValidation(t *testing.T) {
 		{"data:image/png;base64,12345", false},
 		{"", false},
 		{"data:text,:;base85,U3VzcGVuZGlzc2UgbGVjdHVzIGxlbw==", false},
+		{"data:image/jpeg;key=value;base64,UEsDBBQAAAAI", true},
+		{"data:image/jpeg;key=value,UEsDBBQAAAAI", true},
+		{"data:;base64;sdfgsdfgsdfasdfa=s,UEsDBBQAAAAI", true},
+		{"data:,UEsDBBQAAAAI", true},
 	}
 
 	validate := New()
 
 	for i, test := range tests {
-
 		errs := validate.Var(test.param, "datauri")
 
 		if test.expected {


### PR DESCRIPTION
Fixes Or Enhances https://github.com/go-playground/validator/issues/518.

Make sure that you've checked the boxes below before you submit PR:

[x] Tests exist or have been written that cover this particular change.

Change Details:

The datauri validation was not allowing certain valid strings; this
commit updates the regex to meet RFC 2397. I drew heavily on this gist
https://gist.github.com/khanzadimahdi/bab8a3416bdb764b9eda5b38b35735b8,
but had to make a few updates to remove some negative lookaheads (which
Go doesn't allow afaik), and to account for the way the `isDataURI`
function works - it validates the base64 separately from the other parts
of the uri.

@go-playground/admins