### PR TITLE
Added ULID validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Baked-in Validations
 | uuid5 | Universally Unique Identifier UUID v5 |
 | uuid5_rfc4122 | Universally Unique Identifier UUID v5 RFC4122 |
 | uuid_rfc4122 | Universally Unique Identifier UUID RFC4122 |
+| ulid | Universally Unique Lexicographically Sortable Identifier ULID |
 
 ### Comparisons:
 | Tag | Description |

--- a/baked_in.go
+++ b/baked_in.go
@@ -148,6 +148,7 @@ var (
 		"uuid3_rfc4122":                 isUUID3RFC4122,
 		"uuid4_rfc4122":                 isUUID4RFC4122,
 		"uuid5_rfc4122":                 isUUID5RFC4122,
+		"ulid":                          isULID,
 		"ascii":                         isASCII,
 		"printascii":                    isPrintableASCII,
 		"multibyte":                     hasMultiByteCharacter,
@@ -496,6 +497,11 @@ func isUUID3RFC4122(fl FieldLevel) bool {
 // isUUIDRFC4122 is the validation function for validating if the field's value is a valid RFC4122 UUID of any version.
 func isUUIDRFC4122(fl FieldLevel) bool {
 	return uUIDRFC4122Regex.MatchString(fl.Field().String())
+}
+
+// isULID is the validation function for validating if the field's value is a valid ULID.
+func isULID(fl FieldLevel) bool {
+	return uLIDRegex.MatchString(fl.Field().String())
 }
 
 // isISBN is the validation function for validating if the field's value is a valid v10 or v13 ISBN.

--- a/doc.go
+++ b/doc.go
@@ -1007,6 +1007,12 @@ This validates that a string value contains a valid version 5 UUID.  Uppercase U
 
 	Usage: uuid5
 
+Universally Unique Lexicographically Sortable Identifier ULID
+
+This validates that a string value contains a valid ULID value.
+
+	Usage: ulid
+
 ASCII
 
 This validates that a string value contains only ASCII characters.

--- a/regexes.go
+++ b/regexes.go
@@ -29,6 +29,7 @@ const (
 	uUID4RFC4122RegexString          = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
 	uUID5RFC4122RegexString          = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-5[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
 	uUIDRFC4122RegexString           = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+	uLIDRegexString                  = "^[A-HJKMNP-TV-Z0-9]{26}$"
 	aSCIIRegexString                 = "^[\x00-\x7F]*$"
 	printableASCIIRegexString        = "^[\x20-\x7E]*$"
 	multibyteRegexString             = "[^\x00-\x7F]"
@@ -80,6 +81,7 @@ var (
 	uUID4RFC4122Regex          = regexp.MustCompile(uUID4RFC4122RegexString)
 	uUID5RFC4122Regex          = regexp.MustCompile(uUID5RFC4122RegexString)
 	uUIDRFC4122Regex           = regexp.MustCompile(uUIDRFC4122RegexString)
+	uLIDRegex                  = regexp.MustCompile(uLIDRegexString)
 	aSCIIRegex                 = regexp.MustCompile(aSCIIRegexString)
 	printableASCIIRegex        = regexp.MustCompile(printableASCIIRegexString)
 	multibyteRegex             = regexp.MustCompile(multibyteRegexString)

--- a/translations/en/en.go
+++ b/translations/en/en.go
@@ -1137,6 +1137,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "ulid",
+			translation: "{0} must be a valid ULID",
+			override:    false,
+		},
+		{
 			tag:         "ascii",
 			translation: "{0} must contain only ascii characters",
 			override:    false,

--- a/translations/en/en_test.go
+++ b/translations/en/en_test.go
@@ -103,6 +103,7 @@ func TestTranslations(t *testing.T) {
 		UUID3             string            `validate:"uuid3"`
 		UUID4             string            `validate:"uuid4"`
 		UUID5             string            `validate:"uuid5"`
+		ULID              string            `validate:"ulid"`
 		ASCII             string            `validate:"ascii"`
 		PrintableASCII    string            `validate:"printascii"`
 		MultiByte         string            `validate:"multibyte"`
@@ -322,6 +323,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.UUID5",
 			expected: "UUID5 must be a valid version 5 UUID",
+		},
+		{
+			ns:       "Test.ULID",
+			expected: "ULID must be a valid ULID",
 		},
 		{
 			ns:       "Test.ISBN",

--- a/translations/es/es.go
+++ b/translations/es/es.go
@@ -1179,6 +1179,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "ulid",
+			translation: "{0} debe ser un ULID válido",
+			override:    false,
+		},
+		{
 			tag:         "ascii",
 			translation: "{0} debe contener sólo caracteres ascii",
 			override:    false,

--- a/translations/es/es_test.go
+++ b/translations/es/es_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/go-playground/assert/v2"
 	spanish "github.com/go-playground/locales/es"
 	ut "github.com/go-playground/universal-translator"
-	. "github.com/go-playground/assert/v2"
 	"github.com/go-playground/validator/v10"
 )
 
@@ -104,6 +104,7 @@ func TestTranslations(t *testing.T) {
 		UUID3             string            `validate:"uuid3"`
 		UUID4             string            `validate:"uuid4"`
 		UUID5             string            `validate:"uuid5"`
+		ULID              string            `validate:"ulid"`
 		ASCII             string            `validate:"ascii"`
 		PrintableASCII    string            `validate:"printascii"`
 		MultiByte         string            `validate:"multibyte"`
@@ -311,6 +312,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.UUID5",
 			expected: "UUID5 debe ser una versión válida 5 UUID",
+		},
+		{
+			ns:       "Test.ULID",
+			expected: "ULID debe ser un ULID válido",
 		},
 		{
 			ns:       "Test.ISBN",

--- a/translations/fa/fa.go
+++ b/translations/fa/fa.go
@@ -1137,6 +1137,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "ulid",
+			translation: "{0} باید یک ULID معتبر باشد",
+			override:    false,
+		},
+		{
 			tag:         "ascii",
 			translation: "{0} باید فقط شامل کاراکترهای اسکی باشد",
 			override:    false,

--- a/translations/fa/fa_test.go
+++ b/translations/fa/fa_test.go
@@ -103,6 +103,7 @@ func TestTranslations(t *testing.T) {
 		UUID3             string            `validate:"uuid3"`
 		UUID4             string            `validate:"uuid4"`
 		UUID5             string            `validate:"uuid5"`
+		ULID              string            `validate:"ulid"`
 		ASCII             string            `validate:"ascii"`
 		PrintableASCII    string            `validate:"printascii"`
 		MultiByte         string            `validate:"multibyte"`
@@ -321,6 +322,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.UUID5",
 			expected: "UUID5 باید یک UUID نسخه 5 معتبر باشد",
+		},
+		{
+			ns:       "Test.ULID",
+			expected: "ULID باید یک ULID معتبر باشد",
 		},
 		{
 			ns:       "Test.ISBN",

--- a/translations/fr/fr.go
+++ b/translations/fr/fr.go
@@ -1174,6 +1174,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "ulid",
+			translation: "{0} doit être une ULID valide",
+			override:    false,
+		},
+		{
 			tag:         "ascii",
 			translation: "{0} ne doit contenir que des caractères ascii",
 			override:    false,

--- a/translations/fr/fr_test.go
+++ b/translations/fr/fr_test.go
@@ -104,6 +104,7 @@ func TestTranslations(t *testing.T) {
 		UUID3             string    `validate:"uuid3"`
 		UUID4             string    `validate:"uuid4"`
 		UUID5             string    `validate:"uuid5"`
+		ULID              string    `validate:"ulid"`
 		ASCII             string    `validate:"ascii"`
 		PrintableASCII    string    `validate:"printascii"`
 		MultiByte         string    `validate:"multibyte"`
@@ -305,6 +306,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.UUID5",
 			expected: "UUID5 doit être un UUID version 5 valid",
+		},
+		{
+			ns:       "Test.ULID",
+			expected: "ULID doit être une ULID valide",
 		},
 		{
 			ns:       "Test.ISBN",

--- a/translations/id/id.go
+++ b/translations/id/id.go
@@ -1174,6 +1174,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "ulid",
+			translation: "{0} harus berupa ULID yang valid",
+			override:    false,
+		},
+		{
 			tag:         "ascii",
 			translation: "{0} hanya boleh berisi karakter ascii",
 			override:    false,

--- a/translations/id/id_test.go
+++ b/translations/id/id_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/go-playground/assert/v2"
 	indonesia "github.com/go-playground/locales/id"
 	ut "github.com/go-playground/universal-translator"
-	. "github.com/go-playground/assert/v2"
 	"github.com/go-playground/validator/v10"
 )
 
@@ -104,6 +104,7 @@ func TestTranslations(t *testing.T) {
 		UUID3             string    `validate:"uuid3"`
 		UUID4             string    `validate:"uuid4"`
 		UUID5             string    `validate:"uuid5"`
+		ULID              string    `validate:"ulid"`
 		ASCII             string    `validate:"ascii"`
 		PrintableASCII    string    `validate:"printascii"`
 		MultiByte         string    `validate:"multibyte"`
@@ -305,6 +306,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.UUID5",
 			expected: "UUID5 harus berupa UUID versi 5 yang valid",
+		},
+		{
+			ns:       "Test.ULID",
+			expected: "ULID harus berupa ULID yang valid",
 		},
 		{
 			ns:       "Test.ISBN",

--- a/translations/ja/ja.go
+++ b/translations/ja/ja.go
@@ -1230,6 +1230,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "ulid",
+			translation: "{0}は正しいULIDでなければなりません",
+			override:    false,
+		},
+		{
 			tag:         "ascii",
 			translation: "{0}はASCII文字のみを含まなければなりません",
 			override:    false,

--- a/translations/ja/ja_test.go
+++ b/translations/ja/ja_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/go-playground/assert/v2"
 	ja_locale "github.com/go-playground/locales/ja"
 	ut "github.com/go-playground/universal-translator"
-	. "github.com/go-playground/assert/v2"
 	"github.com/go-playground/validator/v10"
 )
 
@@ -104,6 +104,7 @@ func TestTranslations(t *testing.T) {
 		UUID3             string    `validate:"uuid3"`
 		UUID4             string    `validate:"uuid4"`
 		UUID5             string    `validate:"uuid5"`
+		ULID              string    `validate:"ulid"`
 		ASCII             string    `validate:"ascii"`
 		PrintableASCII    string    `validate:"printascii"`
 		MultiByte         string    `validate:"multibyte"`
@@ -305,6 +306,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.UUID5",
 			expected: "UUID5はバージョンが5の正しいUUIDでなければなりません",
+		},
+		{
+			ns:       "Test.ULID",
+			expected: "ULIDは正しいULIDでなければなりません",
 		},
 		{
 			ns:       "Test.ISBN",

--- a/translations/nl/nl.go
+++ b/translations/nl/nl.go
@@ -1174,6 +1174,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "ulid",
+			translation: "{0} moet een geldige ULID zijn",
+			override:    false,
+		},
+		{
 			tag:         "ascii",
 			translation: "{0} mag alleen ascii karakters bevatten",
 			override:    false,

--- a/translations/nl/nl_test.go
+++ b/translations/nl/nl_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/go-playground/assert/v2"
 	english "github.com/go-playground/locales/en"
 	ut "github.com/go-playground/universal-translator"
-	. "github.com/go-playground/assert/v2"
 	"github.com/go-playground/validator/v10"
 )
 
@@ -104,6 +104,7 @@ func TestTranslations(t *testing.T) {
 		UUID3             string    `validate:"uuid3"`
 		UUID4             string    `validate:"uuid4"`
 		UUID5             string    `validate:"uuid5"`
+		ULID              string    `validate:"ulid"`
 		ASCII             string    `validate:"ascii"`
 		PrintableASCII    string    `validate:"printascii"`
 		MultiByte         string    `validate:"multibyte"`
@@ -305,6 +306,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.UUID5",
 			expected: "UUID5 moet een geldige versie 5 UUID zijn",
+		},
+		{
+			ns:       "Test.ULID",
+			expected: "ULID moet een geldige ULID zijn",
 		},
 		{
 			ns:       "Test.ISBN",

--- a/translations/pt/pt.go
+++ b/translations/pt/pt.go
@@ -1179,6 +1179,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "ulid",
+			translation: "{0} deve ser um ULID válido",
+			override:    false,
+		},
+		{
 			tag:         "ascii",
 			translation: "{0} deve conter apenas caracteres ascii",
 			override:    false,

--- a/translations/pt/pt_test.go
+++ b/translations/pt/pt_test.go
@@ -105,6 +105,7 @@ func TestTranslations(t *testing.T) {
 		UUID3             string            `validate:"uuid3"`
 		UUID4             string            `validate:"uuid4"`
 		UUID5             string            `validate:"uuid5"`
+		ULID              string            `validate:"ulid"`
 		ASCII             string            `validate:"ascii"`
 		PrintableASCII    string            `validate:"printascii"`
 		MultiByte         string            `validate:"multibyte"`
@@ -320,6 +321,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.UUID5",
 			expected: "UUID5 deve ser um UUID versão 5 válido",
+		},
+		{
+			ns:       "Test.ULID",
+			expected: "ULID deve ser um ULID válido",
 		},
 		{
 			ns:       "Test.ISBN",

--- a/translations/pt_BR/pt_BR.go
+++ b/translations/pt_BR/pt_BR.go
@@ -1174,6 +1174,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "ulid",
+			translation: "{0} deve ser uma ULID válida",
+			override:    false,
+		},
+		{
 			tag:         "ascii",
 			translation: "{0} deve conter apenas caracteres ascii",
 			override:    false,

--- a/translations/pt_BR/pt_BR_test.go
+++ b/translations/pt_BR/pt_BR_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/go-playground/assert/v2"
 	brazilian_portuguese "github.com/go-playground/locales/pt_BR"
 	ut "github.com/go-playground/universal-translator"
 	"github.com/go-playground/validator/v10"
-	. "github.com/go-playground/assert/v2"
 )
 
 func TestTranslations(t *testing.T) {
@@ -104,6 +104,7 @@ func TestTranslations(t *testing.T) {
 		UUID3             string    `validate:"uuid3"`
 		UUID4             string    `validate:"uuid4"`
 		UUID5             string    `validate:"uuid5"`
+		ULID              string    `validate:"ulid"`
 		ASCII             string    `validate:"ascii"`
 		PrintableASCII    string    `validate:"printascii"`
 		MultiByte         string    `validate:"multibyte"`
@@ -305,6 +306,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.UUID5",
 			expected: "UUID5 deve ser um UUID versão 5 válido",
+		},
+		{
+			ns:       "Test.ULID",
+			expected: "ULID deve ser uma ULID válida",
 		},
 		{
 			ns:       "Test.ISBN",

--- a/translations/ru/ru.go
+++ b/translations/ru/ru.go
@@ -1292,6 +1292,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "ulid",
+			translation: "{0} должен быть ULID",
+			override:    false,
+		},
+		{
 			tag:         "ascii",
 			translation: "{0} должен содержать только ascii символы",
 			override:    false,

--- a/translations/ru/ru_test.go
+++ b/translations/ru/ru_test.go
@@ -120,6 +120,7 @@ func TestTranslations(t *testing.T) {
 		UUID3                   string            `validate:"uuid3"`
 		UUID4                   string            `validate:"uuid4"`
 		UUID5                   string            `validate:"uuid5"`
+		ULID                    string            `validate:"ulid"`
 		ASCII                   string            `validate:"ascii"`
 		PrintableASCII          string            `validate:"printascii"`
 		MultiByte               string            `validate:"multibyte"`
@@ -339,6 +340,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.UUID5",
 			expected: "UUID5 должен быть UUID 5 версии",
+		},
+		{
+			ns:       "Test.ULID",
+			expected: "ULID должен быть ULID",
 		},
 		{
 			ns:       "Test.ISBN",

--- a/translations/tr/tr.go
+++ b/translations/tr/tr.go
@@ -1174,6 +1174,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "ulid",
+			translation: "{0} geçerli bir ULID olmalıdır",
+			override:    false,
+		},
+		{
 			tag:         "ascii",
 			translation: "{0} yalnızca ascii karakterler içermelidir",
 			override:    false,

--- a/translations/tr/tr_test.go
+++ b/translations/tr/tr_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/go-playground/assert/v2"
 	turkish "github.com/go-playground/locales/tr"
 	ut "github.com/go-playground/universal-translator"
-	. "github.com/go-playground/assert/v2"
 	"github.com/go-playground/validator/v10"
 )
 
@@ -104,6 +104,7 @@ func TestTranslations(t *testing.T) {
 		UUID3             string            `validate:"uuid3"`
 		UUID4             string            `validate:"uuid4"`
 		UUID5             string            `validate:"uuid5"`
+		ULID              string            `validate:"ulid"`
 		ASCII             string            `validate:"ascii"`
 		PrintableASCII    string            `validate:"printascii"`
 		MultiByte         string            `validate:"multibyte"`
@@ -311,6 +312,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.UUID5",
 			expected: "UUID5 geçerli bir sürüm 5 UUID olmalıdır",
+		},
+		{
+			ns:       "Test.ULID",
+			expected: "ULID geçerli bir ULID olmalıdır",
 		},
 		{
 			ns:       "Test.ISBN",

--- a/translations/zh/zh.go
+++ b/translations/zh/zh.go
@@ -1226,6 +1226,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "ulid",
+			translation: "{0}必须是一个有效的ULID",
+			override:    false,
+		},
+		{
 			tag:         "ascii",
 			translation: "{0}必须只包含ascii字符",
 			override:    false,

--- a/translations/zh/zh_test.go
+++ b/translations/zh/zh_test.go
@@ -109,6 +109,7 @@ func TestTranslations(t *testing.T) {
 		UUID3                 string    `validate:"uuid3"`
 		UUID4                 string    `validate:"uuid4"`
 		UUID5                 string    `validate:"uuid5"`
+		ULID                  string    `validate:"ulid"`
 		ASCII                 string    `validate:"ascii"`
 		PrintableASCII        string    `validate:"printascii"`
 		MultiByte             string    `validate:"multibyte"`
@@ -326,6 +327,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.UUID5",
 			expected: "UUID5必须是一个有效的V5 UUID",
+		},
+		{
+			ns:       "Test.ULID",
+			expected: "ULID必须是一个有效的ULID",
 		},
 		{
 			ns:       "Test.ISBN",

--- a/translations/zh_tw/zh_tw.go
+++ b/translations/zh_tw/zh_tw.go
@@ -1167,6 +1167,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "ulid",
+			translation: "{0}必須是一個有效的ULID",
+			override:    false,
+		},
+		{
 			tag:         "ascii",
 			translation: "{0}必須只包含ascii字元",
 			override:    false,

--- a/translations/zh_tw/zh_tw_test.go
+++ b/translations/zh_tw/zh_tw_test.go
@@ -104,6 +104,7 @@ func TestTranslations(t *testing.T) {
 		UUID3             string    `validate:"uuid3"`
 		UUID4             string    `validate:"uuid4"`
 		UUID5             string    `validate:"uuid5"`
+		ULID              string    `validate:"ulid"`
 		ASCII             string    `validate:"ascii"`
 		PrintableASCII    string    `validate:"printascii"`
 		MultiByte         string    `validate:"multibyte"`
@@ -308,6 +309,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.UUID5",
 			expected: "UUID5必須是一個有效的V5 UUID",
+		},
+		{
+			ns:       "Test.ULID",
+			expected: "ULID必須是一個有效的ULID",
 		},
 		{
 			ns:       "Test.ISBN",

--- a/validator_test.go
+++ b/validator_test.go
@@ -4269,6 +4269,46 @@ func TestUUIDRFC4122Validation(t *testing.T) {
 	}
 }
 
+func TestULIDValidation(t *testing.T) {
+	tests := []struct {
+		param    string
+		expected bool
+	}{
+		{"", false},
+		{"01BX5ZZKBKACT-V9WEVGEMMVRZ", false},
+		{"01bx5zzkbkactav9wevgemmvrz", false},
+		{"a987Fbc9-4bed-3078-cf07-9141ba07c9f3xxx", false},
+		{"01BX5ZZKBKACTAV9WEVGEMMVRZABC", false},
+		{"01BX5ZZKBKACTAV9WEVGEMMVRZABC", false},
+		{"0IBX5ZZKBKACTAV9WEVGEMMVRZ", false},
+		{"O1BX5ZZKBKACTAV9WEVGEMMVRZ", false},
+		{"01BX5ZZKBKACTAVLWEVGEMMVRZ", false},
+		{"01BX5ZZKBKACTAV9WEVGEMMVRZ", true},
+	}
+
+	validate := New()
+
+	for i, test := range tests {
+
+		errs := validate.Var(test.param, "ulid")
+
+		if test.expected {
+			if !IsEqual(errs, nil) {
+				t.Fatalf("Index: %d ULID failed Error: %s", i, errs)
+			}
+		} else {
+			if IsEqual(errs, nil) {
+				t.Fatalf("Index: %d ULID failed Error: %s", i, errs)
+			} else {
+				val := getError(errs, "", "")
+				if val.Tag() != "ulid" {
+					t.Fatalf("Index: %d ULID failed Error: %s", i, errs)
+				}
+			}
+		}
+	}
+}
+
 func TestISBNValidation(t *testing.T) {
 	tests := []struct {
 		param    string


### PR DESCRIPTION
## Enhances

This PR adds format validation for [ULID](https://github.com/ulid/spec) strings.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers