### PR TITLE
Run tests on latest stable version 1.13.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.13.4
+  - 1.13.7
   - tip
 matrix:
   allow_failures:
@@ -25,5 +25,5 @@ script:
   - go test -v -race -covermode=atomic -coverprofile=coverage.coverprofile ./...
 
 after_success: |
-  [ $TRAVIS_GO_VERSION = 1.13.4 ] &&
+  [ $TRAVIS_GO_VERSION = 1.13.7 ] &&
   goveralls -coverprofile=coverage.coverprofile -service travis-ci -repotoken $COVERALLS_TOKEN


### PR DESCRIPTION
This PR changes travis conf in order to runt test on the latest stable version of 1.13 

@go-playground/admins