### PR TITLE
error is always nil

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -1178,7 +1178,7 @@ func isURL(fl FieldLevel) bool {
 			return false
 		}
 
-		return err == nil
+		return true
 	}
 
 	panic(fmt.Sprintf("Bad field type %T", field.Interface()))


### PR DESCRIPTION
Fixes Or Enhances # .

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:

- The check for error == nil in isUrl check is not necessary  because it's alway nil



@go-playground/admins