### PR TITLE
feat: string byte length validation

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -214,6 +214,9 @@ var (
 		"semver":                        isSemverFormat,
 		"dns_rfc1035_label":             isDnsRFC1035LabelFormat,
 		"credit_card":                   isCreditCard,
+		"byte_len_min":                  hasByteLengthMinOf,
+		"byte_len_max":                  hasByteLengthMaxOf,
+		"byte_len":                      hasByteLengthOf,
 	}
 )
 
@@ -2518,4 +2521,52 @@ func isCreditCard(fl FieldLevel) bool {
 		}
 	}
 	return (sum % 10) == 0
+}
+
+// hasByteLengthMinOf is the validation function for validating if the current field's
+// value is a string with a byte length greater than or equal to the param's value.
+func hasByteLengthMinOf(fl FieldLevel) bool {
+	field := fl.Field()
+	param := fl.Param()
+
+	switch field.Kind() {
+	case reflect.String:
+		p := asInt(param)
+
+		return int64(field.Len()) >= p
+	}
+
+	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
+}
+
+// hasByteLengthMaxOf is the validation function for validating if the current field's
+// value is a string with a byte length less than or equal to the param's value.
+func hasByteLengthMaxOf(fl FieldLevel) bool {
+	field := fl.Field()
+	param := fl.Param()
+
+	switch field.Kind() {
+	case reflect.String:
+		p := asInt(param)
+
+		return int64(field.Len()) <= p
+	}
+
+	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
+}
+
+// hasByteLengthOf is the validation function for validating if the current field's
+// value is a string with a byte length equal to the param's value.
+func hasByteLengthOf(fl FieldLevel) bool {
+	field := fl.Field()
+	param := fl.Param()
+
+	switch field.Kind() {
+	case reflect.String:
+		p := asInt(param)
+
+		return int64(field.Len()) == p
+	}
+
+	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
 }

--- a/doc.go
+++ b/doc.go
@@ -1325,6 +1325,24 @@ This validates that a string value contains a valid credit card number using Luh
 
 Alias Validators and Tags
 
+Byte Length Minimum
+
+This validates that a string value has a byte length greater than or equal to the parameter given.
+
+	Usage: byte_len_min=5
+
+Byte Length Maximum
+
+This validates that a string value has a byte length less than or equal to the parameter given.
+
+	Usage: byte_len_max=5
+
+Byte Length
+
+This validates that a string value has a byte length equal to the parameter given.
+
+	Usage: byte_len=5
+
 NOTE: When returning an error, the tag returned in "FieldError" will be
 the alias tag unless the dive tag is part of the alias. Everything after the
 dive tag is not reported as the alias tag. Also, the "ActualTag" in the before

--- a/validator_test.go
+++ b/validator_test.go
@@ -12345,7 +12345,7 @@ func TestByteLengthMax(t *testing.T) {
 
 	for i, test := range tests {
 
-		// test for byte length >= 6
+		// test for byte length <= 6
 		errs := validate.Var(test.param, "byte_len_max=6")
 
 		if test.expected {
@@ -12374,19 +12374,19 @@ func TestByteLengthEq(t *testing.T) {
 		param    string
 		expected bool
 	}{
-		{"123", false},       // 3 bytes, len < max
-		{"123456", true},     // 6 bytes, len = max
-		{"123456789", false}, // 9 bytes, len > max
-		{"三", false},         // 3 bytes, len < max
-		{"三六", true},         // 6 bytes, len = max
-		{"三六九", false},       // 9 bytes, len > max
+		{"123", false},       // 3 bytes, len < value
+		{"123456", true},     // 6 bytes, len = value
+		{"123456789", false}, // 9 bytes, len > value
+		{"三", false},         // 3 bytes, len < value
+		{"三六", true},         // 6 bytes, len = value
+		{"三六九", false},       // 9 bytes, len > value
 	}
 
 	validate := New()
 
 	for i, test := range tests {
 
-		// test for byte length >= 6
+		// test for byte length == 6
 		errs := validate.Var(test.param, "byte_len=6")
 
 		if test.expected {

--- a/validator_test.go
+++ b/validator_test.go
@@ -12286,3 +12286,126 @@ func TestMultiOrOperatorGroup(t *testing.T) {
 		}
 	}
 }
+
+func TestByteLengthMin(t *testing.T) {
+	tests := []struct {
+		param    string
+		expected bool
+	}{
+		{"123", false},      // 3 bytes, len < min
+		{"123456", true},    // 6 bytes, len = min
+		{"123456789", true}, // 9 bytes, len > min
+		{"三", false},        // 3 bytes, len < min
+		{"三六", true},        // 6 bytes, len = min
+		{"三六九", true},       // 9 bytes, len > min
+	}
+
+	validate := New()
+
+	for i, test := range tests {
+
+		// test for byte length >= 6
+		errs := validate.Var(test.param, "byte_len_min=6")
+
+		if test.expected {
+			if !IsEqual(errs, nil) {
+				t.Fatalf("Index: %d byte_len_min=6 failed Error: %v", i, errs)
+			}
+		} else {
+			if IsEqual(errs, nil) {
+				t.Fatalf("Index: %d byte_len_min=6 failed Error: %v", i, errs)
+			} else {
+				val := getError(errs, "", "")
+				if val.Tag() != "byte_len_min" {
+					t.Fatalf("Index: %d byte_len_min=6 failed Error: %v", i, errs)
+				}
+			}
+		}
+	}
+
+	PanicMatches(t, func() {
+		_ = validate.Var(1, "byte_len_min=6")
+	}, "Bad field type int")
+}
+
+func TestByteLengthMax(t *testing.T) {
+	tests := []struct {
+		param    string
+		expected bool
+	}{
+		{"123", true},        // 3 bytes, len < max
+		{"123456", true},     // 6 bytes, len = max
+		{"123456789", false}, // 9 bytes, len > max
+		{"三", true},          // 3 bytes, len < max
+		{"三六", true},         // 6 bytes, len = max
+		{"三六九", false},       // 9 bytes, len > max
+	}
+
+	validate := New()
+
+	for i, test := range tests {
+
+		// test for byte length >= 6
+		errs := validate.Var(test.param, "byte_len_max=6")
+
+		if test.expected {
+			if !IsEqual(errs, nil) {
+				t.Fatalf("Index: %d byte_len_max=6 failed Error: %v", i, errs)
+			}
+		} else {
+			if IsEqual(errs, nil) {
+				t.Fatalf("Index: %d byte_len_max=6 failed Error: %v", i, errs)
+			} else {
+				val := getError(errs, "", "")
+				if val.Tag() != "byte_len_max" {
+					t.Fatalf("Index: %d byte_len_max=6 failed Error: %v", i, errs)
+				}
+			}
+		}
+	}
+
+	PanicMatches(t, func() {
+		_ = validate.Var(1, "byte_len_max=6")
+	}, "Bad field type int")
+}
+
+func TestByteLengthEq(t *testing.T) {
+	tests := []struct {
+		param    string
+		expected bool
+	}{
+		{"123", false},       // 3 bytes, len < max
+		{"123456", true},     // 6 bytes, len = max
+		{"123456789", false}, // 9 bytes, len > max
+		{"三", false},         // 3 bytes, len < max
+		{"三六", true},         // 6 bytes, len = max
+		{"三六九", false},       // 9 bytes, len > max
+	}
+
+	validate := New()
+
+	for i, test := range tests {
+
+		// test for byte length >= 6
+		errs := validate.Var(test.param, "byte_len=6")
+
+		if test.expected {
+			if !IsEqual(errs, nil) {
+				t.Fatalf("Index: %d byte_len=6 failed Error: %v", i, errs)
+			}
+		} else {
+			if IsEqual(errs, nil) {
+				t.Fatalf("Index: %d byte_len=6 failed Error: %v", i, errs)
+			} else {
+				val := getError(errs, "", "")
+				if val.Tag() != "byte_len" {
+					t.Fatalf("Index: %d byte_len=6 failed Error: %v", i, errs)
+				}
+			}
+		}
+	}
+
+	PanicMatches(t, func() {
+		_ = validate.Var(1, "byte_len=6")
+	}, "Bad field type int")
+}

--- a/validator_test.go
+++ b/validator_test.go
@@ -12264,25 +12264,25 @@ func TestCreditCardFormatValidation(t *testing.T) {
 }
 
 func TestMultiOrOperatorGroup(t *testing.T) {
- 	tests := []struct {
- 		Value    int `validate:"eq=1|gte=5,eq=1|lt=7"`
- 		expected bool
- 	}{
- 		{1, true}, {2, false}, {5, true}, {6, true}, {8, false},
- 	}
+	tests := []struct {
+		Value    int `validate:"eq=1|gte=5,eq=1|lt=7"`
+		expected bool
+	}{
+		{1, true}, {2, false}, {5, true}, {6, true}, {8, false},
+	}
 
- 	validate := New()
+	validate := New()
 
- 	for i, test := range tests {
- 		errs := validate.Struct(test)
- 		if test.expected {
- 			if !IsEqual(errs, nil) {
- 				t.Fatalf("Index: %d multi_group_of_OR_operators failed Error: %s", i, errs)
- 			}
- 		} else {
- 			if IsEqual(errs, nil) {
- 				t.Fatalf("Index: %d multi_group_of_OR_operators should have errs", i)
- 			}
- 		}
- 	}
- }
+	for i, test := range tests {
+		errs := validate.Struct(test)
+		if test.expected {
+			if !IsEqual(errs, nil) {
+				t.Fatalf("Index: %d multi_group_of_OR_operators failed Error: %s", i, errs)
+			}
+		} else {
+			if IsEqual(errs, nil) {
+				t.Fatalf("Index: %d multi_group_of_OR_operators should have errs", i)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Fixes Or Enhances
Create three new validation functions for controlling the byte length of a string.
Should help cover cases that regular min and max tags don't.
For example, ensuring a password is <72 bytes (instead of <72 runes) for use in bcrypt.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers