### PR TITLE
Enhance example in RegisterTagNameFunc docu

### DIFF
--- a/validator_instance.go
+++ b/validator_instance.go
@@ -180,6 +180,7 @@ func (v *Validate) ValidateMap(data map[string]interface{}, rules map[string]int
 //
 //    validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
 //        name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
+//        // skip if tag key says it should be ignored
 //        if name == "-" {
 //            return ""
 //        }


### PR DESCRIPTION
## Enhances
This PR enahnces the code example in the `RegisterTagNameFunc` documentation. 

As a go-newbie, I really had my problems understanding the part of the `RegisterTagNameFunc` example where the tag name retrievel is being skipped in case it's marked for ignorance. 

Maybe it makes sense to enhance it also for others :). 

Feel free to suggest better wording.

**Make sure that you've checked the boxes below before you submit PR:**
- [X] Tests exist or have been written that cover this particular change. 

@go-playground/validator-maintainers