### PR TITLE
add the ability to validate a slice of submaps to validate map

### DIFF
--- a/validator_instance.go
+++ b/validator_instance.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -156,6 +157,14 @@ func (v Validate) ValidateMapCtx(ctx context.Context, data map[string]interface{
 			err := v.ValidateMapCtx(ctx, data[field].(map[string]interface{}), rule.(map[string]interface{}))
 			if len(err) > 0 {
 				errs[field] = err
+			}
+		} else if reflect.ValueOf(rule).Kind() == reflect.Map && reflect.ValueOf(data[field]).Kind() == reflect.Slice {
+			for i := 0; i < reflect.ValueOf(data[field]).Len(); i++ {
+				fieldWithIndex := field + "[" + strconv.FormatInt(int64(i), 10) + "]"
+				err := v.ValidateMapCtx(ctx, reflect.ValueOf(data[field]).Index(i).Interface().(map[string]interface{}), rule.(map[string]interface{}))
+				if len(err) > 0 {
+					errs[fieldWithIndex] = err
+				}
 			}
 		} else if reflect.ValueOf(rule).Kind() == reflect.Map {
 			errs[field] = errors.New("The field: '" + field + "' is not a map to dive")

--- a/validator_test.go
+++ b/validator_test.go
@@ -11418,3 +11418,50 @@ func TestPostCodeByIso3166Alpha2Field_InvalidKind(t *testing.T) {
 	_ = New().Struct(test{"ABC", 123, false})
 	t.Errorf("Didn't panic as expected")
 }
+
+func TestValidate_ValidateMap_WithSlicesOfStructs(t *testing.T) {
+	test := map[string]interface{}{
+		"value": []map[string]interface{}{
+			{
+				"subValue": "abc",
+			}, {},
+		},
+	}
+	rules := map[string]interface{}{
+		"value": map[string]interface{}{
+			"subValue": "required",
+		},
+	}
+	errs := New().ValidateMap(test, rules)
+	NotEqual(t, nil, errs)
+}
+
+func TestValidate_ValidateMap_WithSubMaps(t *testing.T) {
+	test := map[string]interface{}{
+		"value": map[string]interface{}{
+			"subValue": "abc",
+		},
+	}
+	rules := map[string]interface{}{
+		"value": map[string]interface{}{
+			"subValue": "required",
+		},
+	}
+	errs := New().ValidateMap(test, rules)
+	NotEqual(t, nil, errs)
+}
+
+func TestValidate_ValidateMap_InvalidType(t *testing.T) {
+	test := map[string]interface{}{
+		"value": "abc",
+	}
+	rules := map[string]interface{}{
+		"value": map[string]interface{}{
+			"subValue": "required",
+		},
+	}
+	errs := New().ValidateMap(test, rules)
+	if IsEqual(errs, nil) {
+		t.Fatal("expected field error")
+	}
+}


### PR DESCRIPTION
## Fixes Or Enhances
Enhances Validate map flow to support nested validation of slices of maps. This comes up when parsing in a json blob like
```go
	b := []byte(`
		{
		    "Name": [
		        {
		            "Role":1234
		        }
		    ]
		}
	`)
```
with rules that look like
```go
rules := map[string]interface{}{"Name": map[string]interface{}{"Role":"Required"}}
```

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers