### PR TITLE
Fix map diving validation

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -227,7 +227,7 @@ func (v *validate) traverseField(ctx context.Context, parent reflect.Value, curr
 		}
 	}
 
-	if !ct.hasTag {
+	if ct == nil || !ct.hasTag {
 		return
 	}
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -3285,6 +3285,21 @@ func TestMapDiveValidation(t *testing.T) {
 	s := fmt.Sprint(errs.Error())
 	NotEqual(t, s, "")
 
+	type TestMapInterface struct {
+		Errs map[int]interface{} `validate:"dive"`
+	}
+
+	mit := map[int]interface{}{0: Inner{"ok"}, 1: Inner{""}, 3: nil, 5: "string", 6: 33}
+
+	msi := &TestMapInterface{
+		Errs: mit,
+	}
+
+	errs = validate.Struct(msi)
+	NotEqual(t, errs, nil)
+	Equal(t, len(errs.(ValidationErrors)), 1)
+	AssertError(t, errs, "TestMapInterface.Errs[1].Name", "TestMapInterface.Errs[1].Name", "Name", "Name", "required")
+
 	type TestMapTimeStruct struct {
 		Errs map[int]*time.Time `validate:"gt=0,dive,required"`
 	}


### PR DESCRIPTION
## Fixes Or Enhances
Attempt to fix map dive validation fixes #789. I think this also fixes #686 

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers