### PR TITLE
Fix accessing fields in composed structs

### DIFF
--- a/validator_instance.go
+++ b/validator_instance.go
@@ -409,8 +409,8 @@ func (v *Validate) StructPartialCtx(ctx context.Context, s interface{}, fields .
 		if len(flds) > 0 {
 
 			vd.misc = append(vd.misc[0:0], name...)
-			// Don't append empty name for composed structs
-			if string(vd.misc) != "" {
+			// Don't append empty name for unnamed structs
+			if len(vd.misc) != 0 {
 				vd.misc = append(vd.misc, '.')
 			}
 

--- a/validator_instance.go
+++ b/validator_instance.go
@@ -409,7 +409,10 @@ func (v *Validate) StructPartialCtx(ctx context.Context, s interface{}, fields .
 		if len(flds) > 0 {
 
 			vd.misc = append(vd.misc[0:0], name...)
-			vd.misc = append(vd.misc, '.')
+			// Don't append empty name for composed structs
+			if string(vd.misc) != "" {
+				vd.misc = append(vd.misc, '.')
+			}
 
 			for _, s := range flds {
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -949,6 +949,28 @@ func TestStructPartial(t *testing.T) {
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TestPartial.Anonymous.SubAnonStruct[0].Test", "TestPartial.Anonymous.SubAnonStruct[0].Test", "Test", "Test", "required")
 
+	// Test for composed struct
+	testStruct := &TestStruct{
+		String: "test",
+	}
+	composedStruct := struct{ *TestStruct }{&TestStruct{String: "test"}}
+
+	errs = validate.StructPartial(testStruct, "String")
+	Equal(t, errs, nil)
+
+	errs = validate.StructPartial(composedStruct, "TestStruct.String")
+	Equal(t, errs, nil)
+
+	testStruct.String = ""
+
+	errs = validate.StructPartial(testStruct, "String")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TestStruct.String", "TestStruct.String", "String", "String", "required")
+
+	composedStruct.String = ""
+	errs = validate.StructPartial(composedStruct, "TestStruct.String")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "TestStruct.String", "TestStruct.String", "String", "String", "required")
 }
 
 func TestCrossStructLteFieldValidation(t *testing.T) {

--- a/validator_test.go
+++ b/validator_test.go
@@ -949,26 +949,36 @@ func TestStructPartial(t *testing.T) {
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TestPartial.Anonymous.SubAnonStruct[0].Test", "TestPartial.Anonymous.SubAnonStruct[0].Test", "Test", "Test", "required")
 
-	// Test for composed struct
+	// Test for unnamed struct
 	testStruct := &TestStruct{
 		String: "test",
 	}
-	composedStruct := struct{ *TestStruct }{&TestStruct{String: "test"}}
+	unnamedStruct := struct {
+		String string `validate:"required" json:"StringVal"`
+	}{String: "test"}
+	composedUnnamedStruct := struct{ *TestStruct }{&TestStruct{String: "test"}}
 
 	errs = validate.StructPartial(testStruct, "String")
 	Equal(t, errs, nil)
 
-	errs = validate.StructPartial(composedStruct, "TestStruct.String")
+	errs = validate.StructPartial(unnamedStruct, "String")
+	Equal(t, errs, nil)
+
+	errs = validate.StructPartial(composedUnnamedStruct, "TestStruct.String")
 	Equal(t, errs, nil)
 
 	testStruct.String = ""
-
 	errs = validate.StructPartial(testStruct, "String")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TestStruct.String", "TestStruct.String", "String", "String", "required")
 
-	composedStruct.String = ""
-	errs = validate.StructPartial(composedStruct, "TestStruct.String")
+	unnamedStruct.String = ""
+	errs = validate.StructPartial(unnamedStruct, "String")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "String", "String", "String", "String", "required")
+
+	composedUnnamedStruct.String = ""
+	errs = validate.StructPartial(composedUnnamedStruct, "TestStruct.String")
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TestStruct.String", "TestStruct.String", "String", "String", "required")
 }


### PR DESCRIPTION
## Fixes Or Enhances

This change fixes the issue with validating fields in composed structures when the validator uses `.` before the composed struct in the parent one.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/admins