### PR TITLE
validate top level slice

### DIFF
--- a/validator_instance.go
+++ b/validator_instance.go
@@ -325,6 +325,30 @@ func (v *Validate) Struct(s interface{}) error {
 func (v *Validate) StructCtx(ctx context.Context, s interface{}) (err error) {
 
 	val := reflect.ValueOf(s)
+	if val.Kind() == reflect.Ptr && !val.IsNil() {
+		val = val.Elem()
+	}
+
+	// input is not a slice
+	if val.Kind() != reflect.Slice {
+		if err := v.onlyStructCtx(ctx, s); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// input is slice
+	for i := 0; i < val.Len(); i++ {
+		if err := v.onlyStructCtx(ctx, val.Index(i).Interface()); err != nil {
+			return err
+		}
+	}
+	return
+}
+
+func (v *Validate) onlyStructCtx(ctx context.Context, s interface{}) (err error) {
+
+	val := reflect.ValueOf(s)
 	top := val
 
 	if val.Kind() == reflect.Ptr && !val.IsNil() {

--- a/validator_test.go
+++ b/validator_test.go
@@ -8912,6 +8912,32 @@ func TestAlphanumericUnicodeValidation(t *testing.T) {
 	}
 }
 
+func TestTopStructArray(t *testing.T) {
+	in := []struct {
+		Value string `validate:"contains=@"`
+	}{
+		{Value: "test@1"}, {Value: "test@2"},
+	}
+
+	validate := New()
+
+	errs := validate.Struct(in)
+	Equal(t, errs, nil)
+}
+
+func TestTopStructArrayInvalid(t *testing.T) {
+	in := []struct {
+		Value string `validate:"contains=@"`
+	}{
+		{Value: "test@1"}, {Value: "test2"},
+	}
+
+	validate := New()
+
+	errs := validate.Struct(in)
+	NotEqual(t, errs, nil)
+}
+
 func TestArrayStructNamespace(t *testing.T) {
 	validate := New()
 	validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
@@ -11460,7 +11486,7 @@ func TestSemverFormatValidation(t *testing.T) {
 		}
 	}
 }
-  
+
 func TestRFC1035LabelFormatValidation(t *testing.T) {
 	tests := []struct {
 		value    string `validate:"dns_rfc1035_label"`


### PR DESCRIPTION
## Fixes Or Enhances

Adds ability to validate top level slice of structs, fixes #882 .

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers