### PR TITLE
Add isarr and notisarr validators

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -174,6 +174,8 @@ var (
 		"lowercase":            isLowercase,
 		"uppercase":            isUppercase,
 		"datetime":             isDatetime,
+		"inarr":                isInArr,
+		"notinarr":             isNotInArr,
 	}
 )
 
@@ -2095,4 +2097,40 @@ func isDatetime(fl FieldLevel) bool {
 	}
 
 	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
+}
+
+// isInArr is the validation function for validating if the current field's value occurs to the field, within a separate struct, specified by the param's value.
+func isInArr(fl FieldLevel) bool {
+	field := fl.Field()
+	arrv, _, _, ok := fl.GetStructFieldOK2()
+
+	if !ok {
+		return false
+	}
+
+	for i := 0; i < arrv.Len(); i++ {
+		if arrv.Index(i).Interface() == field.Interface() {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isNotInArr is the validation function for validating if the current field's value dosen't occur to the field, within a separate struct, specified by the param's value.
+func isNotInArr(fl FieldLevel) bool {
+	field := fl.Field()
+	arrv, _, _, ok := fl.GetStructFieldOK2()
+
+	if !ok {
+		return false
+	}
+
+	for i := 0; i < arrv.Len(); i++ {
+		if arrv.Index(i).Interface() == field.Interface() {
+			return false
+		}
+	}
+
+	return true
 }

--- a/doc.go
+++ b/doc.go
@@ -98,6 +98,56 @@ used "eqcsfield" it could be multiple levels down. Example:
 	//       whatever you pass, struct, field...
 	//       when calling validate.Field(field, tag) val will be nil
 
+Cross-Field Validation for slices
+
+Cross-Field Validation for slices can be done via the following tags:
+	- inarr
+	- notinarr
+
+Example #1 (validate single value)
+
+	type Inner struct {
+		Values []string
+	}
+
+	type Outer struct {
+		InnerStructField *Inner
+		V string `validate:"inarr=InnerStructField.Values"`
+	}
+
+	inner := &Inner{
+		Values: []string{"v"},
+	}
+
+	outer := &Outer{
+		InnerStructField: inner,
+		V: "v",
+	}
+
+	errs := validate.Struct(outer)
+
+Example #2 (validate all values in slice)
+
+	type Inner struct {
+		Values []string
+	}
+
+	type Outer struct {
+		InnerStructField *Inner
+		V []string `validate:"dive,notinarr=InnerStructField.Values"`
+	}
+
+	inner := &Inner{
+		Values: []string{"v"},
+	}
+
+	outer := &Outer{
+		InnerStructField: inner,
+		V: "v",
+	}
+
+	errs := validate.Struct(outer)
+
 Multiple Validators
 
 Multiple validators on a field will process in the order defined. Example:

--- a/validator_test.go
+++ b/validator_test.go
@@ -9201,3 +9201,65 @@ func TestDatetimeValidation(t *testing.T) {
 		_ = validate.Var(2, "datetime")
 	}, "Bad field type int")
 }
+
+func TestIsInArrValidation(t *testing.T) {
+
+	type Inner struct {
+		V []string
+	}
+
+	type Test struct {
+		Inner *Inner
+		V     string `validate:"inarr=Inner.V"`
+	}
+
+	inner := &Inner{
+		V: []string{"v"},
+	}
+
+	test := &Test{
+		Inner: inner,
+		V:     "v",
+	}
+
+	validate := New()
+	errs := validate.Struct(test)
+	Equal(t, errs, nil)
+
+	test.V = "_"
+
+	errs = validate.Struct(test)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "Test.V", "Test.V", "V", "V", "inarr")
+}
+
+func TestIsNotInArrValidation(t *testing.T) {
+
+	type Inner struct {
+		V []string
+	}
+
+	type Test struct {
+		Inner *Inner
+		V     string `validate:"notinarr=Inner.V"`
+	}
+
+	inner := &Inner{
+		V: []string{"v"},
+	}
+
+	test := &Test{
+		Inner: inner,
+		V:     "_",
+	}
+
+	validate := New()
+	errs := validate.Struct(test)
+	Equal(t, errs, nil)
+
+	test.V = "v"
+
+	errs = validate.Struct(test)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "Test.V", "Test.V", "V", "V", "notinarr")
+}


### PR DESCRIPTION
Enhances 

**Make sure that you've checked the boxes below before you submit PR:**
- [x ] Tests exist or have been written that cover this particular change.

Change Details:

Add two validators `inarr` and `notinarr` to check if a given value occurs in a slice.

Motivation:

Many times I need to make sure that one of the values is mutually exclusive in config/request. Example:

```
linters:
  enable:
    - import
  disable:
    - import
```
To make sure this can be validated I've created the above validators.

@go-playground/admins