### PR TITLE
Add validators that check if string does not start/end with supplied parameter

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -120,6 +120,8 @@ var (
 		"excludesrune":         excludesRune,
 		"startswith":           startsWith,
 		"endswith":             endsWith,
+		"startsnotwith":        startsNotWith,
+		"endsnotwith":          endsNotWith,
 		"isbn":                 isISBN,
 		"isbn10":               isISBN10,
 		"isbn13":               isISBN13,
@@ -688,6 +690,16 @@ func startsWith(fl FieldLevel) bool {
 // EndsWith is the validation function for validating that the field's value ends with the text specified within the param.
 func endsWith(fl FieldLevel) bool {
 	return strings.HasSuffix(fl.Field().String(), fl.Param())
+}
+
+// StartsNotWith is the validation function for validating that the field's value does not start with the text specified within the param.
+func startsNotWith(fl FieldLevel) bool {
+	return !startsWith(fl)
+}
+
+// EndsNotWith is the validation function for validating that the field's value does not end with the text specified within the param.
+func endsNotWith(fl FieldLevel) bool {
+	return !endsWith(fl)
 }
 
 // FieldContains is the validation function for validating if the current field's value contains the field specified by the param's value.

--- a/doc.go
+++ b/doc.go
@@ -814,6 +814,18 @@ This validates that a string value ends with the supplied string value
 
 	Usage: endswith=goodbye
 
+Does Not Start With
+
+This validates that a string value does not start with the supplied string value
+
+	Usage: startsnotwith=hello
+
+Does Not End With
+
+This validates that a string value does not end with the supplied string value
+
+	Usage: endsnotwith=goodbye
+
 International Standard Book Number
 
 This validates that a string value contains a valid isbn10 or isbn13 value.


### PR DESCRIPTION
- [x] Tests exist or have been written that cover this particular change.

Change Details:

- Add startsnotwith and endsnotwith validators
- Just wrappers around startswith and endswith that invert values returned from them


@go-playground/admins