### PR TITLE
Add BIC ISO format validator

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -190,6 +190,7 @@ var (
 		"iso3166_1_alpha3":        isIso3166Alpha3,
 		"iso3166_1_alpha_numeric": isIso3166AlphaNumeric,
 		"bcp47_language_tag":      isBCP47LanguageTag,
+		"bic":                     isIsoBicFormat,
 	}
 )
 
@@ -2299,4 +2300,15 @@ func isBCP47LanguageTag(fl FieldLevel) bool {
 	}
 
 	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
+}
+
+// isIsoBicFormat is the validation function for validating if the current field's value is a valid Business Identifier Code (SWIFT code), defined in ISO 9362
+func isIsoBicFormat(fl FieldLevel) bool {
+	bicString := fl.Field().String()
+
+	if !bicRegex.MatchString(bicString) {
+		return false
+	}
+
+	return true
 }

--- a/doc.go
+++ b/doc.go
@@ -1228,6 +1228,13 @@ More information on https://pkg.go.dev/golang.org/x/text/language
 
 	Usage: bcp47_language_tag
 
+BIC (SWIFT code)
+
+This validates that a string value is a valid Business Identifier Code (SWIFT code), defined in ISO 9362.
+More information on https://www.iso.org/standard/60390.html
+
+	Usage: bic
+
 TimeZone
 
 This validates that a string value is a valid time zone based on the time zone database present on the system.

--- a/regexes.go
+++ b/regexes.go
@@ -49,6 +49,7 @@ const (
 	hTMLEncodedRegexString           = `&#[x]?([0-9a-fA-F]{2})|(&gt)|(&lt)|(&quot)|(&amp)+[;]?`
 	hTMLRegexString                  = `<[/]?([a-zA-Z]+).*?>`
 	splitParamsRegexString           = `'[^']*'|\S+`
+	bicRegexString                   = `^[A-Za-z]{6}[A-Za-z0-9]{2}([A-Za-z0-9]{3})?$`
 )
 
 var (
@@ -98,4 +99,5 @@ var (
 	hTMLEncodedRegex           = regexp.MustCompile(hTMLEncodedRegexString)
 	hTMLRegex                  = regexp.MustCompile(hTMLRegexString)
 	splitParamsRegex           = regexp.MustCompile(splitParamsRegexString)
+	bicRegex                   = regexp.MustCompile(bicRegexString)
 )

--- a/validator_test.go
+++ b/validator_test.go
@@ -11201,3 +11201,44 @@ func TestBCP47LanguageTagValidation(t *testing.T) {
 		_ = validate.Var(2, "bcp47_language_tag")
 	}, "Bad field type int")
 }
+
+func TestBicIsoFormatValidation(t *testing.T) {
+	tests := []struct {
+		value    string `validate:"bic"`
+		tag      string
+		expected bool
+	}{
+		{"SBICKEN1345", "bic", true},
+		{"SBICKEN1", "bic", true},
+		{"SBICKENY", "bic", true},
+		{"SBICKEN1YYP", "bic", true},
+		{"SBIC23NXXX", "bic", false},
+		{"S23CKENXXXX", "bic", false},
+		{"SBICKENXX", "bic", false},
+		{"SBICKENXX9", "bic", false},
+		{"SBICKEN13458", "bic", false},
+		{"SBICKEN", "bic", false},
+	}
+
+	validate := New()
+
+	for i, test := range tests {
+
+		errs := validate.Var(test.value, test.tag)
+
+		if test.expected {
+			if !IsEqual(errs, nil) {
+				t.Fatalf("Index: %d bic failed Error: %s", i, errs)
+			}
+		} else {
+			if IsEqual(errs, nil) {
+				t.Fatalf("Index: %d bic failed Error: %s", i, errs)
+			} else {
+				val := getError(errs, "", "")
+				if val.Tag() != "bic" {
+					t.Fatalf("Index: %d bic failed Error: %s", i, errs)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Fixes Or Enhances


**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Change details:
 - Add BIC (SWIFT code) validation based on [ISO 9362](https://en.wikipedia.org/wiki/ISO_9362)

@go-playground/admins