### PR TITLE
Add ability to validate map data

### DIFF
--- a/_examples/map-validation/main.go
+++ b/_examples/map-validation/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"github.com/go-playground/validator/v10"
+)
+
+var validate *validator.Validate
+
+func main() {
+	validate = validator.New()
+
+	validateMap()
+}
+
+func validateMap() {
+	user := map[string]interface{}{"name": "Arshiya Kiani", "email": "zytel3301@gmail.com"}
+
+	// Every rule will be applied to the item of the data that the offset of rule is pointing to.
+	// So if you have a field "email": "omitempty,required,email", the validator will apply these
+	// rules to offset of email in user data
+	rules := map[string]string{"name": "required,min=8,max=32", "email": "omitempty,required,email"}
+
+	// ValidateMap will return map[string]error.
+	// The offset of every item in errs is the name of invalid field and the value
+	// is the message of error. If there was no error, ValidateMap method will
+	// return an EMPTY map of errors, not nil. If you want to check that
+	// if there was an error or not, you must check the length of the return value
+	errs := validate.ValidateMap(user, rules)
+
+	if len(errs) > 0 {
+		fmt.Println(errs)
+		// The user is invalid
+	}
+
+	// The user is valid
+}

--- a/_examples/map-validation/main.go
+++ b/_examples/map-validation/main.go
@@ -19,7 +19,7 @@ func validateMap() {
 	// Every rule will be applied to the item of the data that the offset of rule is pointing to.
 	// So if you have a field "email": "omitempty,required,email", the validator will apply these
 	// rules to offset of email in user data
-	rules := map[string]string{"name": "required,min=8,max=32", "email": "omitempty,required,email"}
+	rules := map[string]interface{}{"name": "required,min=8,max=32", "email": "omitempty,required,email"}
 
 	// ValidateMap will return map[string]error.
 	// The offset of every item in errs is the name of invalid field and the value

--- a/_examples/map-validation/main.go
+++ b/_examples/map-validation/main.go
@@ -11,6 +11,7 @@ func main() {
 	validate = validator.New()
 
 	validateMap()
+	validateNestedMap()
 }
 
 func validateMap() {
@@ -34,4 +35,39 @@ func validateMap() {
 	}
 
 	// The user is valid
+}
+
+func validateNestedMap() {
+
+	data := map[string]interface{}{
+		"name":  "Arshiya Kiani",
+		"email": "zytel3301@gmail.com",
+		"details": map[string]interface{}{
+			"family_members": map[string]interface{}{
+				"father_name": "Micheal",
+				"mother_name": "Hannah",
+			},
+			"salary": "1000",
+		},
+	}
+
+	// Rules must be set as the structure as the data itself. If you want to dive into the
+	// map, just declare its rules as a map
+	rules := map[string]interface{}{
+		"name":  "min=4,max=32",
+		"email": "required,email",
+		"details": map[string]interface{}{
+			"family_members": map[string]interface{}{
+				"father_name": "required,min=4,max=32",
+				"mother_name": "required,min=4,max=32",
+			},
+			"salary": "number",
+		},
+	}
+
+	if len(validate.ValidateMap(data, rules)) == 0 {
+		// Data is valid
+	}
+
+	// Data is invalid
 }

--- a/validator_instance.go
+++ b/validator_instance.go
@@ -153,6 +153,8 @@ func (v Validate) ValidateMapCtx(ctx context.Context, data map[string]interface{
 			if len(err) > 0 {
 				errs[field] = err
 			}
+		} else if reflect.ValueOf(rule).Kind() == reflect.Map {
+			errs[field] = errors.New("The field: '" + field + "' is not a map to dive")
 		} else {
 			err := v.VarCtx(ctx, data[field], rule.(string))
 			if err != nil {
@@ -165,7 +167,7 @@ func (v Validate) ValidateMapCtx(ctx context.Context, data map[string]interface{
 
 // ValidateMap validates map data form a map of tags
 func (v *Validate) ValidateMap(data map[string]interface{}, rules map[string]interface{}) map[string]interface{} {
-	return v.ValidateMapCtx(context.Background(),data,rules)
+	return v.ValidateMapCtx(context.Background(), data, rules)
 }
 
 // RegisterTagNameFunc registers a function to get alternate names for StructFields.

--- a/validator_instance.go
+++ b/validator_instance.go
@@ -156,6 +156,11 @@ func (v *Validate) ValidateMapCtx(ctx context.Context, data map[string]interface
 	return errs
 }
 
+// ValidateMap validates map data form a map of tags
+func (v *Validate) ValidateMap(data map[string]interface{}, rules map[string]string) map[string]error {
+	return v.ValidateMapCtx(context.Background(),data,rules)
+}
+
 // RegisterTagNameFunc registers a function to get alternate names for StructFields.
 //
 // eg. to use the names which have been specified for JSON representations of structs, rather than normal Go field names:

--- a/validator_instance.go
+++ b/validator_instance.go
@@ -164,7 +164,7 @@ func (v Validate) ValidateMapCtx(ctx context.Context, data map[string]interface{
 }
 
 // ValidateMap validates map data form a map of tags
-func (v *Validate) ValidateMap(data map[string]interface{}, rules map[string]string) map[string]error {
+func (v *Validate) ValidateMap(data map[string]interface{}, rules map[string]interface{}) map[string]interface{} {
 	return v.ValidateMapCtx(context.Background(),data,rules)
 }
 

--- a/validator_instance.go
+++ b/validator_instance.go
@@ -143,6 +143,19 @@ func (v *Validate) SetTagName(name string) {
 	v.tagName = name
 }
 
+// ValidateMapCtx validates a map using a map of validation rules and allows passing of contextual
+// validation validation information via context.Context.
+func (v *Validate) ValidateMapCtx(ctx context.Context, data map[string]interface{}, rules map[string]string) map[string]error {
+	errs := make(map[string]error)
+	for field, rule := range rules {
+		err := v.VarCtx(ctx, data[field], rule)
+		if err != nil {
+			errs[field] = err
+		}
+	}
+	return errs
+}
+
 // RegisterTagNameFunc registers a function to get alternate names for StructFields.
 //
 // eg. to use the names which have been specified for JSON representations of structs, rather than normal Go field names:


### PR DESCRIPTION
Add ability to validate map data based on map validation rules.
In some frameworks like kataras/iris, they return a map of form values. 
So it is hard to validate data that is not in struct form. So we can easily provide the data
itself and validation rules in form of map to have an easier data validation

@go-playground/admins