### PR TITLE
Fixed country_code validation to properly handle strings

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -2351,6 +2351,12 @@ func isIso3166AlphaNumeric(fl FieldLevel) bool {
 
 	var code int
 	switch field.Kind() {
+	case reflect.String:
+		i, err := strconv.Atoi(field.String())
+		if err != nil {
+			return false
+		}
+		code = i % 1000
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		code = int(field.Int() % 1000)
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:

--- a/validator_test.go
+++ b/validator_test.go
@@ -11053,12 +11053,14 @@ func TestIsIso3166Alpha3Validation(t *testing.T) {
 
 func TestIsIso3166AlphaNumericValidation(t *testing.T) {
 	tests := []struct {
-		value    int
+		value    interface{}
 		expected bool
 	}{
 		{248, true},
+		{"248", true},
 		{0, false},
 		{1, false},
+		{"1", false},
 	}
 
 	validate := New()
@@ -11079,8 +11081,39 @@ func TestIsIso3166AlphaNumericValidation(t *testing.T) {
 	}
 
 	PanicMatches(t, func() {
-		_ = validate.Var("1", "iso3166_1_alpha_numeric")
-	}, "Bad field type string")
+		_ = validate.Var([]string{"1"}, "iso3166_1_alpha_numeric")
+	}, "Bad field type []string")
+}
+
+func TestCountryCodeValidation(t *testing.T) {
+	tests := []struct {
+		value    interface{}
+		expected bool
+	}{
+		{248, true},
+		{0, false},
+		{1, false},
+		{"NO", true},
+		{"1", false},
+		{"0", false},
+	}
+
+	validate := New()
+
+	for i, test := range tests {
+
+		errs := validate.Var(test.value, "country_code")
+
+		if test.expected {
+			if !IsEqual(errs, nil) {
+				t.Fatalf("Index: %d country_code failed Error: %s", i, errs)
+			}
+		} else {
+			if IsEqual(errs, nil) {
+				t.Fatalf("Index: %d country_code failed Error: %s", i, errs)
+			}
+		}
+	}
 }
 
 func TestIsIso4217Validation(t *testing.T) {

--- a/validator_test.go
+++ b/validator_test.go
@@ -11061,6 +11061,7 @@ func TestIsIso3166AlphaNumericValidation(t *testing.T) {
 		{0, false},
 		{1, false},
 		{"1", false},
+		{"invalid_int", false},
 	}
 
 	validate := New()
@@ -11093,7 +11094,9 @@ func TestCountryCodeValidation(t *testing.T) {
 		{248, true},
 		{0, false},
 		{1, false},
+		{"POL", true},
 		{"NO", true},
+		{"248", true},
 		{"1", false},
 		{"0", false},
 	}


### PR DESCRIPTION
## Fixes Or Enhances

This PR fixes #860. I have modified existing tests and also added a test for `country_code` to ensure that my modifications have fixed the issue and improve upon the validation.

- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers