### PR TITLE
Fix/rfc952 host

### DIFF
--- a/regexes.go
+++ b/regexes.go
@@ -36,7 +36,7 @@ const (
 	latitudeRegexString              = "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?)$"
 	longitudeRegexString             = "^[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
 	sSNRegexString                   = `^[0-9]{3}[ -]?(0[1-9]|[1-9][0-9])[ -]?([1-9][0-9]{3}|[0-9][1-9][0-9]{2}|[0-9]{2}[1-9][0-9]|[0-9]{3}[1-9])$`
-	hostnameRegexStringRFC952        = `^[a-zA-Z][a-zA-Z0-9\-\.]+[a-zA-Z0-9]$`                                            // https://tools.ietf.org/html/rfc952
+	hostnameRegexStringRFC952        = `^[a-zA-Z]([a-zA-Z0-9\-]+[\.]?)*[a-zA-Z0-9]$`                                      // https://tools.ietf.org/html/rfc952
 	hostnameRegexStringRFC1123       = `^([a-zA-Z0-9]{1}[a-zA-Z0-9_-]{0,62}){1}(\.[a-zA-Z0-9_]{1}[a-zA-Z0-9_-]{0,62})*?$` // accepts hostname starting with a digit https://tools.ietf.org/html/rfc1123
 	btcAddressRegexString            = `^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$`                                                // bitcoin address
 	btcAddressUpperRegexStringBech32 = `^BC1[02-9AC-HJ-NP-Z]{7,76}$`                                                      // bitcoin bech32 address https://en.bitcoin.it/wiki/Bech32

--- a/validator_test.go
+++ b/validator_test.go
@@ -7896,6 +7896,9 @@ func TestHostnameRFC952Validation(t *testing.T) {
 		{"2001:cdba:0000:0000:0000:0000:3257:9652", false},
 		{"2001:cdba:0:0:0:0:3257:9652", false},
 		{"2001:cdba::3257:9652", false},
+		{"example..........com", false},
+		{"1234", false},
+		{"abc1234", true},
 	}
 
 	validate := New()

--- a/validator_test.go
+++ b/validator_test.go
@@ -7899,6 +7899,8 @@ func TestHostnameRFC952Validation(t *testing.T) {
 		{"example..........com", false},
 		{"1234", false},
 		{"abc1234", true},
+		{"example. com", false},
+		{"ex ample.com", false},
 	}
 
 	validate := New()


### PR DESCRIPTION
Signed-off-by: amiraliucsc <amirali7089@gmail.com>

Fixes Or Enhances #599 .

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:
This PR will change the hostnameRegexStringRFC952 to validate the dots only if one character is before the dot. This is to prevent considering string such as "example.....com" as a valid host. 

@go-playground/admins