### PR TITLE
Includes Error in FieldError's interface

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -155,6 +155,9 @@ type FieldError interface {
 	// NOTE: if no registered translator can be found it returns the same as
 	// calling fe.Error()
 	Translate(ut ut.Translator) string
+
+	// Error returns the FieldError's message
+	Error() string
 }
 
 // compile time interface checks


### PR DESCRIPTION
Fixes Or Enhances #420 

There seemed to be an intention to include `Error` in the `FieldError` interface since `fieldError` has that method. This simplified passing along error messages for errors that I didn't want to write my own custom message for.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:

- Includes `Error` method in `FieldError`, a method already implemented on the unexported `fieldError` struct


@go-playground/admins