### PR TITLE
Add support for encoding/json.Number type (string)

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -175,6 +175,9 @@ var (
 		"uppercase":            isUppercase,
 		"datetime":             isDatetime,
 	}
+
+	// jsonNumberType holds the reflect.Type for encoding/json.Number.
+	jsonNumberType = reflect.TypeOf((json.Number)(""))
 )
 
 var oneofValsCache = map[string][]string{}
@@ -1121,7 +1124,19 @@ func isEq(fl FieldLevel) bool {
 	switch field.Kind() {
 
 	case reflect.String:
-		return field.String() == param
+		switch field.Type() {
+		case jsonNumberType:
+			v, err := field.Interface().(json.Number).Float64()
+			if err != nil {
+				return false
+			}
+
+			p := asFloat(param)
+
+			return v == p
+		default:
+			return field.String() == param
+		}
 
 	case reflect.Slice, reflect.Map, reflect.Array:
 		p := asInt(param)
@@ -1531,9 +1546,21 @@ func isGte(fl FieldLevel) bool {
 	switch field.Kind() {
 
 	case reflect.String:
-		p := asInt(param)
+		switch field.Type() {
+		case jsonNumberType:
+			v, err := field.Interface().(json.Number).Float64()
+			if err != nil {
+				return false
+			}
 
-		return int64(utf8.RuneCountInString(field.String())) >= p
+			p := asFloat(param)
+
+			return v >= p
+		default:
+			p := asInt(param)
+
+			return int64(utf8.RuneCountInString(field.String())) >= p
+		}
 
 	case reflect.Slice, reflect.Map, reflect.Array:
 		p := asInt(param)
@@ -1578,9 +1605,21 @@ func isGt(fl FieldLevel) bool {
 	switch field.Kind() {
 
 	case reflect.String:
-		p := asInt(param)
+		switch field.Type() {
+		case jsonNumberType:
+			v, err := field.Interface().(json.Number).Float64()
+			if err != nil {
+				return false
+			}
 
-		return int64(utf8.RuneCountInString(field.String())) > p
+			p := asFloat(param)
+
+			return v > p
+		default:
+			p := asInt(param)
+
+			return int64(utf8.RuneCountInString(field.String())) > p
+		}
 
 	case reflect.Slice, reflect.Map, reflect.Array:
 		p := asInt(param)
@@ -1757,9 +1796,21 @@ func isLte(fl FieldLevel) bool {
 	switch field.Kind() {
 
 	case reflect.String:
-		p := asInt(param)
+		switch field.Type() {
+		case jsonNumberType:
+			v, err := field.Interface().(json.Number).Float64()
+			if err != nil {
+				return false
+			}
 
-		return int64(utf8.RuneCountInString(field.String())) <= p
+			p := asFloat(param)
+
+			return v <= p
+		default:
+			p := asInt(param)
+
+			return int64(utf8.RuneCountInString(field.String())) <= p
+		}
 
 	case reflect.Slice, reflect.Map, reflect.Array:
 		p := asInt(param)
@@ -1804,9 +1855,21 @@ func isLt(fl FieldLevel) bool {
 	switch field.Kind() {
 
 	case reflect.String:
-		p := asInt(param)
+		switch field.Type() {
+		case jsonNumberType:
+			v, err := field.Interface().(json.Number).Float64()
+			if err != nil {
+				return false
+			}
 
-		return int64(utf8.RuneCountInString(field.String())) < p
+			p := asFloat(param)
+
+			return v < p
+		default:
+			p := asInt(param)
+
+			return int64(utf8.RuneCountInString(field.String())) < p
+		}
 
 	case reflect.Slice, reflect.Map, reflect.Array:
 		p := asInt(param)

--- a/doc.go
+++ b/doc.go
@@ -325,7 +325,7 @@ arrays, and maps, validates the number of items.
 
 Maximum
 
-For numbers, max will ensure that the value is
+For numbers and encoding/json.Number, max will ensure that the value is
 less than or equal to the parameter given. For strings, it checks
 that the string length is at most that number of characters. For
 slices, arrays, and maps, validates the number of items.
@@ -334,7 +334,7 @@ slices, arrays, and maps, validates the number of items.
 
 Minimum
 
-For numbers, min will ensure that the value is
+For numbers and encoding/json.Number, min will ensure that the value is
 greater or equal to the parameter given. For strings, it checks that
 the string length is at least that number of characters. For slices,
 arrays, and maps, validates the number of items.
@@ -343,7 +343,7 @@ arrays, and maps, validates the number of items.
 
 Equals
 
-For strings & numbers, eq will ensure that the value is
+For strings, numbers and encoding/json.Number, eq will ensure that the value is
 equal to the parameter given. For slices, arrays, and maps,
 validates the number of items.
 
@@ -351,8 +351,8 @@ validates the number of items.
 
 Not Equal
 
-For strings & numbers, ne will ensure that the value is not
-equal to the parameter given. For slices, arrays, and maps,
+For strings, numbers and encoding/json.Number, ne will ensure that the value is
+not equal to the parameter given. For slices, arrays, and maps,
 validates the number of items.
 
 	Usage: ne=10
@@ -371,8 +371,8 @@ the target string between single quotes.
 
 Greater Than
 
-For numbers, this will ensure that the value is greater than the
-parameter given. For strings, it checks that the string length
+For numbers and encoding/json.Number, this will ensure that the value is greater
+than the parameter given. For strings, it checks that the string length
 is greater than that number of characters. For slices, arrays
 and maps it validates the number of items.
 
@@ -403,9 +403,10 @@ For time.Time ensures the time value is greater than or equal to time.Now.UTC().
 
 Less Than
 
-For numbers, this will ensure that the value is less than the parameter given.
-For strings, it checks that the string length is less than that number of
-characters. For slices, arrays, and maps it validates the number of items.
+For numbers and encoding/json.Number, this will ensure that the value is less
+than the parameter given. For strings, it checks that the string length is less
+than that number of characters. For slices, arrays, and maps it validates the
+number of items.
 
 Example #1
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -71,6 +71,18 @@ type TestString struct {
 	Gt        string `validate:"gt=10"`
 	Gte       string `validate:"gte=10"`
 	OmitEmpty string `validate:"omitempty,min=1,max=10"`
+
+	// Test cases for encoding/json.Number which is implemented as string.
+	JSONNumberEq     json.Number `validate:"eq=2"`
+	JSONNumberNe     json.Number `validate:"ne=2"`
+	JSONNumberMin    json.Number `validate:"min=1"`
+	JSONNumberMax    json.Number `validate:"max=10"`
+	JSONNumberMinMax json.Number `validate:"min=1,max=10"`
+	JSONNumberLt     json.Number `validate:"lt=10"`
+	JSONNumberLte    json.Number `validate:"lte=10"`
+	JSONNumberGt     json.Number `validate:"gt=10"`
+	JSONNumberGte    json.Number `validate:"gte=10"`
+
 	Sub       *SubTest
 	SubIgnore *SubTest `validate:"-"`
 	Anonymous struct {
@@ -6754,6 +6766,17 @@ func TestStructStringValidation(t *testing.T) {
 		Gt:        "01234567890",
 		Gte:       "0123456789",
 		OmitEmpty: "",
+
+		JSONNumberEq:     "2",
+		JSONNumberNe:     "3",
+		JSONNumberMin:    "1.5",
+		JSONNumberMax:    "9.999",
+		JSONNumberMinMax: "5",
+		JSONNumberLt:     "9",
+		JSONNumberLte:    "10",
+		JSONNumberGt:     "10.1",
+		JSONNumberGte:    "10",
+
 		Sub: &SubTest{
 			Test: "1",
 		},
@@ -6784,6 +6807,17 @@ func TestStructStringValidation(t *testing.T) {
 		Gt:        "1",
 		Gte:       "1",
 		OmitEmpty: "12345678901",
+
+		JSONNumberEq:     "3",
+		JSONNumberNe:     "2",
+		JSONNumberMin:    "0.5",
+		JSONNumberMax:    "11",
+		JSONNumberMinMax: "0",
+		JSONNumberLt:     "19",
+		JSONNumberLte:    "11",
+		JSONNumberGt:     "9.9",
+		JSONNumberGte:    "9",
+
 		Sub: &SubTest{
 			Test: "",
 		},
@@ -6801,7 +6835,7 @@ func TestStructStringValidation(t *testing.T) {
 
 	// Assert Top Level
 	NotEqual(t, errs, nil)
-	Equal(t, len(errs.(ValidationErrors)), 13)
+	Equal(t, len(errs.(ValidationErrors)), 22)
 
 	// Assert Fields
 	AssertError(t, errs, "TestString.Required", "TestString.Required", "Required", "Required", "required")
@@ -6814,6 +6848,16 @@ func TestStructStringValidation(t *testing.T) {
 	AssertError(t, errs, "TestString.Gt", "TestString.Gt", "Gt", "Gt", "gt")
 	AssertError(t, errs, "TestString.Gte", "TestString.Gte", "Gte", "Gte", "gte")
 	AssertError(t, errs, "TestString.OmitEmpty", "TestString.OmitEmpty", "OmitEmpty", "OmitEmpty", "max")
+
+	AssertError(t, errs, "TestString.JSONNumberEq", "TestString.JSONNumberEq", "JSONNumberEq", "JSONNumberEq", "eq")
+	AssertError(t, errs, "TestString.JSONNumberNe", "TestString.JSONNumberNe", "JSONNumberNe", "JSONNumberNe", "ne")
+	AssertError(t, errs, "TestString.JSONNumberMin", "TestString.JSONNumberMin", "JSONNumberMin", "JSONNumberMin", "min")
+	AssertError(t, errs, "TestString.JSONNumberMax", "TestString.JSONNumberMax", "JSONNumberMax", "JSONNumberMax", "max")
+	AssertError(t, errs, "TestString.JSONNumberMinMax", "TestString.JSONNumberMinMax", "JSONNumberMinMax", "JSONNumberMinMax", "min")
+	AssertError(t, errs, "TestString.JSONNumberLt", "TestString.JSONNumberLt", "JSONNumberLt", "JSONNumberLt", "lt")
+	AssertError(t, errs, "TestString.JSONNumberLte", "TestString.JSONNumberLte", "JSONNumberLte", "JSONNumberLte", "lte")
+	AssertError(t, errs, "TestString.JSONNumberGt", "TestString.JSONNumberGt", "JSONNumberGt", "JSONNumberGt", "gt")
+	AssertError(t, errs, "TestString.JSONNumberGte", "TestString.JSONNumberGte", "JSONNumberGte", "JSONNumberGte", "gte")
 
 	// Nested Struct Field Errs
 	AssertError(t, errs, "TestString.Anonymous.A", "TestString.Anonymous.A", "A", "A", "required")


### PR DESCRIPTION
Fixes Or Enhances https://github.com/go-playground/validator/issues/626

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:

- Add support for `encoding/json.Number` type (`string`)
- Update related docs

@go-playground/admins