### PR TITLE
Validate tag omitempty, only base on field value

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -249,7 +249,7 @@ OUTER:
 			v.cf = cf
 			v.ct = ct
 
-			if !v.fldIsPointer && !hasValue(v) {
+			if !hasValue(v) {
 				return
 			}
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -8858,6 +8858,16 @@ func TestRequiredWithout(t *testing.T) {
 	AssertError(t, errs, "Field6", "Field6", "Field6", "Field6", "required_without")
 	AssertError(t, errs, "Field7", "Field7", "Field7", "Field7", "required_without")
 	AssertError(t, errs, "Field8", "Field8", "Field8", "Field8", "required_without")
+
+	test3 := struct {
+		Field1 *string `validate:"required_without=Field2,omitempty,min=1" json:"field_1"`
+		Field2 *string `validate:"required_without=Field1,omitempty,min=1" json:"field_2"`
+	}{
+		Field1: &fieldVal,
+	}
+
+	errs = validate.Struct(&test3)
+	Equal(t, errs, nil)
 }
 
 func TestRequiredWithoutAll(t *testing.T) {


### PR DESCRIPTION
Fixes validation of tag omitempty, base on the field value #654.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:

- Validate the tag omitempty, only base on the field value.


@go-playground/admins