### PR TITLE
enhancement: add id translations for some tag

### DIFF
--- a/translations/id/id.go
+++ b/translations/id/id.go
@@ -16,7 +16,6 @@ import (
 // RegisterDefaultTranslations registers a set of default translations
 // for all built in tag's in validator; you may add your own as desired.
 func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (err error) {
-
 	translations := []struct {
 		tag             string
 		translation     string
@@ -32,7 +31,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		{
 			tag: "len",
 			customRegisFunc: func(ut ut.Translator) (err error) {
-
 				if err = ut.Add("len-string", "panjang {0} harus {1}", false); err != nil {
 					return
 				}
@@ -61,10 +59,8 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 				}
 
 				return
-
 			},
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				var err error
 				var t string
 
@@ -123,7 +119,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		{
 			tag: "min",
 			customRegisFunc: func(ut ut.Translator) (err error) {
-
 				if err = ut.Add("min-string", "panjang minimal {0} adalah {1}", false); err != nil {
 					return
 				}
@@ -152,10 +147,8 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 				}
 
 				return
-
 			},
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				var err error
 				var t string
 
@@ -214,7 +207,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		{
 			tag: "max",
 			customRegisFunc: func(ut ut.Translator) (err error) {
-
 				if err = ut.Add("max-string", "panjang maksimal {0} adalah {1}", false); err != nil {
 					return
 				}
@@ -243,10 +235,8 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 				}
 
 				return
-
 			},
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				var err error
 				var t string
 
@@ -307,7 +297,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0} tidak sama dengan {1}",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					fmt.Printf("warning: error translating FieldError: %#v", fe)
@@ -322,7 +311,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0} tidak sama dengan {1}",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					fmt.Printf("warning: error translating FieldError: %#v", fe)
@@ -335,7 +323,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		{
 			tag: "lt",
 			customRegisFunc: func(ut ut.Translator) (err error) {
-
 				if err = ut.Add("lt-string", "panjang {0} harus kurang dari {1}", false); err != nil {
 					return
 				}
@@ -369,10 +356,8 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 				}
 
 				return
-
 			},
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				var err error
 				var t string
 				var f64 float64
@@ -380,7 +365,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 				var kind reflect.Kind
 
 				fn := func() (err error) {
-
 					if idx := strings.Index(fe.Param(), "."); idx != -1 {
 						digits = uint64(len(fe.Param()[idx+1:]))
 					}
@@ -456,7 +440,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		{
 			tag: "lte",
 			customRegisFunc: func(ut ut.Translator) (err error) {
-
 				if err = ut.Add("lte-string", "panjang maksimal {0} adalah {1}", false); err != nil {
 					return
 				}
@@ -492,7 +475,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 				return
 			},
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				var err error
 				var t string
 				var f64 float64
@@ -500,7 +482,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 				var kind reflect.Kind
 
 				fn := func() (err error) {
-
 					if idx := strings.Index(fe.Param(), "."); idx != -1 {
 						digits = uint64(len(fe.Param()[idx+1:]))
 					}
@@ -576,7 +557,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		{
 			tag: "gt",
 			customRegisFunc: func(ut ut.Translator) (err error) {
-
 				if err = ut.Add("gt-string", "panjang {0} harus lebih dari {1}", false); err != nil {
 					return
 				}
@@ -612,7 +592,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 				return
 			},
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				var err error
 				var t string
 				var f64 float64
@@ -620,7 +599,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 				var kind reflect.Kind
 
 				fn := func() (err error) {
-
 					if idx := strings.Index(fe.Param(), "."); idx != -1 {
 						digits = uint64(len(fe.Param()[idx+1:]))
 					}
@@ -696,7 +674,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		{
 			tag: "gte",
 			customRegisFunc: func(ut ut.Translator) (err error) {
-
 				if err = ut.Add("gte-string", "panjang minimal {0} adalah {1}", false); err != nil {
 					return
 				}
@@ -732,7 +709,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 				return
 			},
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				var err error
 				var t string
 				var f64 float64
@@ -740,7 +716,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 				var kind reflect.Kind
 
 				fn := func() (err error) {
-
 					if idx := strings.Index(fe.Param(), "."); idx != -1 {
 						digits = uint64(len(fe.Param()[idx+1:]))
 					}
@@ -818,7 +793,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0} harus sama dengan {1}",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -833,7 +807,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0} harus sama dengan {1}",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -848,7 +821,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0} tidak sama dengan {1}",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -863,7 +835,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0} harus lebih besar dari {1}",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -878,7 +849,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0} harus lebih besar dari atau sama dengan {1}",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -893,7 +863,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0} harus kurang dari {1}",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -908,7 +877,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0} harus kurang dari atau sama dengan {1}",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -923,7 +891,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0} tidak sama dengan {1}",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -938,7 +905,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0} harus lebih besar dari {1}",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -953,7 +919,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0} harus lebih besar dari atau sama dengan {1}",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -968,7 +933,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0} harus kurang dari {1}",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -983,7 +947,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0} harus kurang dari atau sama dengan {1}",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -1044,6 +1007,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "e164",
+			translation: "{0} harus berupa nomor telepon dengan format E.164 yang valid",
+			override:    false,
+		},
+		{
 			tag:         "email",
 			translation: "{0} harus berupa alamat email yang valid",
 			override:    false,
@@ -1068,7 +1036,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0} harus berisi teks '{1}'",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -1083,7 +1050,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0} harus berisi setidaknya salah satu karakter berikut '{1}'",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -1098,7 +1064,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0} tidak boleh berisi teks '{1}'",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -1113,7 +1078,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0} tidak boleh berisi salah satu karakter berikut '{1}'",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -1128,7 +1092,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0} tidak boleh berisi '{1}'",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -1275,22 +1238,27 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		},
 		{
 			tag:         "ip4_addr",
-			translation: "{0} harus berupa alamat IPv4 yang dapat diatasi",
+			translation: "{0} harus berupa alamat IPv4 yang dapat dipecahkan",
 			override:    false,
 		},
 		{
 			tag:         "ip6_addr",
-			translation: "{0} harus berupa alamat IPv6 yang dapat diatasi",
+			translation: "{0} harus berupa alamat IPv6 yang dapat dipecahkan",
 			override:    false,
 		},
 		{
 			tag:         "unix_addr",
-			translation: "{0} harus berupa alamat UNIX yang dapat diatasi",
+			translation: "{0} harus berupa alamat UNIX yang dapat dipecahkan",
 			override:    false,
 		},
 		{
 			tag:         "mac",
 			translation: "{0} harus berisi alamat MAC yang valid",
+			override:    false,
+		},
+		{
+			tag:         "unique",
+			translation: "{0} harus berisi nilai yang unik",
 			override:    false,
 		},
 		{
@@ -1311,22 +1279,78 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 				return s
 			},
 		},
+		{
+			tag:         "json",
+			translation: "{0} harus berupa string json yang valid",
+			override:    false,
+		},
+		{
+			tag:         "jwt",
+			translation: "{0} harus berupa string jwt yang valid",
+			override:    false,
+		},
+		{
+			tag:         "lowercase",
+			translation: "{0} harus berupa string huruf kecil",
+			override:    false,
+		},
+		{
+			tag:         "uppercase",
+			translation: "{0} harus berupa string huruf besar",
+			override:    false,
+		},
+		{
+			tag:         "datetime",
+			translation: "{0} tidak sesuai dengan format {1}",
+			override:    false,
+			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
+				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
+				if err != nil {
+					log.Printf("warning: error translating FieldError: %#v", fe)
+					return fe.(error).Error()
+				}
+
+				return t
+			},
+		},
+		{
+			tag:         "postcode_iso3166_alpha2",
+			translation: "{0} tidak sesuai dengan format kode pos dari negara {1}",
+			override:    false,
+			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
+				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
+				if err != nil {
+					log.Printf("warning: error translating FieldError: %#v", fe)
+					return fe.(error).Error()
+				}
+
+				return t
+			},
+		},
+		{
+			tag:         "postcode_iso3166_alpha2_field",
+			translation: "{0} tidak sesuai dengan format kode pos dari negara di {1}",
+			override:    false,
+			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
+				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
+				if err != nil {
+					log.Printf("warning: error translating FieldError: %#v", fe)
+					return fe.(error).Error()
+				}
+
+				return t
+			},
+		},
 	}
 
 	for _, t := range translations {
 
 		if t.customTransFunc != nil && t.customRegisFunc != nil {
-
 			err = v.RegisterTranslation(t.tag, trans, t.customRegisFunc, t.customTransFunc)
-
 		} else if t.customTransFunc != nil && t.customRegisFunc == nil {
-
 			err = v.RegisterTranslation(t.tag, trans, registrationFunc(t.tag, t.translation, t.override), t.customTransFunc)
-
 		} else if t.customTransFunc == nil && t.customRegisFunc != nil {
-
 			err = v.RegisterTranslation(t.tag, trans, t.customRegisFunc, translateFunc)
-
 		} else {
 			err = v.RegisterTranslation(t.tag, trans, registrationFunc(t.tag, t.translation, t.override), translateFunc)
 		}
@@ -1340,21 +1364,16 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 }
 
 func registrationFunc(tag string, translation string, override bool) validator.RegisterTranslationsFunc {
-
 	return func(ut ut.Translator) (err error) {
-
 		if err = ut.Add(tag, translation, override); err != nil {
 			return
 		}
 
 		return
-
 	}
-
 }
 
 func translateFunc(ut ut.Translator, fe validator.FieldError) string {
-
 	t, err := ut.T(fe.Tag(), fe.Field())
 	if err != nil {
 		log.Printf("warning: error translating FieldError: %#v", fe)

--- a/translations/id/id_test.go
+++ b/translations/id/id_test.go
@@ -4,14 +4,13 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/go-playground/assert/v2"
 	indonesia "github.com/go-playground/locales/id"
 	ut "github.com/go-playground/universal-translator"
-	. "github.com/go-playground/assert/v2"
 	"github.com/go-playground/validator/v10"
 )
 
 func TestTranslations(t *testing.T) {
-
 	idn := indonesia.New()
 	uni := ut.New(idn, idn)
 	trans, _ := uni.GetTranslator("id")
@@ -32,112 +31,123 @@ func TestTranslations(t *testing.T) {
 
 	type Test struct {
 		Inner             Inner
-		RequiredString    string    `validate:"required"`
-		RequiredNumber    int       `validate:"required"`
-		RequiredMultiple  []string  `validate:"required"`
-		LenString         string    `validate:"len=1"`
-		LenNumber         float64   `validate:"len=1113.00"`
-		LenMultiple       []string  `validate:"len=7"`
-		MinString         string    `validate:"min=1"`
-		MinNumber         float64   `validate:"min=1113.00"`
-		MinMultiple       []string  `validate:"min=7"`
-		MaxString         string    `validate:"max=3"`
-		MaxNumber         float64   `validate:"max=1113.00"`
-		MaxMultiple       []string  `validate:"max=7"`
-		EqString          string    `validate:"eq=3"`
-		EqNumber          float64   `validate:"eq=2.33"`
-		EqMultiple        []string  `validate:"eq=7"`
-		NeString          string    `validate:"ne="`
-		NeNumber          float64   `validate:"ne=0.00"`
-		NeMultiple        []string  `validate:"ne=0"`
-		LtString          string    `validate:"lt=3"`
-		LtNumber          float64   `validate:"lt=5.56"`
-		LtMultiple        []string  `validate:"lt=2"`
-		LtTime            time.Time `validate:"lt"`
-		LteString         string    `validate:"lte=3"`
-		LteNumber         float64   `validate:"lte=5.56"`
-		LteMultiple       []string  `validate:"lte=2"`
-		LteTime           time.Time `validate:"lte"`
-		GtString          string    `validate:"gt=3"`
-		GtNumber          float64   `validate:"gt=5.56"`
-		GtMultiple        []string  `validate:"gt=2"`
-		GtTime            time.Time `validate:"gt"`
-		GteString         string    `validate:"gte=3"`
-		GteNumber         float64   `validate:"gte=5.56"`
-		GteMultiple       []string  `validate:"gte=2"`
-		GteTime           time.Time `validate:"gte"`
-		EqFieldString     string    `validate:"eqfield=MaxString"`
-		EqCSFieldString   string    `validate:"eqcsfield=Inner.EqCSFieldString"`
-		NeCSFieldString   string    `validate:"necsfield=Inner.NeCSFieldString"`
-		GtCSFieldString   string    `validate:"gtcsfield=Inner.GtCSFieldString"`
-		GteCSFieldString  string    `validate:"gtecsfield=Inner.GteCSFieldString"`
-		LtCSFieldString   string    `validate:"ltcsfield=Inner.LtCSFieldString"`
-		LteCSFieldString  string    `validate:"ltecsfield=Inner.LteCSFieldString"`
-		NeFieldString     string    `validate:"nefield=EqFieldString"`
-		GtFieldString     string    `validate:"gtfield=MaxString"`
-		GteFieldString    string    `validate:"gtefield=MaxString"`
-		LtFieldString     string    `validate:"ltfield=MaxString"`
-		LteFieldString    string    `validate:"ltefield=MaxString"`
-		AlphaString       string    `validate:"alpha"`
-		AlphanumString    string    `validate:"alphanum"`
-		NumericString     string    `validate:"numeric"`
-		NumberString      string    `validate:"number"`
-		HexadecimalString string    `validate:"hexadecimal"`
-		HexColorString    string    `validate:"hexcolor"`
-		RGBColorString    string    `validate:"rgb"`
-		RGBAColorString   string    `validate:"rgba"`
-		HSLColorString    string    `validate:"hsl"`
-		HSLAColorString   string    `validate:"hsla"`
-		Email             string    `validate:"email"`
-		URL               string    `validate:"url"`
-		URI               string    `validate:"uri"`
-		Base64            string    `validate:"base64"`
-		Contains          string    `validate:"contains=tujuan"`
-		ContainsAny       string    `validate:"containsany=!@#$"`
-		Excludes          string    `validate:"excludes=text"`
-		ExcludesAll       string    `validate:"excludesall=!@#$"`
-		ExcludesRune      string    `validate:"excludesrune=☻"`
-		ISBN              string    `validate:"isbn"`
-		ISBN10            string    `validate:"isbn10"`
-		ISBN13            string    `validate:"isbn13"`
-		UUID              string    `validate:"uuid"`
-		UUID3             string    `validate:"uuid3"`
-		UUID4             string    `validate:"uuid4"`
-		UUID5             string    `validate:"uuid5"`
-		ASCII             string    `validate:"ascii"`
-		PrintableASCII    string    `validate:"printascii"`
-		MultiByte         string    `validate:"multibyte"`
-		DataURI           string    `validate:"datauri"`
-		Latitude          string    `validate:"latitude"`
-		Longitude         string    `validate:"longitude"`
-		SSN               string    `validate:"ssn"`
-		IP                string    `validate:"ip"`
-		IPv4              string    `validate:"ipv4"`
-		IPv6              string    `validate:"ipv6"`
-		CIDR              string    `validate:"cidr"`
-		CIDRv4            string    `validate:"cidrv4"`
-		CIDRv6            string    `validate:"cidrv6"`
-		TCPAddr           string    `validate:"tcp_addr"`
-		TCPAddrv4         string    `validate:"tcp4_addr"`
-		TCPAddrv6         string    `validate:"tcp6_addr"`
-		UDPAddr           string    `validate:"udp_addr"`
-		UDPAddrv4         string    `validate:"udp4_addr"`
-		UDPAddrv6         string    `validate:"udp6_addr"`
-		IPAddr            string    `validate:"ip_addr"`
-		IPAddrv4          string    `validate:"ip4_addr"`
-		IPAddrv6          string    `validate:"ip6_addr"`
-		UinxAddr          string    `validate:"unix_addr"` // can't fail from within Go's net package currently, but maybe in the future
-		MAC               string    `validate:"mac"`
-		IsColor           string    `validate:"iscolor"`
-		StrPtrMinLen      *string   `validate:"min=10"`
-		StrPtrMaxLen      *string   `validate:"max=1"`
-		StrPtrLen         *string   `validate:"len=2"`
-		StrPtrLt          *string   `validate:"lt=1"`
-		StrPtrLte         *string   `validate:"lte=1"`
-		StrPtrGt          *string   `validate:"gt=10"`
-		StrPtrGte         *string   `validate:"gte=10"`
-		OneOfString       string    `validate:"oneof=merah hijau"`
-		OneOfInt          int       `validate:"oneof=5 63"`
+		RequiredString    string            `validate:"required"`
+		RequiredNumber    int               `validate:"required"`
+		RequiredMultiple  []string          `validate:"required"`
+		LenString         string            `validate:"len=1"`
+		LenNumber         float64           `validate:"len=1113.00"`
+		LenMultiple       []string          `validate:"len=7"`
+		MinString         string            `validate:"min=1"`
+		MinNumber         float64           `validate:"min=1113.00"`
+		MinMultiple       []string          `validate:"min=7"`
+		MaxString         string            `validate:"max=3"`
+		MaxNumber         float64           `validate:"max=1113.00"`
+		MaxMultiple       []string          `validate:"max=7"`
+		EqString          string            `validate:"eq=3"`
+		EqNumber          float64           `validate:"eq=2.33"`
+		EqMultiple        []string          `validate:"eq=7"`
+		NeString          string            `validate:"ne="`
+		NeNumber          float64           `validate:"ne=0.00"`
+		NeMultiple        []string          `validate:"ne=0"`
+		LtString          string            `validate:"lt=3"`
+		LtNumber          float64           `validate:"lt=5.56"`
+		LtMultiple        []string          `validate:"lt=2"`
+		LtTime            time.Time         `validate:"lt"`
+		LteString         string            `validate:"lte=3"`
+		LteNumber         float64           `validate:"lte=5.56"`
+		LteMultiple       []string          `validate:"lte=2"`
+		LteTime           time.Time         `validate:"lte"`
+		GtString          string            `validate:"gt=3"`
+		GtNumber          float64           `validate:"gt=5.56"`
+		GtMultiple        []string          `validate:"gt=2"`
+		GtTime            time.Time         `validate:"gt"`
+		GteString         string            `validate:"gte=3"`
+		GteNumber         float64           `validate:"gte=5.56"`
+		GteMultiple       []string          `validate:"gte=2"`
+		GteTime           time.Time         `validate:"gte"`
+		EqFieldString     string            `validate:"eqfield=MaxString"`
+		EqCSFieldString   string            `validate:"eqcsfield=Inner.EqCSFieldString"`
+		NeCSFieldString   string            `validate:"necsfield=Inner.NeCSFieldString"`
+		GtCSFieldString   string            `validate:"gtcsfield=Inner.GtCSFieldString"`
+		GteCSFieldString  string            `validate:"gtecsfield=Inner.GteCSFieldString"`
+		LtCSFieldString   string            `validate:"ltcsfield=Inner.LtCSFieldString"`
+		LteCSFieldString  string            `validate:"ltecsfield=Inner.LteCSFieldString"`
+		NeFieldString     string            `validate:"nefield=EqFieldString"`
+		GtFieldString     string            `validate:"gtfield=MaxString"`
+		GteFieldString    string            `validate:"gtefield=MaxString"`
+		LtFieldString     string            `validate:"ltfield=MaxString"`
+		LteFieldString    string            `validate:"ltefield=MaxString"`
+		AlphaString       string            `validate:"alpha"`
+		AlphanumString    string            `validate:"alphanum"`
+		NumericString     string            `validate:"numeric"`
+		NumberString      string            `validate:"number"`
+		HexadecimalString string            `validate:"hexadecimal"`
+		HexColorString    string            `validate:"hexcolor"`
+		RGBColorString    string            `validate:"rgb"`
+		RGBAColorString   string            `validate:"rgba"`
+		HSLColorString    string            `validate:"hsl"`
+		HSLAColorString   string            `validate:"hsla"`
+		Email             string            `validate:"email"`
+		URL               string            `validate:"url"`
+		URI               string            `validate:"uri"`
+		Base64            string            `validate:"base64"`
+		Contains          string            `validate:"contains=tujuan"`
+		ContainsAny       string            `validate:"containsany=!@#$"`
+		Excludes          string            `validate:"excludes=text"`
+		ExcludesAll       string            `validate:"excludesall=!@#$"`
+		ExcludesRune      string            `validate:"excludesrune=☻"`
+		ISBN              string            `validate:"isbn"`
+		ISBN10            string            `validate:"isbn10"`
+		ISBN13            string            `validate:"isbn13"`
+		UUID              string            `validate:"uuid"`
+		UUID3             string            `validate:"uuid3"`
+		UUID4             string            `validate:"uuid4"`
+		UUID5             string            `validate:"uuid5"`
+		ASCII             string            `validate:"ascii"`
+		PrintableASCII    string            `validate:"printascii"`
+		MultiByte         string            `validate:"multibyte"`
+		DataURI           string            `validate:"datauri"`
+		Latitude          string            `validate:"latitude"`
+		Longitude         string            `validate:"longitude"`
+		SSN               string            `validate:"ssn"`
+		IP                string            `validate:"ip"`
+		IPv4              string            `validate:"ipv4"`
+		IPv6              string            `validate:"ipv6"`
+		CIDR              string            `validate:"cidr"`
+		CIDRv4            string            `validate:"cidrv4"`
+		CIDRv6            string            `validate:"cidrv6"`
+		TCPAddr           string            `validate:"tcp_addr"`
+		TCPAddrv4         string            `validate:"tcp4_addr"`
+		TCPAddrv6         string            `validate:"tcp6_addr"`
+		UDPAddr           string            `validate:"udp_addr"`
+		UDPAddrv4         string            `validate:"udp4_addr"`
+		UDPAddrv6         string            `validate:"udp6_addr"`
+		IPAddr            string            `validate:"ip_addr"`
+		IPAddrv4          string            `validate:"ip4_addr"`
+		IPAddrv6          string            `validate:"ip6_addr"`
+		UinxAddr          string            `validate:"unix_addr"` // can't fail from within Go's net package currently, but maybe in the future
+		MAC               string            `validate:"mac"`
+		IsColor           string            `validate:"iscolor"`
+		StrPtrMinLen      *string           `validate:"min=10"`
+		StrPtrMaxLen      *string           `validate:"max=1"`
+		StrPtrLen         *string           `validate:"len=2"`
+		StrPtrLt          *string           `validate:"lt=1"`
+		StrPtrLte         *string           `validate:"lte=1"`
+		StrPtrGt          *string           `validate:"gt=10"`
+		StrPtrGte         *string           `validate:"gte=10"`
+		OneOfString       string            `validate:"oneof=merah hijau"`
+		OneOfInt          int               `validate:"oneof=5 63"`
+		UniqueSlice       []string          `validate:"unique"`
+		UniqueArray       [3]string         `validate:"unique"`
+		UniqueMap         map[string]string `validate:"unique"`
+		JSONString        string            `validate:"json"`
+		JWTString         string            `validate:"jwt"`
+		LowercaseString   string            `validate:"lowercase"`
+		UppercaseString   string            `validate:"uppercase"`
+		Datetime          string            `validate:"datetime=2006-01-02"`
+		PostCode          string            `validate:"postcode_iso3166_alpha2=SG"`
+		PostCodeCountry   string
+		PostCodeByField   string `validate:"postcode_iso3166_alpha2_field=PostCodeCountry"`
 	}
 
 	var test Test
@@ -180,9 +190,16 @@ func TestTranslations(t *testing.T) {
 
 	test.MultiByte = "1234feerf"
 
+	test.LowercaseString = "ABCDEFG"
+	test.UppercaseString = "abcdefg"
+
 	s := "toolong"
 	test.StrPtrMaxLen = &s
 	test.StrPtrLen = &s
+
+	test.UniqueSlice = []string{"1234", "1234"}
+	test.UniqueMap = map[string]string{"key1": "1234", "key2": "1234"}
+	test.Datetime = "2008-Feb-01"
 
 	err = validate.Struct(test)
 	NotEqual(t, err, nil)
@@ -208,11 +225,11 @@ func TestTranslations(t *testing.T) {
 		},
 		{
 			ns:       "Test.IPAddrv4",
-			expected: "IPAddrv4 harus berupa alamat IPv4 yang dapat diatasi",
+			expected: "IPAddrv4 harus berupa alamat IPv4 yang dapat dipecahkan",
 		},
 		{
 			ns:       "Test.IPAddrv6",
-			expected: "IPAddrv6 harus berupa alamat IPv6 yang dapat diatasi",
+			expected: "IPAddrv6 harus berupa alamat IPv6 yang dapat dipecahkan",
 		},
 		{
 			ns:       "Test.UDPAddr",
@@ -614,6 +631,46 @@ func TestTranslations(t *testing.T) {
 			ns:       "Test.OneOfInt",
 			expected: "OneOfInt harus berupa salah satu dari [5 63]",
 		},
+		{
+			ns:       "Test.UniqueSlice",
+			expected: "UniqueSlice harus berisi nilai yang unik",
+		},
+		{
+			ns:       "Test.UniqueArray",
+			expected: "UniqueArray harus berisi nilai yang unik",
+		},
+		{
+			ns:       "Test.UniqueMap",
+			expected: "UniqueMap harus berisi nilai yang unik",
+		},
+		{
+			ns:       "Test.JSONString",
+			expected: "JSONString harus berupa string json yang valid",
+		},
+		{
+			ns:       "Test.JWTString",
+			expected: "JWTString harus berupa string jwt yang valid",
+		},
+		{
+			ns:       "Test.LowercaseString",
+			expected: "LowercaseString harus berupa string huruf kecil",
+		},
+		{
+			ns:       "Test.UppercaseString",
+			expected: "UppercaseString harus berupa string huruf besar",
+		},
+		{
+			ns:       "Test.Datetime",
+			expected: "Datetime tidak sesuai dengan format 2006-01-02",
+		},
+		{
+			ns:       "Test.PostCode",
+			expected: "PostCode tidak sesuai dengan format kode pos dari negara SG",
+		},
+		{
+			ns:       "Test.PostCodeByField",
+			expected: "PostCodeByField tidak sesuai dengan format kode pos dari negara di PostCodeCountry",
+		},
 	}
 
 	for _, tt := range tests {
@@ -630,5 +687,4 @@ func TestTranslations(t *testing.T) {
 		NotEqual(t, fe, nil)
 		Equal(t, tt.expected, fe.Translate(trans))
 	}
-
 }


### PR DESCRIPTION
## Details
- add e164, unique, json, jwt, lowercase, uppercase, datetime, postcode_iso3166_alpha2, postcode_iso3166_alpha2_field
- update ip4_addr, ip6_addr, unix_addr
- remove some empty line to match with en.go (make it easier to compare for future translation)
- update the unit test

## Fixes Or Enhances
**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers