### PR TITLE
Add support for time.Duration type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+bin
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/baked_in.go
+++ b/baked_in.go
@@ -2123,11 +2123,8 @@ func isDatetime(fl FieldLevel) bool {
 
 	if field.Kind() == reflect.String {
 		_, err := time.Parse(param, field.String())
-		if err != nil {
-			return false
-		}
 
-		return true
+		return err == nil
 	}
 
 	panic(fmt.Sprintf("Bad field type %T", field.Interface()))

--- a/baked_in.go
+++ b/baked_in.go
@@ -1129,13 +1129,7 @@ func isEq(fl FieldLevel) bool {
 		return int64(field.Len()) == p
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		var p int64
-
-		if field.Type() == timeDurationType {
-			p = asIntFromTimeDuration(param)
-		} else {
-			p = asInt(param)
-		}
+		p := asIntFromType(field.Type(), param)
 
 		return field.Int() == p
 
@@ -1547,13 +1541,7 @@ func isGte(fl FieldLevel) bool {
 		return int64(field.Len()) >= p
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		var p int64
-
-		if field.Type() == timeDurationType {
-			p = asIntFromTimeDuration(param)
-		} else {
-			p = asInt(param)
-		}
+		p := asIntFromType(field.Type(), param)
 
 		return field.Int() >= p
 
@@ -1600,13 +1588,7 @@ func isGt(fl FieldLevel) bool {
 		return int64(field.Len()) > p
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		var p int64
-
-		if field.Type() == timeDurationType {
-			p = asIntFromTimeDuration(param)
-		} else {
-			p = asInt(param)
-		}
+		p := asIntFromType(field.Type(), param)
 
 		return field.Int() > p
 
@@ -1649,13 +1631,7 @@ func hasLengthOf(fl FieldLevel) bool {
 		return int64(field.Len()) == p
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		var p int64
-
-		if field.Type() == timeDurationType {
-			p = asIntFromTimeDuration(param)
-		} else {
-			p = asInt(param)
-		}
+		p := asIntFromType(field.Type(), param)
 
 		return field.Int() == p
 
@@ -1791,13 +1767,7 @@ func isLte(fl FieldLevel) bool {
 		return int64(field.Len()) <= p
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		var p int64
-
-		if field.Type() == timeDurationType {
-			p = asIntFromTimeDuration(param)
-		} else {
-			p = asInt(param)
-		}
+		p := asIntFromType(field.Type(), param)
 
 		return field.Int() <= p
 
@@ -1844,13 +1814,7 @@ func isLt(fl FieldLevel) bool {
 		return int64(field.Len()) < p
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		var p int64
-
-		if field.Type() == timeDurationType {
-			p = asIntFromTimeDuration(param)
-		} else {
-			p = asInt(param)
-		}
+		p := asIntFromType(field.Type(), param)
 
 		return field.Int() < p
 

--- a/baked_in.go
+++ b/baked_in.go
@@ -1129,7 +1129,13 @@ func isEq(fl FieldLevel) bool {
 		return int64(field.Len()) == p
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		p := asInt(param)
+		var p int64
+
+		if field.Type() == timeDurationType {
+			p = asIntFromTimeDuration(param)
+		} else {
+			p = asInt(param)
+		}
 
 		return field.Int() == p
 
@@ -1541,7 +1547,13 @@ func isGte(fl FieldLevel) bool {
 		return int64(field.Len()) >= p
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		p := asInt(param)
+		var p int64
+
+		if field.Type() == timeDurationType {
+			p = asIntFromTimeDuration(param)
+		} else {
+			p = asInt(param)
+		}
 
 		return field.Int() >= p
 
@@ -1588,7 +1600,13 @@ func isGt(fl FieldLevel) bool {
 		return int64(field.Len()) > p
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		p := asInt(param)
+		var p int64
+
+		if field.Type() == timeDurationType {
+			p = asIntFromTimeDuration(param)
+		} else {
+			p = asInt(param)
+		}
 
 		return field.Int() > p
 
@@ -1631,7 +1649,13 @@ func hasLengthOf(fl FieldLevel) bool {
 		return int64(field.Len()) == p
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		p := asInt(param)
+		var p int64
+
+		if field.Type() == timeDurationType {
+			p = asIntFromTimeDuration(param)
+		} else {
+			p = asInt(param)
+		}
 
 		return field.Int() == p
 
@@ -1767,7 +1791,13 @@ func isLte(fl FieldLevel) bool {
 		return int64(field.Len()) <= p
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		p := asInt(param)
+		var p int64
+
+		if field.Type() == timeDurationType {
+			p = asIntFromTimeDuration(param)
+		} else {
+			p = asInt(param)
+		}
 
 		return field.Int() <= p
 
@@ -1814,7 +1844,13 @@ func isLt(fl FieldLevel) bool {
 		return int64(field.Len()) < p
 
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		p := asInt(param)
+		var p int64
+
+		if field.Type() == timeDurationType {
+			p = asIntFromTimeDuration(param)
+		} else {
+			p = asInt(param)
+		}
 
 		return field.Int() < p
 

--- a/doc.go
+++ b/doc.go
@@ -321,7 +321,16 @@ equal to the parameter given. For strings, it checks that
 the string length is exactly that number of characters. For slices,
 arrays, and maps, validates the number of items.
 
+Example #1
+
 	Usage: len=10
+
+Example #2 (time.Duration)
+
+For time.Duration, len will ensure that the value is equal to the duration given
+in the parameter.
+
+	Usage: len=1h30m
 
 Maximum
 
@@ -330,7 +339,16 @@ less than or equal to the parameter given. For strings, it checks
 that the string length is at most that number of characters. For
 slices, arrays, and maps, validates the number of items.
 
+Example #1
+
 	Usage: max=10
+
+Example #2 (time.Duration)
+
+For time.Duration, max will ensure that the value is less than or equal to the
+duration given in the parameter.
+
+	Usage: max=1h30m
 
 Minimum
 
@@ -339,7 +357,16 @@ greater or equal to the parameter given. For strings, it checks that
 the string length is at least that number of characters. For slices,
 arrays, and maps, validates the number of items.
 
+Example #1
+
 	Usage: min=10
+
+Example #2 (time.Duration)
+
+For time.Duration, min will ensure that the value is greater than or equal to
+the duration given in the parameter.
+
+	Usage: min=1h30m
 
 Equals
 
@@ -347,7 +374,16 @@ For strings & numbers, eq will ensure that the value is
 equal to the parameter given. For slices, arrays, and maps,
 validates the number of items.
 
+Example #1
+
 	Usage: eq=10
+
+Example #2 (time.Duration)
+
+For time.Duration, eq will ensure that the value is equal to the duration given
+in the parameter.
+
+	Usage: eq=1h30m
 
 Not Equal
 
@@ -355,7 +391,16 @@ For strings & numbers, ne will ensure that the value is not
 equal to the parameter given. For slices, arrays, and maps,
 validates the number of items.
 
+Example #1
+
 	Usage: ne=10
+
+Example #2 (time.Duration)
+
+For time.Duration, ne will ensure that the value is not equal to the duration
+given in the parameter.
+
+	Usage: ne=1h30m
 
 One Of
 
@@ -386,10 +431,16 @@ For time.Time ensures the time value is greater than time.Now.UTC().
 
 	Usage: gt
 
+Example #3 (time.Duration)
+
+For time.Duration, gt will ensure that the value is greater than the duration
+given in the parameter.
+
+	Usage: gt=1h30m
+
 Greater Than or Equal
 
 Same as 'min' above. Kept both to make terminology with 'len' easier.
-
 
 Example #1
 
@@ -400,6 +451,13 @@ Example #2 (time.Time)
 For time.Time ensures the time value is greater than or equal to time.Now.UTC().
 
 	Usage: gte
+
+Example #3 (time.Duration)
+
+For time.Duration, gte will ensure that the value is greater than or equal to
+the duration given in the parameter.
+
+	Usage: gte=1h30m
 
 Less Than
 
@@ -412,9 +470,17 @@ Example #1
 	Usage: lt=10
 
 Example #2 (time.Time)
+
 For time.Time ensures the time value is less than time.Now.UTC().
 
 	Usage: lt
+
+Example #3 (time.Duration)
+
+For time.Duration, lt will ensure that the value is less than the duration given
+in the parameter.
+
+	Usage: lt=1h30m
 
 Less Than or Equal
 
@@ -429,6 +495,13 @@ Example #2 (time.Time)
 For time.Time ensures the time value is less than or equal to time.Now.UTC().
 
 	Usage: lte
+
+Example #3 (time.Duration)
+
+For time.Duration, lte will ensure that the value is less than or equal to the
+duration given in the parameter.
+
+	Usage: lte=1h30m
 
 Field Equals Another Field
 
@@ -476,9 +549,9 @@ relative to the top level struct.
 
 Field Greater Than Another Field
 
-Only valid for Numbers and time.Time types, this will validate the field value
-against another fields value either within a struct or passed in field.
-usage examples are for validation of a Start and End date:
+Only valid for Numbers, time.Duration and time.Time types, this will validate
+the field value against another fields value either within a struct or passed in
+field. usage examples are for validation of a Start and End date:
 
 Example #1:
 
@@ -490,7 +563,6 @@ Example #2:
 	// Validating by field:
 	validate.VarWithValue(start, end, "gtfield")
 
-
 Field Greater Than Another Relative Field
 
 This does the same as gtfield except that it validates the field provided
@@ -500,9 +572,9 @@ relative to the top level struct.
 
 Field Greater Than or Equal To Another Field
 
-Only valid for Numbers and time.Time types, this will validate the field value
-against another fields value either within a struct or passed in field.
-usage examples are for validation of a Start and End date:
+Only valid for Numbers, time.Duration and time.Time types, this will validate
+the field value against another fields value either within a struct or passed in
+field. usage examples are for validation of a Start and End date:
 
 Example #1:
 
@@ -523,9 +595,9 @@ to the top level struct.
 
 Less Than Another Field
 
-Only valid for Numbers and time.Time types, this will validate the field value
-against another fields value either within a struct or passed in field.
-usage examples are for validation of a Start and End date:
+Only valid for Numbers, time.Duration and time.Time types, this will validate
+the field value against another fields value either within a struct or passed in
+field. usage examples are for validation of a Start and End date:
 
 Example #1:
 
@@ -546,9 +618,9 @@ to the top level struct.
 
 Less Than or Equal To Another Field
 
-Only valid for Numbers and time.Time types, this will validate the field value
-against another fields value either within a struct or passed in field.
-usage examples are for validation of a Start and End date:
+Only valid for Numbers, time.Duration and time.Time types, this will validate
+the field value against another fields value either within a struct or passed in
+field. usage examples are for validation of a Start and End date:
 
 Example #1:
 

--- a/util.go
+++ b/util.go
@@ -239,6 +239,17 @@ func asIntFromTimeDuration(param string) int64 {
 	return int64(d)
 }
 
+// asIntFromType calls the proper function to parse param as int64,
+// given a field's Type t.
+func asIntFromType(t reflect.Type, param string) int64 {
+	switch t {
+	case timeDurationType:
+		return asIntFromTimeDuration(param)
+	default:
+		return asInt(param)
+	}
+}
+
 // asUint returns the parameter as a uint64
 // or panics if it can't convert
 func asUint(param string) uint64 {

--- a/util.go
+++ b/util.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // extractTypeInternal gets the actual underlying type of field value.
@@ -227,6 +228,15 @@ func asInt(param string) int64 {
 	panicIf(err)
 
 	return i
+}
+
+// asIntFromTimeDuration parses param as time.Duration and returns it as int64
+// or panics on error.
+func asIntFromTimeDuration(param string) int64 {
+	d, err := time.ParseDuration(param)
+	panicIf(err)
+
+	return int64(d)
 }
 
 // asUint returns the parameter as a uint64

--- a/validator_instance.go
+++ b/validator_instance.go
@@ -41,9 +41,10 @@ const (
 )
 
 var (
-	timeType         = reflect.TypeOf(time.Time{})
 	timeDurationType = reflect.TypeOf(time.Duration(0))
-	defaultCField    = &cField{namesEqual: true}
+	timeType         = reflect.TypeOf(time.Time{})
+
+	defaultCField = &cField{namesEqual: true}
 )
 
 // FilterFunc is the type used to filter fields using

--- a/validator_instance.go
+++ b/validator_instance.go
@@ -41,8 +41,9 @@ const (
 )
 
 var (
-	timeType      = reflect.TypeOf(time.Time{})
-	defaultCField = &cField{namesEqual: true}
+	timeType         = reflect.TypeOf(time.Time{})
+	timeDurationType = reflect.TypeOf(time.Duration(0))
+	defaultCField    = &cField{namesEqual: true}
 )
 
 // FilterFunc is the type used to filter fields using

--- a/validator_test.go
+++ b/validator_test.go
@@ -9375,7 +9375,7 @@ func TestUniqueValidationStructSlice(t *testing.T) {
 			}
 		}
 	}
-	PanicMatches(t, func() { validate.Var(testStructs, "unique=C") }, "Bad field name C")
+	PanicMatches(t, func() { _ = validate.Var(testStructs, "unique=C") }, "Bad field name C")
 }
 
 func TestHTMLValidation(t *testing.T) {
@@ -10143,7 +10143,7 @@ func TestGetTag(t *testing.T) {
 	}
 
 	val := New()
-	val.RegisterValidation("mytag", func(fl FieldLevel) bool {
+	_ = val.RegisterValidation("mytag", func(fl FieldLevel) bool {
 		tag = fl.GetTag()
 		return true
 	})

--- a/validator_test.go
+++ b/validator_test.go
@@ -940,6 +940,8 @@ func TestStructPartial(t *testing.T) {
 }
 
 func TestCrossStructLteFieldValidation(t *testing.T) {
+	var errs error
+	validate := New()
 
 	type Inner struct {
 		CreatedAt *time.Time
@@ -982,8 +984,7 @@ func TestCrossStructLteFieldValidation(t *testing.T) {
 		Array:     []string{"val1"},
 	}
 
-	validate := New()
-	errs := validate.Struct(test)
+	errs = validate.Struct(test)
 	Equal(t, errs, nil)
 
 	test.CreatedAt = &then
@@ -1069,14 +1070,16 @@ func TestCrossStructLteFieldValidation(t *testing.T) {
 	type TimeDurationInner struct {
 		Duration time.Duration
 	}
+	var timeDurationInner *TimeDurationInner
 
 	type TimeDurationTest struct {
 		Inner    *TimeDurationInner
 		Duration time.Duration `validate:"ltecsfield=Inner.Duration"`
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationInner := &TimeDurationInner{time.Hour + time.Minute}
-	timeDurationTest := &TimeDurationTest{timeDurationInner, time.Hour}
+	timeDurationInner = &TimeDurationInner{time.Hour + time.Minute}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -1095,13 +1098,17 @@ func TestCrossStructLteFieldValidation(t *testing.T) {
 		Inner    *TimeDurationInner
 		Duration time.Duration `validate:"omitempty,ltecsfield=Inner.Duration"`
 	}
+	var timeDurationOmitemptyTest *TimeDurationOmitemptyTest
+
 	timeDurationInner = &TimeDurationInner{-time.Minute}
-	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
+	timeDurationOmitemptyTest = &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
 	errs = validate.Struct(timeDurationOmitemptyTest)
 	Equal(t, errs, nil)
 }
 
 func TestCrossStructLtFieldValidation(t *testing.T) {
+	var errs error
+	validate := New()
 
 	type Inner struct {
 		CreatedAt *time.Time
@@ -1144,8 +1151,7 @@ func TestCrossStructLtFieldValidation(t *testing.T) {
 		Array:     []string{"val1"},
 	}
 
-	validate := New()
-	errs := validate.Struct(test)
+	errs = validate.Struct(test)
 	Equal(t, errs, nil)
 
 	test.CreatedAt = &then
@@ -1219,14 +1225,16 @@ func TestCrossStructLtFieldValidation(t *testing.T) {
 	type TimeDurationInner struct {
 		Duration time.Duration
 	}
+	var timeDurationInner *TimeDurationInner
 
 	type TimeDurationTest struct {
 		Inner    *TimeDurationInner
 		Duration time.Duration `validate:"ltcsfield=Inner.Duration"`
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationInner := &TimeDurationInner{time.Hour + time.Minute}
-	timeDurationTest := &TimeDurationTest{timeDurationInner, time.Hour}
+	timeDurationInner = &TimeDurationInner{time.Hour + time.Minute}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -1246,14 +1254,17 @@ func TestCrossStructLtFieldValidation(t *testing.T) {
 		Inner    *TimeDurationInner
 		Duration time.Duration `validate:"omitempty,ltcsfield=Inner.Duration"`
 	}
+	var timeDurationOmitemptyTest *TimeDurationOmitemptyTest
 
 	timeDurationInner = &TimeDurationInner{-time.Minute}
-	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
+	timeDurationOmitemptyTest = &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
 	errs = validate.Struct(timeDurationOmitemptyTest)
 	Equal(t, errs, nil)
 }
 
 func TestCrossStructGteFieldValidation(t *testing.T) {
+	var errs error
+	validate := New()
 
 	type Inner struct {
 		CreatedAt *time.Time
@@ -1296,8 +1307,7 @@ func TestCrossStructGteFieldValidation(t *testing.T) {
 		Array:     []string{"val1", "val2", "val3"},
 	}
 
-	validate := New()
-	errs := validate.Struct(test)
+	errs = validate.Struct(test)
 	Equal(t, errs, nil)
 
 	test.CreatedAt = &then
@@ -1382,14 +1392,16 @@ func TestCrossStructGteFieldValidation(t *testing.T) {
 	type TimeDurationInner struct {
 		Duration time.Duration
 	}
+	var timeDurationInner *TimeDurationInner
 
 	type TimeDurationTest struct {
 		Inner    *TimeDurationInner
 		Duration time.Duration `validate:"gtecsfield=Inner.Duration"`
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationInner := &TimeDurationInner{time.Hour - time.Minute}
-	timeDurationTest := &TimeDurationTest{timeDurationInner, time.Hour}
+	timeDurationInner = &TimeDurationInner{time.Hour - time.Minute}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -1408,14 +1420,17 @@ func TestCrossStructGteFieldValidation(t *testing.T) {
 		Inner    *TimeDurationInner
 		Duration time.Duration `validate:"omitempty,gtecsfield=Inner.Duration"`
 	}
+	var timeDurationOmitemptyTest *TimeDurationOmitemptyTest
 
 	timeDurationInner = &TimeDurationInner{time.Hour}
-	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
+	timeDurationOmitemptyTest = &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
 	errs = validate.Struct(timeDurationOmitemptyTest)
 	Equal(t, errs, nil)
 }
 
 func TestCrossStructGtFieldValidation(t *testing.T) {
+	var errs error
+	validate := New()
 
 	type Inner struct {
 		CreatedAt *time.Time
@@ -1458,8 +1473,7 @@ func TestCrossStructGtFieldValidation(t *testing.T) {
 		Array:     []string{"val1", "val2", "val3"},
 	}
 
-	validate := New()
-	errs := validate.Struct(test)
+	errs = validate.Struct(test)
 	Equal(t, errs, nil)
 
 	test.CreatedAt = &then
@@ -1533,14 +1547,16 @@ func TestCrossStructGtFieldValidation(t *testing.T) {
 	type TimeDurationInner struct {
 		Duration time.Duration
 	}
+	var timeDurationInner *TimeDurationInner
 
 	type TimeDurationTest struct {
 		Inner    *TimeDurationInner
 		Duration time.Duration `validate:"gtcsfield=Inner.Duration"`
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationInner := &TimeDurationInner{time.Hour - time.Minute}
-	timeDurationTest := &TimeDurationTest{timeDurationInner, time.Hour}
+	timeDurationInner = &TimeDurationInner{time.Hour - time.Minute}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -1560,14 +1576,17 @@ func TestCrossStructGtFieldValidation(t *testing.T) {
 		Inner    *TimeDurationInner
 		Duration time.Duration `validate:"omitempty,gtcsfield=Inner.Duration"`
 	}
+	var timeDurationOmitemptyTest *TimeDurationOmitemptyTest
 
 	timeDurationInner = &TimeDurationInner{time.Hour}
-	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
+	timeDurationOmitemptyTest = &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
 	errs = validate.Struct(timeDurationOmitemptyTest)
 	Equal(t, errs, nil)
 }
 
 func TestCrossStructNeFieldValidation(t *testing.T) {
+	var errs error
+	validate := New()
 
 	type Inner struct {
 		CreatedAt *time.Time
@@ -1590,8 +1609,7 @@ func TestCrossStructNeFieldValidation(t *testing.T) {
 		CreatedAt: &now,
 	}
 
-	validate := New()
-	errs := validate.Struct(test)
+	errs = validate.Struct(test)
 	Equal(t, errs, nil)
 
 	test.CreatedAt = &then
@@ -1696,14 +1714,16 @@ func TestCrossStructNeFieldValidation(t *testing.T) {
 	type TimeDurationInner struct {
 		Duration time.Duration
 	}
+	var timeDurationInner *TimeDurationInner
 
 	type TimeDurationTest struct {
 		Inner    *TimeDurationInner
 		Duration time.Duration `validate:"necsfield=Inner.Duration"`
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationInner := &TimeDurationInner{time.Hour - time.Minute}
-	timeDurationTest := &TimeDurationTest{timeDurationInner, time.Hour}
+	timeDurationInner = &TimeDurationInner{time.Hour - time.Minute}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -1722,14 +1742,17 @@ func TestCrossStructNeFieldValidation(t *testing.T) {
 		Inner    *TimeDurationInner
 		Duration time.Duration `validate:"omitempty,necsfield=Inner.Duration"`
 	}
+	var timeDurationOmitemptyTest *TimeDurationOmitemptyTest
 
 	timeDurationInner = &TimeDurationInner{time.Duration(0)}
-	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
+	timeDurationOmitemptyTest = &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
 	errs = validate.Struct(timeDurationOmitemptyTest)
 	Equal(t, errs, nil)
 }
 
 func TestCrossStructEqFieldValidation(t *testing.T) {
+	var errs error
+	validate := New()
 
 	type Inner struct {
 		CreatedAt *time.Time
@@ -1751,8 +1774,7 @@ func TestCrossStructEqFieldValidation(t *testing.T) {
 		CreatedAt: &now,
 	}
 
-	validate := New()
-	errs := validate.Struct(test)
+	errs = validate.Struct(test)
 	Equal(t, errs, nil)
 
 	newTime := time.Now().UTC()
@@ -1856,14 +1878,16 @@ func TestCrossStructEqFieldValidation(t *testing.T) {
 	type TimeDurationInner struct {
 		Duration time.Duration
 	}
+	var timeDurationInner *TimeDurationInner
 
 	type TimeDurationTest struct {
 		Inner    *TimeDurationInner
 		Duration time.Duration `validate:"eqcsfield=Inner.Duration"`
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationInner := &TimeDurationInner{time.Hour}
-	timeDurationTest := &TimeDurationTest{timeDurationInner, time.Hour}
+	timeDurationInner = &TimeDurationInner{time.Hour}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -1883,9 +1907,10 @@ func TestCrossStructEqFieldValidation(t *testing.T) {
 		Inner    *TimeDurationInner
 		Duration time.Duration `validate:"omitempty,eqcsfield=Inner.Duration"`
 	}
+	var timeDurationOmitemptyTest *TimeDurationOmitemptyTest
 
 	timeDurationInner = &TimeDurationInner{time.Hour}
-	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
+	timeDurationOmitemptyTest = &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
 	errs = validate.Struct(timeDurationOmitemptyTest)
 	Equal(t, errs, nil)
 }
@@ -4511,7 +4536,7 @@ func TestContainsValidation(t *testing.T) {
 }
 
 func TestIsNeFieldValidation(t *testing.T) {
-
+	var errs error
 	validate := New()
 
 	var j uint64
@@ -4533,7 +4558,7 @@ func TestIsNeFieldValidation(t *testing.T) {
 	arr3 := []string{"test"}
 	now2 := now
 
-	errs := validate.VarWithValue(s, s2, "nefield")
+	errs = validate.VarWithValue(s, s2, "nefield")
 	Equal(t, errs, nil)
 
 	errs = validate.VarWithValue(i2, i, "nefield")
@@ -4640,8 +4665,9 @@ func TestIsNeFieldValidation(t *testing.T) {
 		First  time.Duration `validate:"nefield=Second"`
 		Second time.Duration
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationTest := &TimeDurationTest{time.Hour, time.Hour - time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour, time.Hour - time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -4665,7 +4691,7 @@ func TestIsNeFieldValidation(t *testing.T) {
 }
 
 func TestIsNeValidation(t *testing.T) {
-
+	var errs error
 	validate := New()
 
 	var j uint64
@@ -4677,7 +4703,7 @@ func TestIsNeValidation(t *testing.T) {
 	arr := []string{"test"}
 	now := time.Now().UTC()
 
-	errs := validate.Var(s, "ne=abcd")
+	errs = validate.Var(s, "ne=abcd")
 	Equal(t, errs, nil)
 
 	errs = validate.Var(i, "ne=1")
@@ -4720,8 +4746,9 @@ func TestIsNeValidation(t *testing.T) {
 	type TimeDurationTest struct {
 		Duration time.Duration `validate:"ne=1h"`
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationTest := &TimeDurationTest{time.Hour - time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour - time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -4744,7 +4771,7 @@ func TestIsNeValidation(t *testing.T) {
 }
 
 func TestIsEqFieldValidation(t *testing.T) {
-
+	var errs error
 	validate := New()
 
 	var j uint64
@@ -4766,7 +4793,7 @@ func TestIsEqFieldValidation(t *testing.T) {
 	arr3 := []string{"test", "test2"}
 	now2 := now
 
-	errs := validate.VarWithValue(s, s2, "eqfield")
+	errs = validate.VarWithValue(s, s2, "eqfield")
 	Equal(t, errs, nil)
 
 	errs = validate.VarWithValue(i2, i, "eqfield")
@@ -4885,8 +4912,9 @@ func TestIsEqFieldValidation(t *testing.T) {
 		First  time.Duration `validate:"eqfield=Second"`
 		Second time.Duration
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationTest := &TimeDurationTest{time.Hour, time.Hour}
+	timeDurationTest = &TimeDurationTest{time.Hour, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -4911,7 +4939,7 @@ func TestIsEqFieldValidation(t *testing.T) {
 }
 
 func TestIsEqValidation(t *testing.T) {
-
+	var errs error
 	validate := New()
 
 	var j uint64
@@ -4923,7 +4951,7 @@ func TestIsEqValidation(t *testing.T) {
 	arr := []string{"test"}
 	now := time.Now().UTC()
 
-	errs := validate.Var(s, "eq=abcd")
+	errs = validate.Var(s, "eq=abcd")
 	Equal(t, errs, nil)
 
 	errs = validate.Var(i, "eq=1")
@@ -4967,8 +4995,9 @@ func TestIsEqValidation(t *testing.T) {
 	type TimeDurationTest struct {
 		Duration time.Duration `validate:"eq=1h"`
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationTest := &TimeDurationTest{time.Hour}
+	timeDurationTest = &TimeDurationTest{time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -5465,7 +5494,7 @@ func TestStructOnlyValidation(t *testing.T) {
 }
 
 func TestGtField(t *testing.T) {
-
+	var errs error
 	validate := New()
 
 	type TimeTest struct {
@@ -5482,7 +5511,7 @@ func TestGtField(t *testing.T) {
 		End:   &end,
 	}
 
-	errs := validate.Struct(timeTest)
+	errs = validate.Struct(timeTest)
 	Equal(t, errs, nil)
 
 	timeTest = &TimeTest{
@@ -5534,8 +5563,9 @@ func TestGtField(t *testing.T) {
 		First  time.Duration `validate:"gtfield=Second"`
 		Second time.Duration
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationTest := &TimeDurationTest{time.Hour, time.Hour - time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour, time.Hour - time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -5693,7 +5723,7 @@ func TestGtField(t *testing.T) {
 }
 
 func TestLtField(t *testing.T) {
-
+	var errs error
 	validate := New()
 
 	type TimeTest struct {
@@ -5710,7 +5740,7 @@ func TestLtField(t *testing.T) {
 		End:   &end,
 	}
 
-	errs := validate.Struct(timeTest)
+	errs = validate.Struct(timeTest)
 	Equal(t, errs, nil)
 
 	timeTest = &TimeTest{
@@ -5760,8 +5790,9 @@ func TestLtField(t *testing.T) {
 		First  time.Duration `validate:"ltfield=Second"`
 		Second time.Duration
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationTest := &TimeDurationTest{time.Hour, time.Hour + time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour, time.Hour + time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -6024,7 +6055,7 @@ func TestContainsAndExcludes(t *testing.T) {
 }
 
 func TestLteField(t *testing.T) {
-
+	var errs error
 	validate := New()
 
 	type TimeTest struct {
@@ -6041,7 +6072,7 @@ func TestLteField(t *testing.T) {
 		End:   &end,
 	}
 
-	errs := validate.Struct(timeTest)
+	errs = validate.Struct(timeTest)
 	Equal(t, errs, nil)
 
 	timeTest = &TimeTest{
@@ -6093,8 +6124,9 @@ func TestLteField(t *testing.T) {
 		First  time.Duration `validate:"ltefield=Second"`
 		Second time.Duration
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationTest := &TimeDurationTest{time.Hour, time.Hour + time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour, time.Hour + time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -6233,7 +6265,7 @@ func TestLteField(t *testing.T) {
 }
 
 func TestGteField(t *testing.T) {
-
+	var errs error
 	validate := New()
 
 	type TimeTest struct {
@@ -6250,7 +6282,7 @@ func TestGteField(t *testing.T) {
 		End:   &end,
 	}
 
-	errs := validate.Struct(timeTest)
+	errs = validate.Struct(timeTest)
 	Equal(t, errs, nil)
 
 	timeTest = &TimeTest{
@@ -6302,8 +6334,9 @@ func TestGteField(t *testing.T) {
 		First  time.Duration `validate:"gtefield=Second"`
 		Second time.Duration
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationTest := &TimeDurationTest{time.Hour, time.Hour - time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour, time.Hour - time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -6562,9 +6595,11 @@ func TestLength(t *testing.T) {
 }
 
 func TestIsGt(t *testing.T) {
+	var errs error
 	validate := New()
+
 	myMap := map[string]string{}
-	errs := validate.Var(myMap, "gt=0")
+	errs = validate.Var(myMap, "gt=0")
 	NotEqual(t, errs, nil)
 
 	f := 1.23
@@ -6633,8 +6668,9 @@ func TestIsGt(t *testing.T) {
 	type TimeDurationTest struct {
 		Duration time.Duration `validate:"gt=59m"`
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationTest := &TimeDurationTest{time.Hour}
+	timeDurationTest = &TimeDurationTest{time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -6658,14 +6694,16 @@ func TestIsGt(t *testing.T) {
 }
 
 func TestIsGte(t *testing.T) {
+	var errs error
 	validate := New()
+
 	i := true
 	PanicMatches(t, func() { _ = validate.Var(i, "gte") }, "Bad field type bool")
 
 	t1 := time.Now().UTC()
 	t1 = t1.Add(time.Hour * 24)
 
-	errs := validate.Var(t1, "gte")
+	errs = validate.Var(t1, "gte")
 	Equal(t, errs, nil)
 
 	t2 := time.Now().UTC().Add(-time.Hour)
@@ -6714,8 +6752,9 @@ func TestIsGte(t *testing.T) {
 	type TimeDurationTest struct {
 		Duration time.Duration `validate:"gte=59m"`
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationTest := &TimeDurationTest{time.Hour}
+	timeDurationTest = &TimeDurationTest{time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -6738,13 +6777,14 @@ func TestIsGte(t *testing.T) {
 }
 
 func TestMinValidation(t *testing.T) {
+	var errs error
 	validate := New()
 
 	// Tests for time.Duration type.
 
 	// -- Validations for a variable of time.Duration type.
 
-	errs := validate.Var(time.Hour, "min=59m")
+	errs = validate.Var(time.Hour, "min=59m")
 	Equal(t, errs, nil)
 
 	errs = validate.Var(time.Hour-time.Minute, "min=59m")
@@ -6762,8 +6802,9 @@ func TestMinValidation(t *testing.T) {
 	type TimeDurationTest struct {
 		Duration time.Duration `validate:"min=59m"`
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationTest := &TimeDurationTest{time.Hour}
+	timeDurationTest = &TimeDurationTest{time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -6786,13 +6827,14 @@ func TestMinValidation(t *testing.T) {
 }
 
 func TestMaxValidation(t *testing.T) {
+	var errs error
 	validate := New()
 
 	// Tests for time.Duration type.
 
 	// -- Validations for a variable of time.Duration type.
 
-	errs := validate.Var(time.Hour, "max=1h1m")
+	errs = validate.Var(time.Hour, "max=1h1m")
 	Equal(t, errs, nil)
 
 	errs = validate.Var(time.Hour+time.Minute, "max=1h1m")
@@ -6810,8 +6852,9 @@ func TestMaxValidation(t *testing.T) {
 	type TimeDurationTest struct {
 		Duration time.Duration `validate:"max=1h1m"`
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationTest := &TimeDurationTest{time.Hour}
+	timeDurationTest = &TimeDurationTest{time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -6834,13 +6877,14 @@ func TestMaxValidation(t *testing.T) {
 }
 
 func TestMinMaxValidation(t *testing.T) {
+	var errs error
 	validate := New()
 
 	// Tests for time.Duration type.
 
 	// -- Validations for a variable of time.Duration type.
 
-	errs := validate.Var(time.Hour, "min=59m,max=1h1m")
+	errs = validate.Var(time.Hour, "min=59m,max=1h1m")
 	Equal(t, errs, nil)
 
 	errs = validate.Var(time.Hour-time.Minute, "min=59m,max=1h1m")
@@ -6865,8 +6909,9 @@ func TestMinMaxValidation(t *testing.T) {
 	type TimeDurationTest struct {
 		Duration time.Duration `validate:"min=59m,max=1h1m"`
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationTest := &TimeDurationTest{time.Hour}
+	timeDurationTest = &TimeDurationTest{time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -6898,13 +6943,14 @@ func TestMinMaxValidation(t *testing.T) {
 }
 
 func TestLenValidation(t *testing.T) {
+	var errs error
 	validate := New()
 
 	// Tests for time.Duration type.
 
 	// -- Validations for a variable of time.Duration type.
 
-	errs := validate.Var(time.Hour, "len=1h")
+	errs = validate.Var(time.Hour, "len=1h")
 	Equal(t, errs, nil)
 
 	errs = validate.Var(time.Hour-time.Minute, "len=1h")
@@ -6923,8 +6969,9 @@ func TestLenValidation(t *testing.T) {
 	type TimeDurationTest struct {
 		Duration time.Duration `validate:"len=1h"`
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationTest := &TimeDurationTest{time.Hour}
+	timeDurationTest = &TimeDurationTest{time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -6948,9 +6995,11 @@ func TestLenValidation(t *testing.T) {
 }
 
 func TestIsLt(t *testing.T) {
+	var errs error
 	validate := New()
+
 	myMap := map[string]string{}
-	errs := validate.Var(myMap, "lt=0")
+	errs = validate.Var(myMap, "lt=0")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "lt")
 
@@ -7021,8 +7070,9 @@ func TestIsLt(t *testing.T) {
 	type TimeDurationTest struct {
 		Duration time.Duration `validate:"lt=1h1m"`
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationTest := &TimeDurationTest{time.Hour}
+	timeDurationTest = &TimeDurationTest{time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
@@ -7046,7 +7096,7 @@ func TestIsLt(t *testing.T) {
 }
 
 func TestIsLte(t *testing.T) {
-
+	var errs error
 	validate := New()
 
 	i := true
@@ -7054,7 +7104,7 @@ func TestIsLte(t *testing.T) {
 
 	t1 := time.Now().UTC().Add(-time.Hour)
 
-	errs := validate.Var(t1, "lte")
+	errs = validate.Var(t1, "lte")
 	Equal(t, errs, nil)
 
 	t2 := time.Now().UTC()
@@ -7104,8 +7154,9 @@ func TestIsLte(t *testing.T) {
 	type TimeDurationTest struct {
 		Duration time.Duration `validate:"lte=1h1m"`
 	}
+	var timeDurationTest *TimeDurationTest
 
-	timeDurationTest := &TimeDurationTest{time.Hour}
+	timeDurationTest = &TimeDurationTest{time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -1049,24 +1049,22 @@ func TestCrossStructLteFieldValidation(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
+	// -- Validations for variables of time.Duration type.
 
-	// -- Validations for a variable of time.Duration type.
-
-	errs = validate.VarWithValue(duration, duration+time.Minute, "ltecsfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour+time.Minute, "ltecsfield")
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue(duration, duration, "ltecsfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour, "ltecsfield")
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue(duration, duration-time.Minute, "ltecsfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour-time.Minute, "ltecsfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "ltecsfield")
 
 	errs = validate.VarWithValue(time.Duration(0), -time.Minute, "omitempty,ltecsfield")
 	Equal(t, errs, nil)
 
-	// -- Validations for a struct and a inner struct with time.Duration type fields.
+	// -- Validations for a struct and an inner struct with time.Duration type fields.
 
 	type TimeDurationInner struct {
 		Duration time.Duration
@@ -1077,18 +1075,18 @@ func TestCrossStructLteFieldValidation(t *testing.T) {
 		Duration time.Duration `validate:"ltecsfield=Inner.Duration"`
 	}
 
-	timeDurationInner := &TimeDurationInner{duration + time.Minute}
-	timeDurationTest := &TimeDurationTest{timeDurationInner, duration}
+	timeDurationInner := &TimeDurationInner{time.Hour + time.Minute}
+	timeDurationTest := &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationInner = &TimeDurationInner{duration}
-	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	timeDurationInner = &TimeDurationInner{time.Hour}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationInner = &TimeDurationInner{duration - time.Minute}
-	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	timeDurationInner = &TimeDurationInner{time.Hour - time.Minute}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "ltecsfield")
@@ -1200,25 +1198,23 @@ func TestCrossStructLtFieldValidation(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
+	// -- Validations for variables of time.Duration type.
 
-	// -- Validations for a variable of time.Duration type.
-
-	errs = validate.VarWithValue(duration, duration+time.Minute, "ltcsfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour+time.Minute, "ltcsfield")
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue(duration, duration, "ltcsfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour, "ltcsfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "ltcsfield")
 
-	errs = validate.VarWithValue(duration, duration-time.Minute, "ltcsfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour-time.Minute, "ltcsfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "ltcsfield")
 
 	errs = validate.VarWithValue(time.Duration(0), -time.Minute, "omitempty,ltcsfield")
 	Equal(t, errs, nil)
 
-	// -- Validations for a struct and a inner struct with time.Duration type fields.
+	// -- Validations for a struct and an inner struct with time.Duration type fields.
 
 	type TimeDurationInner struct {
 		Duration time.Duration
@@ -1229,19 +1225,19 @@ func TestCrossStructLtFieldValidation(t *testing.T) {
 		Duration time.Duration `validate:"ltcsfield=Inner.Duration"`
 	}
 
-	timeDurationInner := &TimeDurationInner{duration + time.Minute}
-	timeDurationTest := &TimeDurationTest{timeDurationInner, duration}
+	timeDurationInner := &TimeDurationInner{time.Hour + time.Minute}
+	timeDurationTest := &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationInner = &TimeDurationInner{duration}
-	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	timeDurationInner = &TimeDurationInner{time.Hour}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "ltcsfield")
 
-	timeDurationInner = &TimeDurationInner{duration - time.Minute}
-	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	timeDurationInner = &TimeDurationInner{time.Hour - time.Minute}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "ltcsfield")
@@ -1366,24 +1362,22 @@ func TestCrossStructGteFieldValidation(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
+	// -- Validations for variables of time.Duration type.
 
-	// -- Validations for a variable of time.Duration type.
-
-	errs = validate.VarWithValue(duration, duration-time.Minute, "gtecsfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour-time.Minute, "gtecsfield")
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue(duration, duration, "gtecsfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour, "gtecsfield")
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue(duration, duration+time.Minute, "gtecsfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour+time.Minute, "gtecsfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "gtecsfield")
 
-	errs = validate.VarWithValue(time.Duration(0), duration, "omitempty,gtecsfield")
+	errs = validate.VarWithValue(time.Duration(0), time.Hour, "omitempty,gtecsfield")
 	Equal(t, errs, nil)
 
-	// -- Validations for a struct and a inner struct with time.Duration type fields.
+	// -- Validations for a struct and an inner struct with time.Duration type fields.
 
 	type TimeDurationInner struct {
 		Duration time.Duration
@@ -1394,18 +1388,18 @@ func TestCrossStructGteFieldValidation(t *testing.T) {
 		Duration time.Duration `validate:"gtecsfield=Inner.Duration"`
 	}
 
-	timeDurationInner := &TimeDurationInner{duration - time.Minute}
-	timeDurationTest := &TimeDurationTest{timeDurationInner, duration}
+	timeDurationInner := &TimeDurationInner{time.Hour - time.Minute}
+	timeDurationTest := &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationInner = &TimeDurationInner{duration}
-	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	timeDurationInner = &TimeDurationInner{time.Hour}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationInner = &TimeDurationInner{duration + time.Minute}
-	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	timeDurationInner = &TimeDurationInner{time.Hour + time.Minute}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "gtecsfield")
@@ -1415,7 +1409,7 @@ func TestCrossStructGteFieldValidation(t *testing.T) {
 		Duration time.Duration `validate:"omitempty,gtecsfield=Inner.Duration"`
 	}
 
-	timeDurationInner = &TimeDurationInner{duration}
+	timeDurationInner = &TimeDurationInner{time.Hour}
 	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
 	errs = validate.Struct(timeDurationOmitemptyTest)
 	Equal(t, errs, nil)
@@ -1518,25 +1512,23 @@ func TestCrossStructGtFieldValidation(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
+	// -- Validations for variables of time.Duration type.
 
-	// -- Validations for a variable of time.Duration type.
-
-	errs = validate.VarWithValue(duration, duration-time.Minute, "gtcsfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour-time.Minute, "gtcsfield")
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue(duration, duration, "gtcsfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour, "gtcsfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "gtcsfield")
 
-	errs = validate.VarWithValue(duration, duration+time.Minute, "gtcsfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour+time.Minute, "gtcsfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "gtcsfield")
 
-	errs = validate.VarWithValue(time.Duration(0), duration, "omitempty,gtcsfield")
+	errs = validate.VarWithValue(time.Duration(0), time.Hour, "omitempty,gtcsfield")
 	Equal(t, errs, nil)
 
-	// -- Validations for a struct and a inner struct with time.Duration type fields.
+	// -- Validations for a struct and an inner struct with time.Duration type fields.
 
 	type TimeDurationInner struct {
 		Duration time.Duration
@@ -1547,19 +1539,19 @@ func TestCrossStructGtFieldValidation(t *testing.T) {
 		Duration time.Duration `validate:"gtcsfield=Inner.Duration"`
 	}
 
-	timeDurationInner := &TimeDurationInner{duration - time.Minute}
-	timeDurationTest := &TimeDurationTest{timeDurationInner, duration}
+	timeDurationInner := &TimeDurationInner{time.Hour - time.Minute}
+	timeDurationTest := &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationInner = &TimeDurationInner{duration}
-	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	timeDurationInner = &TimeDurationInner{time.Hour}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "gtcsfield")
 
-	timeDurationInner = &TimeDurationInner{duration + time.Minute}
-	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	timeDurationInner = &TimeDurationInner{time.Hour + time.Minute}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "gtcsfield")
@@ -1569,7 +1561,7 @@ func TestCrossStructGtFieldValidation(t *testing.T) {
 		Duration time.Duration `validate:"omitempty,gtcsfield=Inner.Duration"`
 	}
 
-	timeDurationInner = &TimeDurationInner{duration}
+	timeDurationInner = &TimeDurationInner{time.Hour}
 	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
 	errs = validate.Struct(timeDurationOmitemptyTest)
 	Equal(t, errs, nil)
@@ -1684,24 +1676,22 @@ func TestCrossStructNeFieldValidation(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
+	// -- Validations for variables of time.Duration type.
 
-	// -- Validations for a variable of time.Duration type.
-
-	errs = validate.VarWithValue(duration, duration-time.Minute, "necsfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour-time.Minute, "necsfield")
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue(duration, duration+time.Minute, "necsfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour+time.Minute, "necsfield")
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue(duration, duration, "necsfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour, "necsfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "necsfield")
 
 	errs = validate.VarWithValue(time.Duration(0), time.Duration(0), "omitempty,necsfield")
 	Equal(t, errs, nil)
 
-	// -- Validations for a struct and a inner struct with time.Duration type fields.
+	// -- Validations for a struct and an inner struct with time.Duration type fields.
 
 	type TimeDurationInner struct {
 		Duration time.Duration
@@ -1712,18 +1702,18 @@ func TestCrossStructNeFieldValidation(t *testing.T) {
 		Duration time.Duration `validate:"necsfield=Inner.Duration"`
 	}
 
-	timeDurationInner := &TimeDurationInner{duration - time.Minute}
-	timeDurationTest := &TimeDurationTest{timeDurationInner, duration}
+	timeDurationInner := &TimeDurationInner{time.Hour - time.Minute}
+	timeDurationTest := &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationInner = &TimeDurationInner{duration + time.Minute}
-	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	timeDurationInner = &TimeDurationInner{time.Hour + time.Minute}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationInner = &TimeDurationInner{duration}
-	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	timeDurationInner = &TimeDurationInner{time.Hour}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "necsfield")
@@ -1845,25 +1835,23 @@ func TestCrossStructEqFieldValidation(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
+	// -- Validations for variables of time.Duration type.
 
-	// -- Validations for a variable of time.Duration type.
-
-	errs = validate.VarWithValue(duration, duration, "eqcsfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour, "eqcsfield")
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue(duration, duration-time.Minute, "eqcsfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour-time.Minute, "eqcsfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "eqcsfield")
 
-	errs = validate.VarWithValue(duration, duration+time.Minute, "eqcsfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour+time.Minute, "eqcsfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "eqcsfield")
 
-	errs = validate.VarWithValue(time.Duration(0), duration, "omitempty,eqcsfield")
+	errs = validate.VarWithValue(time.Duration(0), time.Hour, "omitempty,eqcsfield")
 	Equal(t, errs, nil)
 
-	// -- Validations for a struct and a inner struct with time.Duration type fields.
+	// -- Validations for a struct and an inner struct with time.Duration type fields.
 
 	type TimeDurationInner struct {
 		Duration time.Duration
@@ -1874,19 +1862,19 @@ func TestCrossStructEqFieldValidation(t *testing.T) {
 		Duration time.Duration `validate:"eqcsfield=Inner.Duration"`
 	}
 
-	timeDurationInner := &TimeDurationInner{duration}
-	timeDurationTest := &TimeDurationTest{timeDurationInner, duration}
+	timeDurationInner := &TimeDurationInner{time.Hour}
+	timeDurationTest := &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationInner = &TimeDurationInner{duration - time.Minute}
-	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	timeDurationInner = &TimeDurationInner{time.Hour - time.Minute}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "eqcsfield")
 
-	timeDurationInner = &TimeDurationInner{duration + time.Minute}
-	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	timeDurationInner = &TimeDurationInner{time.Hour + time.Minute}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "eqcsfield")
@@ -1896,7 +1884,7 @@ func TestCrossStructEqFieldValidation(t *testing.T) {
 		Duration time.Duration `validate:"omitempty,eqcsfield=Inner.Duration"`
 	}
 
-	timeDurationInner = &TimeDurationInner{duration}
+	timeDurationInner = &TimeDurationInner{time.Hour}
 	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
 	errs = validate.Struct(timeDurationOmitemptyTest)
 	Equal(t, errs, nil)
@@ -4631,17 +4619,15 @@ func TestIsNeFieldValidation(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
-
 	// -- Validations for variables of time.Duration type.
 
-	errs = validate.VarWithValue(duration, duration-time.Minute, "nefield")
+	errs = validate.VarWithValue(time.Hour, time.Hour-time.Minute, "nefield")
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue(duration, duration+time.Minute, "nefield")
+	errs = validate.VarWithValue(time.Hour, time.Hour+time.Minute, "nefield")
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue(duration, duration, "nefield")
+	errs = validate.VarWithValue(time.Hour, time.Hour, "nefield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "nefield")
 
@@ -4655,15 +4641,15 @@ func TestIsNeFieldValidation(t *testing.T) {
 		Second time.Duration
 	}
 
-	timeDurationTest := &TimeDurationTest{duration, duration - time.Minute}
+	timeDurationTest := &TimeDurationTest{time.Hour, time.Hour - time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration, duration + time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour, time.Hour + time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration, duration}
+	timeDurationTest = &TimeDurationTest{time.Hour, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.First", "TimeDurationTest.First", "First", "First", "nefield")
@@ -4714,17 +4700,15 @@ func TestIsNeValidation(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
-
 	// -- Validations for a variable of time.Duration type.
 
-	errs = validate.Var(duration-time.Minute, "ne=1h")
+	errs = validate.Var(time.Hour-time.Minute, "ne=1h")
 	Equal(t, errs, nil)
 
-	errs = validate.Var(duration+time.Minute, "ne=1h")
+	errs = validate.Var(time.Hour+time.Minute, "ne=1h")
 	Equal(t, errs, nil)
 
-	errs = validate.Var(duration, "ne=1h")
+	errs = validate.Var(time.Hour, "ne=1h")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "ne")
 
@@ -4737,15 +4721,15 @@ func TestIsNeValidation(t *testing.T) {
 		Duration time.Duration `validate:"ne=1h"`
 	}
 
-	timeDurationTest := &TimeDurationTest{duration - time.Minute}
+	timeDurationTest := &TimeDurationTest{time.Hour - time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration + time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour + time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration}
+	timeDurationTest = &TimeDurationTest{time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "ne")
@@ -4879,22 +4863,20 @@ func TestIsEqFieldValidation(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
-
 	// -- Validations for variables of time.Duration type.
 
-	errs = validate.VarWithValue(duration, duration, "eqfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour, "eqfield")
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue(duration, duration-time.Minute, "eqfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour-time.Minute, "eqfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "eqfield")
 
-	errs = validate.VarWithValue(duration, duration+time.Minute, "eqfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour+time.Minute, "eqfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "eqfield")
 
-	errs = validate.VarWithValue(time.Duration(0), duration, "omitempty,eqfield")
+	errs = validate.VarWithValue(time.Duration(0), time.Hour, "omitempty,eqfield")
 	Equal(t, errs, nil)
 
 	// -- Validations for a struct with time.Duration type fields.
@@ -4904,16 +4886,16 @@ func TestIsEqFieldValidation(t *testing.T) {
 		Second time.Duration
 	}
 
-	timeDurationTest := &TimeDurationTest{duration, duration}
+	timeDurationTest := &TimeDurationTest{time.Hour, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration, duration - time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour, time.Hour - time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.First", "TimeDurationTest.First", "First", "First", "eqfield")
 
-	timeDurationTest = &TimeDurationTest{duration, duration + time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour, time.Hour + time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.First", "TimeDurationTest.First", "First", "First", "eqfield")
@@ -4923,7 +4905,7 @@ func TestIsEqFieldValidation(t *testing.T) {
 		Second time.Duration
 	}
 
-	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0), duration}
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0), time.Hour}
 	errs = validate.Struct(timeDurationOmitemptyTest)
 	Equal(t, errs, nil)
 }
@@ -4964,18 +4946,16 @@ func TestIsEqValidation(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
-
 	// -- Validations for a variable of time.Duration type.
 
-	errs = validate.Var(duration, "eq=1h")
+	errs = validate.Var(time.Hour, "eq=1h")
 	Equal(t, errs, nil)
 
-	errs = validate.Var(duration-time.Minute, "eq=1h")
+	errs = validate.Var(time.Hour-time.Minute, "eq=1h")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "eq")
 
-	errs = validate.Var(duration+time.Minute, "eq=1h")
+	errs = validate.Var(time.Hour+time.Minute, "eq=1h")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "eq")
 
@@ -4988,16 +4968,16 @@ func TestIsEqValidation(t *testing.T) {
 		Duration time.Duration `validate:"eq=1h"`
 	}
 
-	timeDurationTest := &TimeDurationTest{duration}
+	timeDurationTest := &TimeDurationTest{time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration - time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour - time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "eq")
 
-	timeDurationTest = &TimeDurationTest{duration + time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour + time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "eq")
@@ -5532,22 +5512,20 @@ func TestGtField(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
-
 	// -- Validations for variables of time.Duration type.
 
-	errs = validate.VarWithValue(duration, duration-time.Minute, "gtfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour-time.Minute, "gtfield")
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue(duration, duration, "gtfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour, "gtfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "gtfield")
 
-	errs = validate.VarWithValue(duration, duration+time.Minute, "gtfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour+time.Minute, "gtfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "gtfield")
 
-	errs = validate.VarWithValue(time.Duration(0), duration, "omitempty,gtfield")
+	errs = validate.VarWithValue(time.Duration(0), time.Hour, "omitempty,gtfield")
 	Equal(t, errs, nil)
 
 	// -- Validations for a struct with time.Duration type fields.
@@ -5557,16 +5535,16 @@ func TestGtField(t *testing.T) {
 		Second time.Duration
 	}
 
-	timeDurationTest := &TimeDurationTest{duration, duration - time.Minute}
+	timeDurationTest := &TimeDurationTest{time.Hour, time.Hour - time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration, duration}
+	timeDurationTest = &TimeDurationTest{time.Hour, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.First", "TimeDurationTest.First", "First", "First", "gtfield")
 
-	timeDurationTest = &TimeDurationTest{duration, duration + time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour, time.Hour + time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.First", "TimeDurationTest.First", "First", "First", "gtfield")
@@ -5576,7 +5554,7 @@ func TestGtField(t *testing.T) {
 		Second time.Duration
 	}
 
-	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0), duration}
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0), time.Hour}
 	errs = validate.Struct(timeDurationOmitemptyTest)
 	Equal(t, errs, nil)
 
@@ -5760,18 +5738,16 @@ func TestLtField(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
-
 	// -- Validations for variables of time.Duration type.
 
-	errs = validate.VarWithValue(duration, duration+time.Minute, "ltfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour+time.Minute, "ltfield")
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue(duration, duration, "ltfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour, "ltfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "ltfield")
 
-	errs = validate.VarWithValue(duration, duration-time.Minute, "ltfield")
+	errs = validate.VarWithValue(time.Hour, time.Hour-time.Minute, "ltfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "ltfield")
 
@@ -5785,16 +5761,16 @@ func TestLtField(t *testing.T) {
 		Second time.Duration
 	}
 
-	timeDurationTest := &TimeDurationTest{duration, duration + time.Minute}
+	timeDurationTest := &TimeDurationTest{time.Hour, time.Hour + time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration, duration}
+	timeDurationTest = &TimeDurationTest{time.Hour, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.First", "TimeDurationTest.First", "First", "First", "ltfield")
 
-	timeDurationTest = &TimeDurationTest{duration, duration - time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour, time.Hour - time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.First", "TimeDurationTest.First", "First", "First", "ltfield")
@@ -6096,17 +6072,15 @@ func TestLteField(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
-
 	// -- Validations for variables of time.Duration type.
 
-	errs = validate.VarWithValue(duration, duration+time.Minute, "ltefield")
+	errs = validate.VarWithValue(time.Hour, time.Hour+time.Minute, "ltefield")
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue(duration, duration, "ltefield")
+	errs = validate.VarWithValue(time.Hour, time.Hour, "ltefield")
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue(duration, duration-time.Minute, "ltefield")
+	errs = validate.VarWithValue(time.Hour, time.Hour-time.Minute, "ltefield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "ltefield")
 
@@ -6120,15 +6094,15 @@ func TestLteField(t *testing.T) {
 		Second time.Duration
 	}
 
-	timeDurationTest := &TimeDurationTest{duration, duration + time.Minute}
+	timeDurationTest := &TimeDurationTest{time.Hour, time.Hour + time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration, duration}
+	timeDurationTest = &TimeDurationTest{time.Hour, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration, duration - time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour, time.Hour - time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.First", "TimeDurationTest.First", "First", "First", "ltefield")
@@ -6307,21 +6281,19 @@ func TestGteField(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
-
 	// -- Validations for variables of time.Duration type.
 
-	errs = validate.VarWithValue(duration, duration-time.Minute, "gtefield")
+	errs = validate.VarWithValue(time.Hour, time.Hour-time.Minute, "gtefield")
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue(duration, duration, "gtefield")
+	errs = validate.VarWithValue(time.Hour, time.Hour, "gtefield")
 	Equal(t, errs, nil)
 
-	errs = validate.VarWithValue(duration, duration+time.Minute, "gtefield")
+	errs = validate.VarWithValue(time.Hour, time.Hour+time.Minute, "gtefield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "gtefield")
 
-	errs = validate.VarWithValue(time.Duration(0), duration, "omitempty,gtefield")
+	errs = validate.VarWithValue(time.Duration(0), time.Hour, "omitempty,gtefield")
 	Equal(t, errs, nil)
 
 	// -- Validations for a struct with time.Duration type fields.
@@ -6331,15 +6303,15 @@ func TestGteField(t *testing.T) {
 		Second time.Duration
 	}
 
-	timeDurationTest := &TimeDurationTest{duration, duration - time.Minute}
+	timeDurationTest := &TimeDurationTest{time.Hour, time.Hour - time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration, duration}
+	timeDurationTest = &TimeDurationTest{time.Hour, time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration, duration + time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour, time.Hour + time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.First", "TimeDurationTest.First", "First", "First", "gtefield")
@@ -6349,7 +6321,7 @@ func TestGteField(t *testing.T) {
 		Second time.Duration
 	}
 
-	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0), duration}
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0), time.Hour}
 	errs = validate.Struct(timeDurationOmitemptyTest)
 	Equal(t, errs, nil)
 
@@ -6640,40 +6612,38 @@ func TestIsGt(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
-
 	// -- Validations for a variable of time.Duration type.
 
-	errs = validate.Var(duration, "gt=59m")
+	errs = validate.Var(time.Hour, "gt=59m")
 	Equal(t, errs, nil)
 
-	errs = validate.Var(duration-time.Minute, "gt=59m")
+	errs = validate.Var(time.Hour-time.Minute, "gt=59m")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "gt")
 
-	errs = validate.Var(duration-2*time.Minute, "gt=59m")
+	errs = validate.Var(time.Hour-2*time.Minute, "gt=59m")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "gt")
 
 	errs = validate.Var(time.Duration(0), "omitempty,gt=59m")
 	Equal(t, errs, nil)
 
-	// -- Validations for a struct with time.Duration type fields.
+	// -- Validations for a struct with a time.Duration type field.
 
 	type TimeDurationTest struct {
 		Duration time.Duration `validate:"gt=59m"`
 	}
 
-	timeDurationTest := &TimeDurationTest{duration}
+	timeDurationTest := &TimeDurationTest{time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration - time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour - time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "gt")
 
-	timeDurationTest = &TimeDurationTest{duration - 2*time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour - 2*time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "gt")
@@ -6724,38 +6694,36 @@ func TestIsGte(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
-
 	// -- Validations for a variable of time.Duration type.
 
-	errs = validate.Var(duration, "gte=59m")
+	errs = validate.Var(time.Hour, "gte=59m")
 	Equal(t, errs, nil)
 
-	errs = validate.Var(duration-time.Minute, "gte=59m")
+	errs = validate.Var(time.Hour-time.Minute, "gte=59m")
 	Equal(t, errs, nil)
 
-	errs = validate.Var(duration-2*time.Minute, "gte=59m")
+	errs = validate.Var(time.Hour-2*time.Minute, "gte=59m")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "gte")
 
 	errs = validate.Var(time.Duration(0), "omitempty,gte=59m")
 	Equal(t, errs, nil)
 
-	// -- Validations for a struct with time.Duration type fields.
+	// -- Validations for a struct with a time.Duration type field.
 
 	type TimeDurationTest struct {
 		Duration time.Duration `validate:"gte=59m"`
 	}
 
-	timeDurationTest := &TimeDurationTest{duration}
+	timeDurationTest := &TimeDurationTest{time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration - time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour - time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration - 2*time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour - 2*time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "gte")
@@ -6774,38 +6742,36 @@ func TestMinValidation(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
-
 	// -- Validations for a variable of time.Duration type.
 
-	errs := validate.Var(duration, "min=59m")
+	errs := validate.Var(time.Hour, "min=59m")
 	Equal(t, errs, nil)
 
-	errs = validate.Var(duration-time.Minute, "min=59m")
+	errs = validate.Var(time.Hour-time.Minute, "min=59m")
 	Equal(t, errs, nil)
 
-	errs = validate.Var(duration-2*time.Minute, "min=59m")
+	errs = validate.Var(time.Hour-2*time.Minute, "min=59m")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "min")
 
 	errs = validate.Var(time.Duration(0), "omitempty,min=59m")
 	Equal(t, errs, nil)
 
-	// -- Validations for a struct with time.Duration type field.
+	// -- Validations for a struct with a time.Duration type field.
 
 	type TimeDurationTest struct {
 		Duration time.Duration `validate:"min=59m"`
 	}
 
-	timeDurationTest := &TimeDurationTest{duration}
+	timeDurationTest := &TimeDurationTest{time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration - time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour - time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration - 2*time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour - 2*time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "min")
@@ -6824,38 +6790,36 @@ func TestMaxValidation(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
-
 	// -- Validations for a variable of time.Duration type.
 
-	errs := validate.Var(duration, "max=1h1m")
+	errs := validate.Var(time.Hour, "max=1h1m")
 	Equal(t, errs, nil)
 
-	errs = validate.Var(duration+time.Minute, "max=1h1m")
+	errs = validate.Var(time.Hour+time.Minute, "max=1h1m")
 	Equal(t, errs, nil)
 
-	errs = validate.Var(duration+2*time.Minute, "max=1h1m")
+	errs = validate.Var(time.Hour+2*time.Minute, "max=1h1m")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "max")
 
 	errs = validate.Var(time.Duration(0), "omitempty,max=-1s")
 	Equal(t, errs, nil)
 
-	// -- Validations for a struct with time.Duration type field.
+	// -- Validations for a struct with a time.Duration type field.
 
 	type TimeDurationTest struct {
 		Duration time.Duration `validate:"max=1h1m"`
 	}
 
-	timeDurationTest := &TimeDurationTest{duration}
+	timeDurationTest := &TimeDurationTest{time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration + time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour + time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration + 2*time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour + 2*time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "max")
@@ -6874,54 +6838,52 @@ func TestMinMaxValidation(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
-
 	// -- Validations for a variable of time.Duration type.
 
-	errs := validate.Var(duration, "min=59m,max=1h1m")
+	errs := validate.Var(time.Hour, "min=59m,max=1h1m")
 	Equal(t, errs, nil)
 
-	errs = validate.Var(duration-time.Minute, "min=59m,max=1h1m")
+	errs = validate.Var(time.Hour-time.Minute, "min=59m,max=1h1m")
 	Equal(t, errs, nil)
 
-	errs = validate.Var(duration+time.Minute, "min=59m,max=1h1m")
+	errs = validate.Var(time.Hour+time.Minute, "min=59m,max=1h1m")
 	Equal(t, errs, nil)
 
-	errs = validate.Var(duration-2*time.Minute, "min=59m,max=1h1m")
+	errs = validate.Var(time.Hour-2*time.Minute, "min=59m,max=1h1m")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "min")
 
-	errs = validate.Var(duration+2*time.Minute, "min=59m,max=1h1m")
+	errs = validate.Var(time.Hour+2*time.Minute, "min=59m,max=1h1m")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "max")
 
 	errs = validate.Var(time.Duration(0), "omitempty,min=59m,max=1h1m")
 	Equal(t, errs, nil)
 
-	// -- Validations for a struct with time.Duration type field.
+	// -- Validations for a struct with a time.Duration type field.
 
 	type TimeDurationTest struct {
 		Duration time.Duration `validate:"min=59m,max=1h1m"`
 	}
 
-	timeDurationTest := &TimeDurationTest{duration}
+	timeDurationTest := &TimeDurationTest{time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration - time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour - time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration + time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour + time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration - 2*time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour - 2*time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "min")
 
-	timeDurationTest = &TimeDurationTest{duration + 2*time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour + 2*time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "max")
@@ -6940,40 +6902,38 @@ func TestLenValidation(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
-
 	// -- Validations for a variable of time.Duration type.
 
-	errs := validate.Var(duration, "len=1h")
+	errs := validate.Var(time.Hour, "len=1h")
 	Equal(t, errs, nil)
 
-	errs = validate.Var(duration-time.Minute, "len=1h")
+	errs = validate.Var(time.Hour-time.Minute, "len=1h")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "len")
 
-	errs = validate.Var(duration+time.Minute, "len=1h")
+	errs = validate.Var(time.Hour+time.Minute, "len=1h")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "len")
 
 	errs = validate.Var(time.Duration(0), "omitempty,len=1h")
 	Equal(t, errs, nil)
 
-	// -- Validations for a struct with time.Duration type field.
+	// -- Validations for a struct with a time.Duration type field.
 
 	type TimeDurationTest struct {
 		Duration time.Duration `validate:"len=1h"`
 	}
 
-	timeDurationTest := &TimeDurationTest{duration}
+	timeDurationTest := &TimeDurationTest{time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration - time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour - time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "len")
 
-	timeDurationTest = &TimeDurationTest{duration + time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour + time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "len")
@@ -7040,40 +7000,38 @@ func TestIsLt(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
-
 	// -- Validations for a variable of time.Duration type.
 
-	errs = validate.Var(duration, "lt=1h1m")
+	errs = validate.Var(time.Hour, "lt=1h1m")
 	Equal(t, errs, nil)
 
-	errs = validate.Var(duration+time.Minute, "lt=1h1m")
+	errs = validate.Var(time.Hour+time.Minute, "lt=1h1m")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "lt")
 
-	errs = validate.Var(duration+2*time.Minute, "lt=1h1m")
+	errs = validate.Var(time.Hour+2*time.Minute, "lt=1h1m")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "lt")
 
 	errs = validate.Var(time.Duration(0), "omitempty,lt=0")
 	Equal(t, errs, nil)
 
-	// -- Validations for a struct with time.Duration type fields.
+	// -- Validations for a struct with a time.Duration type field.
 
 	type TimeDurationTest struct {
 		Duration time.Duration `validate:"lt=1h1m"`
 	}
 
-	timeDurationTest := &TimeDurationTest{duration}
+	timeDurationTest := &TimeDurationTest{time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration + time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour + time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "lt")
 
-	timeDurationTest = &TimeDurationTest{duration + 2*time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour + 2*time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "lt")
@@ -7126,38 +7084,36 @@ func TestIsLte(t *testing.T) {
 
 	// Tests for time.Duration type.
 
-	duration := time.Duration(1 * time.Hour)
-
 	// -- Validations for a variable of time.Duration type.
 
-	errs = validate.Var(duration, "lte=1h1m")
+	errs = validate.Var(time.Hour, "lte=1h1m")
 	Equal(t, errs, nil)
 
-	errs = validate.Var(duration+time.Minute, "lte=1h1m")
+	errs = validate.Var(time.Hour+time.Minute, "lte=1h1m")
 	Equal(t, errs, nil)
 
-	errs = validate.Var(duration+2*time.Minute, "lte=1h1m")
+	errs = validate.Var(time.Hour+2*time.Minute, "lte=1h1m")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "lte")
 
 	errs = validate.Var(time.Duration(0), "omitempty,lte=-1s")
 	Equal(t, errs, nil)
 
-	// -- Validations for a struct with time.Duration type fields.
+	// -- Validations for a struct with a time.Duration type field.
 
 	type TimeDurationTest struct {
 		Duration time.Duration `validate:"lte=1h1m"`
 	}
 
-	timeDurationTest := &TimeDurationTest{duration}
+	timeDurationTest := &TimeDurationTest{time.Hour}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration + time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour + time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	Equal(t, errs, nil)
 
-	timeDurationTest = &TimeDurationTest{duration + 2*time.Minute}
+	timeDurationTest = &TimeDurationTest{time.Hour + 2*time.Minute}
 	errs = validate.Struct(timeDurationTest)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "lte")

--- a/validator_test.go
+++ b/validator_test.go
@@ -1046,6 +1046,61 @@ func TestCrossStructLteFieldValidation(t *testing.T) {
 	errs = validate.Struct(tst)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "Test2.Time", "Test2.Time", "Time", "Time", "ltecsfield")
+
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for a variable of time.Duration type.
+
+	errs = validate.VarWithValue(duration, duration+time.Minute, "ltecsfield")
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue(duration, duration, "ltecsfield")
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue(duration, duration-time.Minute, "ltecsfield")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "ltecsfield")
+
+	errs = validate.VarWithValue(time.Duration(0), -time.Minute, "omitempty,ltecsfield")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct and a inner struct with time.Duration type fields.
+
+	type TimeDurationInner struct {
+		Duration time.Duration
+	}
+
+	type TimeDurationTest struct {
+		Inner    *TimeDurationInner
+		Duration time.Duration `validate:"ltecsfield=Inner.Duration"`
+	}
+
+	timeDurationInner := &TimeDurationInner{duration + time.Minute}
+	timeDurationTest := &TimeDurationTest{timeDurationInner, duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationInner = &TimeDurationInner{duration}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationInner = &TimeDurationInner{duration - time.Minute}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "ltecsfield")
+
+	type TimeDurationOmitemptyTest struct {
+		Inner    *TimeDurationInner
+		Duration time.Duration `validate:"omitempty,ltecsfield=Inner.Duration"`
+	}
+	timeDurationInner = &TimeDurationInner{-time.Minute}
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
 }
 
 func TestCrossStructLtFieldValidation(t *testing.T) {
@@ -1142,6 +1197,64 @@ func TestCrossStructLtFieldValidation(t *testing.T) {
 	errs = validate.Struct(tst)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "Test2.Time", "Test2.Time", "Time", "Time", "ltcsfield")
+
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for a variable of time.Duration type.
+
+	errs = validate.VarWithValue(duration, duration+time.Minute, "ltcsfield")
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue(duration, duration, "ltcsfield")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "ltcsfield")
+
+	errs = validate.VarWithValue(duration, duration-time.Minute, "ltcsfield")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "ltcsfield")
+
+	errs = validate.VarWithValue(time.Duration(0), -time.Minute, "omitempty,ltcsfield")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct and a inner struct with time.Duration type fields.
+
+	type TimeDurationInner struct {
+		Duration time.Duration
+	}
+
+	type TimeDurationTest struct {
+		Inner    *TimeDurationInner
+		Duration time.Duration `validate:"ltcsfield=Inner.Duration"`
+	}
+
+	timeDurationInner := &TimeDurationInner{duration + time.Minute}
+	timeDurationTest := &TimeDurationTest{timeDurationInner, duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationInner = &TimeDurationInner{duration}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "ltcsfield")
+
+	timeDurationInner = &TimeDurationInner{duration - time.Minute}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "ltcsfield")
+
+	type TimeDurationOmitemptyTest struct {
+		Inner    *TimeDurationInner
+		Duration time.Duration `validate:"omitempty,ltcsfield=Inner.Duration"`
+	}
+
+	timeDurationInner = &TimeDurationInner{-time.Minute}
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
 }
 
 func TestCrossStructGteFieldValidation(t *testing.T) {
@@ -1250,6 +1363,62 @@ func TestCrossStructGteFieldValidation(t *testing.T) {
 	errs = validate.Struct(tst)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "Test2.Time", "Test2.Time", "Time", "Time", "gtecsfield")
+
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for a variable of time.Duration type.
+
+	errs = validate.VarWithValue(duration, duration-time.Minute, "gtecsfield")
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue(duration, duration, "gtecsfield")
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue(duration, duration+time.Minute, "gtecsfield")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "gtecsfield")
+
+	errs = validate.VarWithValue(time.Duration(0), duration, "omitempty,gtecsfield")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct and a inner struct with time.Duration type fields.
+
+	type TimeDurationInner struct {
+		Duration time.Duration
+	}
+
+	type TimeDurationTest struct {
+		Inner    *TimeDurationInner
+		Duration time.Duration `validate:"gtecsfield=Inner.Duration"`
+	}
+
+	timeDurationInner := &TimeDurationInner{duration - time.Minute}
+	timeDurationTest := &TimeDurationTest{timeDurationInner, duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationInner = &TimeDurationInner{duration}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationInner = &TimeDurationInner{duration + time.Minute}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "gtecsfield")
+
+	type TimeDurationOmitemptyTest struct {
+		Inner    *TimeDurationInner
+		Duration time.Duration `validate:"omitempty,gtecsfield=Inner.Duration"`
+	}
+
+	timeDurationInner = &TimeDurationInner{duration}
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
 }
 
 func TestCrossStructGtFieldValidation(t *testing.T) {
@@ -1346,6 +1515,64 @@ func TestCrossStructGtFieldValidation(t *testing.T) {
 	errs = validate.Struct(tst)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "Test2.Time", "Test2.Time", "Time", "Time", "gtcsfield")
+
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for a variable of time.Duration type.
+
+	errs = validate.VarWithValue(duration, duration-time.Minute, "gtcsfield")
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue(duration, duration, "gtcsfield")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "gtcsfield")
+
+	errs = validate.VarWithValue(duration, duration+time.Minute, "gtcsfield")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "gtcsfield")
+
+	errs = validate.VarWithValue(time.Duration(0), duration, "omitempty,gtcsfield")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct and a inner struct with time.Duration type fields.
+
+	type TimeDurationInner struct {
+		Duration time.Duration
+	}
+
+	type TimeDurationTest struct {
+		Inner    *TimeDurationInner
+		Duration time.Duration `validate:"gtcsfield=Inner.Duration"`
+	}
+
+	timeDurationInner := &TimeDurationInner{duration - time.Minute}
+	timeDurationTest := &TimeDurationTest{timeDurationInner, duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationInner = &TimeDurationInner{duration}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "gtcsfield")
+
+	timeDurationInner = &TimeDurationInner{duration + time.Minute}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "gtcsfield")
+
+	type TimeDurationOmitemptyTest struct {
+		Inner    *TimeDurationInner
+		Duration time.Duration `validate:"omitempty,gtcsfield=Inner.Duration"`
+	}
+
+	timeDurationInner = &TimeDurationInner{duration}
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
 }
 
 func TestCrossStructNeFieldValidation(t *testing.T) {
@@ -1454,6 +1681,62 @@ func TestCrossStructNeFieldValidation(t *testing.T) {
 	errs = validate.VarWithValue(nil, 1, "necsfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "necsfield")
+
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for a variable of time.Duration type.
+
+	errs = validate.VarWithValue(duration, duration-time.Minute, "necsfield")
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue(duration, duration+time.Minute, "necsfield")
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue(duration, duration, "necsfield")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "necsfield")
+
+	errs = validate.VarWithValue(time.Duration(0), time.Duration(0), "omitempty,necsfield")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct and a inner struct with time.Duration type fields.
+
+	type TimeDurationInner struct {
+		Duration time.Duration
+	}
+
+	type TimeDurationTest struct {
+		Inner    *TimeDurationInner
+		Duration time.Duration `validate:"necsfield=Inner.Duration"`
+	}
+
+	timeDurationInner := &TimeDurationInner{duration - time.Minute}
+	timeDurationTest := &TimeDurationTest{timeDurationInner, duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationInner = &TimeDurationInner{duration + time.Minute}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationInner = &TimeDurationInner{duration}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "necsfield")
+
+	type TimeDurationOmitemptyTest struct {
+		Inner    *TimeDurationInner
+		Duration time.Duration `validate:"omitempty,necsfield=Inner.Duration"`
+	}
+
+	timeDurationInner = &TimeDurationInner{time.Duration(0)}
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
 }
 
 func TestCrossStructEqFieldValidation(t *testing.T) {
@@ -1559,6 +1842,64 @@ func TestCrossStructEqFieldValidation(t *testing.T) {
 	errs = validate.VarWithValue(nil, 1, "eqcsfield")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "", "", "", "", "eqcsfield")
+
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for a variable of time.Duration type.
+
+	errs = validate.VarWithValue(duration, duration, "eqcsfield")
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue(duration, duration-time.Minute, "eqcsfield")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "eqcsfield")
+
+	errs = validate.VarWithValue(duration, duration+time.Minute, "eqcsfield")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "eqcsfield")
+
+	errs = validate.VarWithValue(time.Duration(0), duration, "omitempty,eqcsfield")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct and a inner struct with time.Duration type fields.
+
+	type TimeDurationInner struct {
+		Duration time.Duration
+	}
+
+	type TimeDurationTest struct {
+		Inner    *TimeDurationInner
+		Duration time.Duration `validate:"eqcsfield=Inner.Duration"`
+	}
+
+	timeDurationInner := &TimeDurationInner{duration}
+	timeDurationTest := &TimeDurationTest{timeDurationInner, duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationInner = &TimeDurationInner{duration - time.Minute}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "eqcsfield")
+
+	timeDurationInner = &TimeDurationInner{duration + time.Minute}
+	timeDurationTest = &TimeDurationTest{timeDurationInner, duration}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "eqcsfield")
+
+	type TimeDurationOmitemptyTest struct {
+		Inner    *TimeDurationInner
+		Duration time.Duration `validate:"omitempty,eqcsfield=Inner.Duration"`
+	}
+
+	timeDurationInner = &TimeDurationInner{duration}
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{timeDurationInner, time.Duration(0)}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
 }
 
 func TestCrossNamespaceFieldValidation(t *testing.T) {
@@ -4287,6 +4628,54 @@ func TestIsNeFieldValidation(t *testing.T) {
 
 	errs = validate.Struct(tst)
 	Equal(t, errs, nil)
+
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for variables of time.Duration type.
+
+	errs = validate.VarWithValue(duration, duration-time.Minute, "nefield")
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue(duration, duration+time.Minute, "nefield")
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue(duration, duration, "nefield")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "nefield")
+
+	errs = validate.VarWithValue(time.Duration(0), time.Duration(0), "omitempty,nefield")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct with time.Duration type fields.
+
+	type TimeDurationTest struct {
+		First  time.Duration `validate:"nefield=Second"`
+		Second time.Duration
+	}
+
+	timeDurationTest := &TimeDurationTest{duration, duration - time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration, duration + time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration, duration}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.First", "TimeDurationTest.First", "First", "First", "nefield")
+
+	type TimeDurationOmitemptyTest struct {
+		First  time.Duration `validate:"omitempty,nefield=Second"`
+		Second time.Duration
+	}
+
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0), time.Duration(0)}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
 }
 
 func TestIsNeValidation(t *testing.T) {
@@ -4322,6 +4711,52 @@ func TestIsNeValidation(t *testing.T) {
 	AssertError(t, errs, "", "", "", "", "ne")
 
 	PanicMatches(t, func() { _ = validate.Var(now, "ne=now") }, "Bad field type time.Time")
+
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for a variable of time.Duration type.
+
+	errs = validate.Var(duration-time.Minute, "ne=1h")
+	Equal(t, errs, nil)
+
+	errs = validate.Var(duration+time.Minute, "ne=1h")
+	Equal(t, errs, nil)
+
+	errs = validate.Var(duration, "ne=1h")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "ne")
+
+	errs = validate.Var(time.Duration(0), "omitempty,ne=0")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct with a time.Duration type field.
+
+	type TimeDurationTest struct {
+		Duration time.Duration `validate:"ne=1h"`
+	}
+
+	timeDurationTest := &TimeDurationTest{duration - time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration + time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "ne")
+
+	type TimeDurationOmitemptyTest struct {
+		Duration time.Duration `validate:"omitempty,ne=0"`
+	}
+
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0)}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
 }
 
 func TestIsEqFieldValidation(t *testing.T) {
@@ -4441,6 +4876,56 @@ func TestIsEqFieldValidation(t *testing.T) {
 	errs = validate.Struct(test)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TStruct.CreatedAt", "TStruct.CreatedAt", "CreatedAt", "CreatedAt", "eqfield")
+
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for variables of time.Duration type.
+
+	errs = validate.VarWithValue(duration, duration, "eqfield")
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue(duration, duration-time.Minute, "eqfield")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "eqfield")
+
+	errs = validate.VarWithValue(duration, duration+time.Minute, "eqfield")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "eqfield")
+
+	errs = validate.VarWithValue(time.Duration(0), duration, "omitempty,eqfield")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct with time.Duration type fields.
+
+	type TimeDurationTest struct {
+		First  time.Duration `validate:"eqfield=Second"`
+		Second time.Duration
+	}
+
+	timeDurationTest := &TimeDurationTest{duration, duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration, duration - time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.First", "TimeDurationTest.First", "First", "First", "eqfield")
+
+	timeDurationTest = &TimeDurationTest{duration, duration + time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.First", "TimeDurationTest.First", "First", "First", "eqfield")
+
+	type TimeDurationOmitemptyTest struct {
+		First  time.Duration `validate:"omitempty,eqfield=Second"`
+		Second time.Duration
+	}
+
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0), duration}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
 }
 
 func TestIsEqValidation(t *testing.T) {
@@ -4476,6 +4961,54 @@ func TestIsEqValidation(t *testing.T) {
 	AssertError(t, errs, "", "", "", "", "eq")
 
 	PanicMatches(t, func() { _ = validate.Var(now, "eq=now") }, "Bad field type time.Time")
+
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for a variable of time.Duration type.
+
+	errs = validate.Var(duration, "eq=1h")
+	Equal(t, errs, nil)
+
+	errs = validate.Var(duration-time.Minute, "eq=1h")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "eq")
+
+	errs = validate.Var(duration+time.Minute, "eq=1h")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "eq")
+
+	errs = validate.Var(time.Duration(0), "omitempty,eq=1h")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct with a time.Duration type field.
+
+	type TimeDurationTest struct {
+		Duration time.Duration `validate:"eq=1h"`
+	}
+
+	timeDurationTest := &TimeDurationTest{duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration - time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "eq")
+
+	timeDurationTest = &TimeDurationTest{duration + time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "eq")
+
+	type TimeDurationOmitemptyTest struct {
+		Duration time.Duration `validate:"omitempty,eq=1h"`
+	}
+
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0)}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
 }
 
 func TestOneOfValidation(t *testing.T) {
@@ -4997,6 +5530,58 @@ func TestGtField(t *testing.T) {
 	errs = validate.VarWithValue("test bigger", "test", "gtfield")
 	Equal(t, errs, nil)
 
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for variables of time.Duration type.
+
+	errs = validate.VarWithValue(duration, duration-time.Minute, "gtfield")
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue(duration, duration, "gtfield")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "gtfield")
+
+	errs = validate.VarWithValue(duration, duration+time.Minute, "gtfield")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "gtfield")
+
+	errs = validate.VarWithValue(time.Duration(0), duration, "omitempty,gtfield")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct with time.Duration type fields.
+
+	type TimeDurationTest struct {
+		First  time.Duration `validate:"gtfield=Second"`
+		Second time.Duration
+	}
+
+	timeDurationTest := &TimeDurationTest{duration, duration - time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration, duration}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.First", "TimeDurationTest.First", "First", "First", "gtfield")
+
+	timeDurationTest = &TimeDurationTest{duration, duration + time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.First", "TimeDurationTest.First", "First", "First", "gtfield")
+
+	type TimeDurationOmitemptyTest struct {
+		First  time.Duration `validate:"omitempty,gtfield=Second"`
+		Second time.Duration
+	}
+
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0), duration}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
+
+	// Tests for Ints types.
+
 	type IntTest struct {
 		Val1 int `validate:"required"`
 		Val2 int `validate:"required,gtfield=Val1"`
@@ -5172,6 +5757,58 @@ func TestLtField(t *testing.T) {
 
 	errs = validate.VarWithValue("tes", "test", "ltfield")
 	Equal(t, errs, nil)
+
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for variables of time.Duration type.
+
+	errs = validate.VarWithValue(duration, duration+time.Minute, "ltfield")
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue(duration, duration, "ltfield")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "ltfield")
+
+	errs = validate.VarWithValue(duration, duration-time.Minute, "ltfield")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "ltfield")
+
+	errs = validate.VarWithValue(time.Duration(0), -time.Minute, "omitempty,ltfield")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct with time.Duration type fields.
+
+	type TimeDurationTest struct {
+		First  time.Duration `validate:"ltfield=Second"`
+		Second time.Duration
+	}
+
+	timeDurationTest := &TimeDurationTest{duration, duration + time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration, duration}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.First", "TimeDurationTest.First", "First", "First", "ltfield")
+
+	timeDurationTest = &TimeDurationTest{duration, duration - time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.First", "TimeDurationTest.First", "First", "First", "ltfield")
+
+	type TimeDurationOmitemptyTest struct {
+		First  time.Duration `validate:"omitempty,ltfield=Second"`
+		Second time.Duration
+	}
+
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0), -time.Minute}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
+
+	// Tests for Ints types.
 
 	type IntTest struct {
 		Val1 int `validate:"required"`
@@ -5457,6 +6094,56 @@ func TestLteField(t *testing.T) {
 	errs = validate.VarWithValue("test", "test", "ltefield")
 	Equal(t, errs, nil)
 
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for variables of time.Duration type.
+
+	errs = validate.VarWithValue(duration, duration+time.Minute, "ltefield")
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue(duration, duration, "ltefield")
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue(duration, duration-time.Minute, "ltefield")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "ltefield")
+
+	errs = validate.VarWithValue(time.Duration(0), -time.Minute, "omitempty,ltefield")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct with time.Duration type fields.
+
+	type TimeDurationTest struct {
+		First  time.Duration `validate:"ltefield=Second"`
+		Second time.Duration
+	}
+
+	timeDurationTest := &TimeDurationTest{duration, duration + time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration, duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration, duration - time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.First", "TimeDurationTest.First", "First", "First", "ltefield")
+
+	type TimeDurationOmitemptyTest struct {
+		First  time.Duration `validate:"omitempty,ltefield=Second"`
+		Second time.Duration
+	}
+
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0), -time.Minute}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
+
+	// Tests for Ints types.
+
 	type IntTest struct {
 		Val1 int `validate:"required"`
 		Val2 int `validate:"required,ltefield=Val1"`
@@ -5617,6 +6304,56 @@ func TestGteField(t *testing.T) {
 
 	errs = validate.VarWithValue("test bigger", "test", "gtefield")
 	Equal(t, errs, nil)
+
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for variables of time.Duration type.
+
+	errs = validate.VarWithValue(duration, duration-time.Minute, "gtefield")
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue(duration, duration, "gtefield")
+	Equal(t, errs, nil)
+
+	errs = validate.VarWithValue(duration, duration+time.Minute, "gtefield")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "gtefield")
+
+	errs = validate.VarWithValue(time.Duration(0), duration, "omitempty,gtefield")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct with time.Duration type fields.
+
+	type TimeDurationTest struct {
+		First  time.Duration `validate:"gtefield=Second"`
+		Second time.Duration
+	}
+
+	timeDurationTest := &TimeDurationTest{duration, duration - time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration, duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration, duration + time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.First", "TimeDurationTest.First", "First", "First", "gtefield")
+
+	type TimeDurationOmitemptyTest struct {
+		First  time.Duration `validate:"omitempty,gtefield=Second"`
+		Second time.Duration
+	}
+
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0), duration}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
+
+	// Tests for Ints types.
 
 	type IntTest struct {
 		Val1 int `validate:"required"`
@@ -5900,6 +6637,54 @@ func TestIsGt(t *testing.T) {
 	errs = validate.Struct(s)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "Test.Now", "Test.Now", "Now", "Now", "gt")
+
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for a variable of time.Duration type.
+
+	errs = validate.Var(duration, "gt=59m")
+	Equal(t, errs, nil)
+
+	errs = validate.Var(duration-time.Minute, "gt=59m")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "gt")
+
+	errs = validate.Var(duration-2*time.Minute, "gt=59m")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "gt")
+
+	errs = validate.Var(time.Duration(0), "omitempty,gt=59m")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct with time.Duration type fields.
+
+	type TimeDurationTest struct {
+		Duration time.Duration `validate:"gt=59m"`
+	}
+
+	timeDurationTest := &TimeDurationTest{duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration - time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "gt")
+
+	timeDurationTest = &TimeDurationTest{duration - 2*time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "gt")
+
+	type TimeDurationOmitemptyTest struct {
+		Duration time.Duration `validate:"omitempty,gt=59m"`
+	}
+
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0)}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
 }
 
 func TestIsGte(t *testing.T) {
@@ -5936,6 +6721,270 @@ func TestIsGte(t *testing.T) {
 	errs = validate.Struct(s)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "Test.Now", "Test.Now", "Now", "Now", "gte")
+
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for a variable of time.Duration type.
+
+	errs = validate.Var(duration, "gte=59m")
+	Equal(t, errs, nil)
+
+	errs = validate.Var(duration-time.Minute, "gte=59m")
+	Equal(t, errs, nil)
+
+	errs = validate.Var(duration-2*time.Minute, "gte=59m")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "gte")
+
+	errs = validate.Var(time.Duration(0), "omitempty,gte=59m")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct with time.Duration type fields.
+
+	type TimeDurationTest struct {
+		Duration time.Duration `validate:"gte=59m"`
+	}
+
+	timeDurationTest := &TimeDurationTest{duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration - time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration - 2*time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "gte")
+
+	type TimeDurationOmitemptyTest struct {
+		Duration time.Duration `validate:"omitempty,gte=59m"`
+	}
+
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0)}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
+}
+
+func TestMinValidation(t *testing.T) {
+	validate := New()
+
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for a variable of time.Duration type.
+
+	errs := validate.Var(duration, "min=59m")
+	Equal(t, errs, nil)
+
+	errs = validate.Var(duration-time.Minute, "min=59m")
+	Equal(t, errs, nil)
+
+	errs = validate.Var(duration-2*time.Minute, "min=59m")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "min")
+
+	errs = validate.Var(time.Duration(0), "omitempty,min=59m")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct with time.Duration type field.
+
+	type TimeDurationTest struct {
+		Duration time.Duration `validate:"min=59m"`
+	}
+
+	timeDurationTest := &TimeDurationTest{duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration - time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration - 2*time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "min")
+
+	type TimeDurationOmitemptyTest struct {
+		Duration time.Duration `validate:"omitempty,min=59m"`
+	}
+
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0)}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
+}
+
+func TestMaxValidation(t *testing.T) {
+	validate := New()
+
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for a variable of time.Duration type.
+
+	errs := validate.Var(duration, "max=1h1m")
+	Equal(t, errs, nil)
+
+	errs = validate.Var(duration+time.Minute, "max=1h1m")
+	Equal(t, errs, nil)
+
+	errs = validate.Var(duration+2*time.Minute, "max=1h1m")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "max")
+
+	errs = validate.Var(time.Duration(0), "omitempty,max=-1s")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct with time.Duration type field.
+
+	type TimeDurationTest struct {
+		Duration time.Duration `validate:"max=1h1m"`
+	}
+
+	timeDurationTest := &TimeDurationTest{duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration + time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration + 2*time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "max")
+
+	type TimeDurationOmitemptyTest struct {
+		Duration time.Duration `validate:"omitempty,max=-1s"`
+	}
+
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0)}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
+}
+
+func TestMinMaxValidation(t *testing.T) {
+	validate := New()
+
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for a variable of time.Duration type.
+
+	errs := validate.Var(duration, "min=59m,max=1h1m")
+	Equal(t, errs, nil)
+
+	errs = validate.Var(duration-time.Minute, "min=59m,max=1h1m")
+	Equal(t, errs, nil)
+
+	errs = validate.Var(duration+time.Minute, "min=59m,max=1h1m")
+	Equal(t, errs, nil)
+
+	errs = validate.Var(duration-2*time.Minute, "min=59m,max=1h1m")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "min")
+
+	errs = validate.Var(duration+2*time.Minute, "min=59m,max=1h1m")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "max")
+
+	errs = validate.Var(time.Duration(0), "omitempty,min=59m,max=1h1m")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct with time.Duration type field.
+
+	type TimeDurationTest struct {
+		Duration time.Duration `validate:"min=59m,max=1h1m"`
+	}
+
+	timeDurationTest := &TimeDurationTest{duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration - time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration + time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration - 2*time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "min")
+
+	timeDurationTest = &TimeDurationTest{duration + 2*time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "max")
+
+	type TimeDurationOmitemptyTest struct {
+		Duration time.Duration `validate:"omitempty,min=59m,max=1h1m"`
+	}
+
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0)}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
+}
+
+func TestLenValidation(t *testing.T) {
+	validate := New()
+
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for a variable of time.Duration type.
+
+	errs := validate.Var(duration, "len=1h")
+	Equal(t, errs, nil)
+
+	errs = validate.Var(duration-time.Minute, "len=1h")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "len")
+
+	errs = validate.Var(duration+time.Minute, "len=1h")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "len")
+
+	errs = validate.Var(time.Duration(0), "omitempty,len=1h")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct with time.Duration type field.
+
+	type TimeDurationTest struct {
+		Duration time.Duration `validate:"len=1h"`
+	}
+
+	timeDurationTest := &TimeDurationTest{duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration - time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "len")
+
+	timeDurationTest = &TimeDurationTest{duration + time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "len")
+
+	type TimeDurationOmitemptyTest struct {
+		Duration time.Duration `validate:"omitempty,len=1h"`
+	}
+
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0)}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
 }
 
 func TestIsLt(t *testing.T) {
@@ -5988,6 +7037,54 @@ func TestIsLt(t *testing.T) {
 	errs = validate.Struct(s)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "Test.Now", "Test.Now", "Now", "Now", "lt")
+
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for a variable of time.Duration type.
+
+	errs = validate.Var(duration, "lt=1h1m")
+	Equal(t, errs, nil)
+
+	errs = validate.Var(duration+time.Minute, "lt=1h1m")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "lt")
+
+	errs = validate.Var(duration+2*time.Minute, "lt=1h1m")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "lt")
+
+	errs = validate.Var(time.Duration(0), "omitempty,lt=0")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct with time.Duration type fields.
+
+	type TimeDurationTest struct {
+		Duration time.Duration `validate:"lt=1h1m"`
+	}
+
+	timeDurationTest := &TimeDurationTest{duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration + time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "lt")
+
+	timeDurationTest = &TimeDurationTest{duration + 2*time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "lt")
+
+	type TimeDurationOmitemptyTest struct {
+		Duration time.Duration `validate:"omitempty,lt=0"`
+	}
+
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0)}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
 }
 
 func TestIsLte(t *testing.T) {
@@ -6026,6 +7123,52 @@ func TestIsLte(t *testing.T) {
 
 	errs = validate.Struct(s)
 	NotEqual(t, errs, nil)
+
+	// Tests for time.Duration type.
+
+	duration := time.Duration(1 * time.Hour)
+
+	// -- Validations for a variable of time.Duration type.
+
+	errs = validate.Var(duration, "lte=1h1m")
+	Equal(t, errs, nil)
+
+	errs = validate.Var(duration+time.Minute, "lte=1h1m")
+	Equal(t, errs, nil)
+
+	errs = validate.Var(duration+2*time.Minute, "lte=1h1m")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "lte")
+
+	errs = validate.Var(time.Duration(0), "omitempty,lte=-1s")
+	Equal(t, errs, nil)
+
+	// -- Validations for a struct with time.Duration type fields.
+
+	type TimeDurationTest struct {
+		Duration time.Duration `validate:"lte=1h1m"`
+	}
+
+	timeDurationTest := &TimeDurationTest{duration}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration + time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	Equal(t, errs, nil)
+
+	timeDurationTest = &TimeDurationTest{duration + 2*time.Minute}
+	errs = validate.Struct(timeDurationTest)
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TimeDurationTest.Duration", "TimeDurationTest.Duration", "Duration", "Duration", "lte")
+
+	type TimeDurationOmitemptyTest struct {
+		Duration time.Duration `validate:"omitempty,lte=-1s"`
+	}
+
+	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0)}
+	errs = validate.Struct(timeDurationOmitemptyTest)
+	Equal(t, errs, nil)
 }
 
 func TestUrnRFC2141(t *testing.T) {


### PR DESCRIPTION
Fixes Or Enhances https://github.com/go-playground/validator/issues/584

**Make sure that you've checked the boxes below before you submit PR:**

- [x] Tests exist or have been written that cover this particular change.

Change Details:

### Validations for `time.Duration`

Tag    | Coded in function             | Tested in function
-------|-------------------------------|-------------------
`eq=`  | `isEq()`                      | `TestIsEqValidation()`
`ne=`  | `isNe()` _(not changed)_      | `TestIsNeValidation()`
`lt=`  | `isLt()`                      | `TestIsLt()`
`lte=` | `isLte()`                     | `TestIsLte()`
`gt=`  | `isGt()`                      | `TestIsGt()`
`gte=` | `isGte()`                     | `TestIsGte()`
`min=` | `hasMinOf()` _(not changed)_  | `TestMinValidation()` _(new)_, `TestMinMaxValidation()` _(new)_
`max=` | `hasMaxOf()` _(not changed)_  | `TestMaxValidation()` _(new)_, `TestMinMaxValidation()` _(new)_
`len=` | `hasLengthOf()`               | `TestLenValidation()` _(new)_

### Cross-Field Validations for `time.Duration`

Tag         | Coded in function              | Tested in function
------------|--------------------------------|-------------------
`eqfield=`  | `isEqField()` _(not changed)_  | `TestIsEqFieldValidation()`
`nefield=`  | `isNeField()` _(not changed)_  | `TestIsNeFieldValidation()`
`ltfield=`  | `isLtField()` _(not changed)_  | `TestLtField()`
`ltefield=` | `isLteField()` _(not changed)_ | `TestLteField()`
`gtfield=`  | `isGtField()` _(not changed)_  | `TestGtField()`
`gtefield=` | `isGteField()` _(not changed)_ | `TestGteField()`

### Cross-Field Validations for `time.Duration` (within a separate struct)

Tag           | Coded in function                         | Tested in function
--------------|-------------------------------------------|-------------------
`eqcsfield=`  | `isEqCrossStructField()` _(not changed)_  | `TestCrossStructEqFieldValidation()`
`necsfield=`  | `isNeCrossStructField()` _(not changed)_  | `TestCrossStructNeFieldValidation()`
`ltcsfield=`  | `isLtCrossStructField()` _(not changed)_  | `TestCrossStructLtFieldValidation()`
`ltecsfield=` | `isLteCrossStructField()` _(not changed)_ | `TestCrossStructLteFieldValidation()`
`gtcsfield=`  | `isGtCrossStructField()` _(not changed)_  | `TestCrossStructGtFieldValidation()`
`gtecsfield=` | `isGteCrossStructField()` _(not changed)_ | `TestCrossStructGteFieldValidation()`

### Special

Tag         | Coded in function             | Tested in function
------------|-------------------------------|-------------------
`omitempty` | _(not changed)_               | It has been tested in all the previous test functions listed above
`required`  | `hasValue()` _(not changed)_  | I don't know how to test it, or if it is needed
`isdefault` | `isDefault()` _(not changed)_ | I don't know how to test it, or if it is needed

### Docs

Updated in the `doc.go` file.


@go-playground/admins
