### PR TITLE
Updated `endsnotwith` description in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Baked-in Validations
 | contains | Contains |
 | containsany | Contains Any |
 | containsrune | Contains Rune |
-| endsnotwith | Ends With |
+| endsnotwith | Ends Not With |
 | endswith | Ends With |
 | excludes | Excludes |
 | excludesall | Excludes All |


### PR DESCRIPTION
In the strings section, `endsnotwith` has the same description as `endswith`.

## Fixes Or Enhances


**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.
_(Readme update - PR does not require tests.)_

@go-playground/validator-maintainers