### PR TITLE
Fix a category of endswith in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Baked-in Validations
 | contains | Contains |
 | containsany | Contains Any |
 | containsrune | Contains Rune |
+| endswith | Ends With |
 | lowercase | Lowercase |
 | multibyte | Multi-Byte Characters |
 | number | NOT DOCUMENTED IN doc.go |
@@ -186,7 +187,6 @@ Baked-in Validations
 | - | - |
 | dir | Directory |
 | e164 | NOT DOCUMENTED IN doc.go |
-| endswith | Ends With |
 | excludes | Excludes |
 | excludesall | Excludes All |
 | excludesrune | Excludes Rune |


### PR DESCRIPTION
Fixes Or Enhances # .

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change Details:

- Change a category of `endswith` from Other to Strings in README.md


@go-playground/admins