### PR TITLE
zh/zh_tw translation packages add e164/unique/jwt/boolean translations

### DIFF
--- a/translations/zh/zh.go
+++ b/translations/zh/zh.go
@@ -1081,6 +1081,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "e164",
+			translation: "{0}必须是一个有效的E.164手机号",
+			override:    false,
+		},
+		{
 			tag:         "email",
 			translation: "{0}必须是一个有效的邮箱",
 			override:    false,
@@ -1381,6 +1386,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "unique",
+			translation: "{0}字段内的值必须唯一",
+			override:    false,
+		},
+		{
 			tag:         "iscolor",
 			translation: "{0}必须是一个有效的颜色",
 			override:    false,
@@ -1400,7 +1410,12 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		},
 		{
 			tag:         "json",
-			translation: "{0}必须是一个JSON字符串",
+			translation: "{0}必须是一个有效的JSON字符串",
+			override:    false,
+		},
+		{
+			tag:         "jwt",
+			translation: "{0}必须是一个有效的JWT字符串",
 			override:    false,
 		},
 		{
@@ -1427,6 +1442,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 
 				return t
 			},
+		},
+		{
+			tag:         "boolean",
+			translation: "{0}必须是一个有效的布尔值",
+			override:    false,
 		},
 	}
 

--- a/translations/zh/zh.go
+++ b/translations/zh/zh.go
@@ -648,7 +648,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 				var kind reflect.Kind
 
 				fn := func() (err error) {
-
 					if idx := strings.Index(fe.Param(), "."); idx != -1 {
 						digits = uint64(len(fe.Param()[idx+1:]))
 					}
@@ -699,7 +698,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 					if fe.Type() != reflect.TypeOf(time.Time{}) {
 						err = fmt.Errorf("tag '%s'不能用于struct类型.", fe.Tag())
 					} else {
-
 						t, err = ut.T("gt-datetime", fe.Field())
 					}
 

--- a/translations/zh/zh_test.go
+++ b/translations/zh/zh_test.go
@@ -1,7 +1,6 @@
 package zh
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -724,7 +723,6 @@ func TestTranslations(t *testing.T) {
 			}
 		}
 
-		fmt.Printf("===================\n%v ---\n%v ----\n%v \n", t, tt, fe)
 		NotEqual(t, fe, nil)
 		Equal(t, tt.expected, fe.Translate(trans))
 	}

--- a/translations/zh/zh_test.go
+++ b/translations/zh/zh_test.go
@@ -1,6 +1,7 @@
 package zh
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -32,122 +33,128 @@ func TestTranslations(t *testing.T) {
 
 	type Test struct {
 		Inner                 Inner
-		RequiredString        string    `validate:"required"`
-		RequiredNumber        int       `validate:"required"`
-		RequiredMultiple      []string  `validate:"required"`
-		LenString             string    `validate:"len=1"`
-		LenNumber             float64   `validate:"len=1113.00"`
-		LenMultiple           []string  `validate:"len=7"`
-		MinString             string    `validate:"min=1"`
-		MinNumber             float64   `validate:"min=1113.00"`
-		MinMultiple           []string  `validate:"min=7"`
-		MaxString             string    `validate:"max=3"`
-		MaxNumber             float64   `validate:"max=1113.00"`
-		MaxMultiple           []string  `validate:"max=7"`
-		EqString              string    `validate:"eq=3"`
-		EqNumber              float64   `validate:"eq=2.33"`
-		EqMultiple            []string  `validate:"eq=7"`
-		NeString              string    `validate:"ne="`
-		NeNumber              float64   `validate:"ne=0.00"`
-		NeMultiple            []string  `validate:"ne=0"`
-		LtString              string    `validate:"lt=3"`
-		LtNumber              float64   `validate:"lt=5.56"`
-		LtMultiple            []string  `validate:"lt=2"`
-		LtTime                time.Time `validate:"lt"`
-		LteString             string    `validate:"lte=3"`
-		LteNumber             float64   `validate:"lte=5.56"`
-		LteMultiple           []string  `validate:"lte=2"`
-		LteTime               time.Time `validate:"lte"`
-		GtString              string    `validate:"gt=3"`
-		GtNumber              float64   `validate:"gt=5.56"`
-		GtMultiple            []string  `validate:"gt=2"`
-		GtTime                time.Time `validate:"gt"`
-		GteString             string    `validate:"gte=3"`
-		GteNumber             float64   `validate:"gte=5.56"`
-		GteMultiple           []string  `validate:"gte=2"`
-		GteTime               time.Time `validate:"gte"`
-		EqFieldString         string    `validate:"eqfield=MaxString"`
-		EqCSFieldString       string    `validate:"eqcsfield=Inner.EqCSFieldString"`
-		NeCSFieldString       string    `validate:"necsfield=Inner.NeCSFieldString"`
-		GtCSFieldString       string    `validate:"gtcsfield=Inner.GtCSFieldString"`
-		GteCSFieldString      string    `validate:"gtecsfield=Inner.GteCSFieldString"`
-		LtCSFieldString       string    `validate:"ltcsfield=Inner.LtCSFieldString"`
-		LteCSFieldString      string    `validate:"ltecsfield=Inner.LteCSFieldString"`
-		NeFieldString         string    `validate:"nefield=EqFieldString"`
-		GtFieldString         string    `validate:"gtfield=MaxString"`
-		GteFieldString        string    `validate:"gtefield=MaxString"`
-		LtFieldString         string    `validate:"ltfield=MaxString"`
-		LteFieldString        string    `validate:"ltefield=MaxString"`
-		AlphaString           string    `validate:"alpha"`
-		AlphanumString        string    `validate:"alphanum"`
-		AlphanumUnicodeString string    `validate:"alphanumunicode"`
-		AlphaUnicodeString    string    `validate:"alphaunicode"`
-		NumericString         string    `validate:"numeric"`
-		NumberString          string    `validate:"number"`
-		HexadecimalString     string    `validate:"hexadecimal"`
-		HexColorString        string    `validate:"hexcolor"`
-		RGBColorString        string    `validate:"rgb"`
-		RGBAColorString       string    `validate:"rgba"`
-		HSLColorString        string    `validate:"hsl"`
-		HSLAColorString       string    `validate:"hsla"`
-		Email                 string    `validate:"email"`
-		URL                   string    `validate:"url"`
-		URI                   string    `validate:"uri"`
-		Base64                string    `validate:"base64"`
-		Contains              string    `validate:"contains=purpose"`
-		ContainsAny           string    `validate:"containsany=!@#$"`
-		ContainsRune          string    `validate:"containsrune=☻"`
-		Excludes              string    `validate:"excludes=text"`
-		ExcludesAll           string    `validate:"excludesall=!@#$"`
-		ExcludesRune          string    `validate:"excludesrune=☻"`
-		EndsWith              string    `validate:"endswith=end"`
-		StartsWith            string    `validate:"startswith=start"`
-		ISBN                  string    `validate:"isbn"`
-		ISBN10                string    `validate:"isbn10"`
-		ISBN13                string    `validate:"isbn13"`
-		UUID                  string    `validate:"uuid"`
-		UUID3                 string    `validate:"uuid3"`
-		UUID4                 string    `validate:"uuid4"`
-		UUID5                 string    `validate:"uuid5"`
-		ULID                  string    `validate:"ulid"`
-		ASCII                 string    `validate:"ascii"`
-		PrintableASCII        string    `validate:"printascii"`
-		MultiByte             string    `validate:"multibyte"`
-		DataURI               string    `validate:"datauri"`
-		Latitude              string    `validate:"latitude"`
-		Longitude             string    `validate:"longitude"`
-		SSN                   string    `validate:"ssn"`
-		IP                    string    `validate:"ip"`
-		IPv4                  string    `validate:"ipv4"`
-		IPv6                  string    `validate:"ipv6"`
-		CIDR                  string    `validate:"cidr"`
-		CIDRv4                string    `validate:"cidrv4"`
-		CIDRv6                string    `validate:"cidrv6"`
-		TCPAddr               string    `validate:"tcp_addr"`
-		TCPAddrv4             string    `validate:"tcp4_addr"`
-		TCPAddrv6             string    `validate:"tcp6_addr"`
-		UDPAddr               string    `validate:"udp_addr"`
-		UDPAddrv4             string    `validate:"udp4_addr"`
-		UDPAddrv6             string    `validate:"udp6_addr"`
-		IPAddr                string    `validate:"ip_addr"`
-		IPAddrv4              string    `validate:"ip4_addr"`
-		IPAddrv6              string    `validate:"ip6_addr"`
-		UinxAddr              string    `validate:"unix_addr"` // can't fail from within Go's net package currently, but maybe in the future
-		MAC                   string    `validate:"mac"`
-		IsColor               string    `validate:"iscolor"`
-		StrPtrMinLen          *string   `validate:"min=10"`
-		StrPtrMaxLen          *string   `validate:"max=1"`
-		StrPtrLen             *string   `validate:"len=2"`
-		StrPtrLt              *string   `validate:"lt=1"`
-		StrPtrLte             *string   `validate:"lte=1"`
-		StrPtrGt              *string   `validate:"gt=10"`
-		StrPtrGte             *string   `validate:"gte=10"`
-		OneOfString           string    `validate:"oneof=red green"`
-		OneOfInt              int       `validate:"oneof=5 63"`
-		JsonString            string    `validate:"json"`
-		LowercaseString       string    `validate:"lowercase"`
-		UppercaseString       string    `validate:"uppercase"`
-		Datetime              string    `validate:"datetime=2006-01-02"`
+		RequiredString        string            `validate:"required"`
+		RequiredNumber        int               `validate:"required"`
+		RequiredMultiple      []string          `validate:"required"`
+		LenString             string            `validate:"len=1"`
+		LenNumber             float64           `validate:"len=1113.00"`
+		LenMultiple           []string          `validate:"len=7"`
+		MinString             string            `validate:"min=1"`
+		MinNumber             float64           `validate:"min=1113.00"`
+		MinMultiple           []string          `validate:"min=7"`
+		MaxString             string            `validate:"max=3"`
+		MaxNumber             float64           `validate:"max=1113.00"`
+		MaxMultiple           []string          `validate:"max=7"`
+		EqString              string            `validate:"eq=3"`
+		EqNumber              float64           `validate:"eq=2.33"`
+		EqMultiple            []string          `validate:"eq=7"`
+		NeString              string            `validate:"ne="`
+		NeNumber              float64           `validate:"ne=0.00"`
+		NeMultiple            []string          `validate:"ne=0"`
+		LtString              string            `validate:"lt=3"`
+		LtNumber              float64           `validate:"lt=5.56"`
+		LtMultiple            []string          `validate:"lt=2"`
+		LtTime                time.Time         `validate:"lt"`
+		LteString             string            `validate:"lte=3"`
+		LteNumber             float64           `validate:"lte=5.56"`
+		LteMultiple           []string          `validate:"lte=2"`
+		LteTime               time.Time         `validate:"lte"`
+		GtString              string            `validate:"gt=3"`
+		GtNumber              float64           `validate:"gt=5.56"`
+		GtMultiple            []string          `validate:"gt=2"`
+		GtTime                time.Time         `validate:"gt"`
+		GteString             string            `validate:"gte=3"`
+		GteNumber             float64           `validate:"gte=5.56"`
+		GteMultiple           []string          `validate:"gte=2"`
+		GteTime               time.Time         `validate:"gte"`
+		EqFieldString         string            `validate:"eqfield=MaxString"`
+		EqCSFieldString       string            `validate:"eqcsfield=Inner.EqCSFieldString"`
+		NeCSFieldString       string            `validate:"necsfield=Inner.NeCSFieldString"`
+		GtCSFieldString       string            `validate:"gtcsfield=Inner.GtCSFieldString"`
+		GteCSFieldString      string            `validate:"gtecsfield=Inner.GteCSFieldString"`
+		LtCSFieldString       string            `validate:"ltcsfield=Inner.LtCSFieldString"`
+		LteCSFieldString      string            `validate:"ltecsfield=Inner.LteCSFieldString"`
+		NeFieldString         string            `validate:"nefield=EqFieldString"`
+		GtFieldString         string            `validate:"gtfield=MaxString"`
+		GteFieldString        string            `validate:"gtefield=MaxString"`
+		LtFieldString         string            `validate:"ltfield=MaxString"`
+		LteFieldString        string            `validate:"ltefield=MaxString"`
+		AlphaString           string            `validate:"alpha"`
+		AlphanumString        string            `validate:"alphanum"`
+		AlphanumUnicodeString string            `validate:"alphanumunicode"`
+		AlphaUnicodeString    string            `validate:"alphaunicode"`
+		NumericString         string            `validate:"numeric"`
+		NumberString          string            `validate:"number"`
+		HexadecimalString     string            `validate:"hexadecimal"`
+		HexColorString        string            `validate:"hexcolor"`
+		RGBColorString        string            `validate:"rgb"`
+		RGBAColorString       string            `validate:"rgba"`
+		HSLColorString        string            `validate:"hsl"`
+		HSLAColorString       string            `validate:"hsla"`
+		E164                  string            `validate:"e164"`
+		Email                 string            `validate:"email"`
+		URL                   string            `validate:"url"`
+		URI                   string            `validate:"uri"`
+		Base64                string            `validate:"base64"`
+		Contains              string            `validate:"contains=purpose"`
+		ContainsAny           string            `validate:"containsany=!@#$"`
+		ContainsRune          string            `validate:"containsrune=☻"`
+		Excludes              string            `validate:"excludes=text"`
+		ExcludesAll           string            `validate:"excludesall=!@#$"`
+		ExcludesRune          string            `validate:"excludesrune=☻"`
+		EndsWith              string            `validate:"endswith=end"`
+		StartsWith            string            `validate:"startswith=start"`
+		ISBN                  string            `validate:"isbn"`
+		ISBN10                string            `validate:"isbn10"`
+		ISBN13                string            `validate:"isbn13"`
+		UUID                  string            `validate:"uuid"`
+		UUID3                 string            `validate:"uuid3"`
+		UUID4                 string            `validate:"uuid4"`
+		UUID5                 string            `validate:"uuid5"`
+		ULID                  string            `validate:"ulid"`
+		ASCII                 string            `validate:"ascii"`
+		PrintableASCII        string            `validate:"printascii"`
+		MultiByte             string            `validate:"multibyte"`
+		DataURI               string            `validate:"datauri"`
+		Latitude              string            `validate:"latitude"`
+		Longitude             string            `validate:"longitude"`
+		SSN                   string            `validate:"ssn"`
+		IP                    string            `validate:"ip"`
+		IPv4                  string            `validate:"ipv4"`
+		IPv6                  string            `validate:"ipv6"`
+		CIDR                  string            `validate:"cidr"`
+		CIDRv4                string            `validate:"cidrv4"`
+		CIDRv6                string            `validate:"cidrv6"`
+		TCPAddr               string            `validate:"tcp_addr"`
+		TCPAddrv4             string            `validate:"tcp4_addr"`
+		TCPAddrv6             string            `validate:"tcp6_addr"`
+		UDPAddr               string            `validate:"udp_addr"`
+		UDPAddrv4             string            `validate:"udp4_addr"`
+		UDPAddrv6             string            `validate:"udp6_addr"`
+		IPAddr                string            `validate:"ip_addr"`
+		IPAddrv4              string            `validate:"ip4_addr"`
+		IPAddrv6              string            `validate:"ip6_addr"`
+		UinxAddr              string            `validate:"unix_addr"` // can't fail from within Go's net package currently, but maybe in the future
+		MAC                   string            `validate:"mac"`
+		IsColor               string            `validate:"iscolor"`
+		StrPtrMinLen          *string           `validate:"min=10"`
+		StrPtrMaxLen          *string           `validate:"max=1"`
+		StrPtrLen             *string           `validate:"len=2"`
+		StrPtrLt              *string           `validate:"lt=1"`
+		StrPtrLte             *string           `validate:"lte=1"`
+		StrPtrGt              *string           `validate:"gt=10"`
+		StrPtrGte             *string           `validate:"gte=10"`
+		OneOfString           string            `validate:"oneof=red green"`
+		OneOfInt              int               `validate:"oneof=5 63"`
+		UniqueSlice           []string          `validate:"unique"`
+		UniqueArray           [3]string         `validate:"unique"`
+		UniqueMap             map[string]string `validate:"unique"`
+		JSONString            string            `validate:"json"`
+		JWTString             string            `validate:"jwt"`
+		LowercaseString       string            `validate:"lowercase"`
+		UppercaseString       string            `validate:"uppercase"`
+		Datetime              string            `validate:"datetime=2006-01-02"`
+		BooleanString         string            `validate:"boolean"`
 	}
 
 	var test Test
@@ -199,12 +206,16 @@ func TestTranslations(t *testing.T) {
 	test.StrPtrMaxLen = &s
 	test.StrPtrLen = &s
 
-	test.JsonString = "{\"foo\":\"bar\",}"
+	test.JSONString = "{\"foo\":\"bar\",}"
 
 	test.LowercaseString = "ABCDEFG"
 	test.UppercaseString = "abcdefg"
 
+	test.UniqueSlice = []string{"1234", "1234"}
+	test.UniqueMap = map[string]string{"key1": "1234", "key2": "1234"}
+
 	test.Datetime = "20060102"
+	test.BooleanString = "A"
 
 	err = validate.Struct(test)
 	NotEqual(t, err, nil)
@@ -379,6 +390,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.Base64",
 			expected: "Base64必须是一个有效的Base64字符串",
+		},
+		{
+			ns:       "Test.E164",
+			expected: "E164必须是一个有效的E.164手机号",
 		},
 		{
 			ns:       "Test.Email",
@@ -661,8 +676,24 @@ func TestTranslations(t *testing.T) {
 			expected: "OneOfInt必须是[5 63]中的一个",
 		},
 		{
-			ns:       "Test.JsonString",
-			expected: "JsonString必须是一个JSON字符串",
+			ns:       "Test.UniqueSlice",
+			expected: "UniqueSlice字段内的值必须唯一",
+		},
+		{
+			ns:       "Test.UniqueArray",
+			expected: "UniqueArray字段内的值必须唯一",
+		},
+		{
+			ns:       "Test.UniqueMap",
+			expected: "UniqueMap字段内的值必须唯一",
+		},
+		{
+			ns:       "Test.JSONString",
+			expected: "JSONString必须是一个有效的JSON字符串",
+		},
+		{
+			ns:       "Test.JWTString",
+			expected: "JWTString必须是一个有效的JWT字符串",
 		},
 		{
 			ns:       "Test.LowercaseString",
@@ -675,6 +706,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.Datetime",
 			expected: "Datetime的格式必须是2006-01-02",
+		},
+		{
+			ns:       "Test.BooleanString",
+			expected: "BooleanString必须是一个有效的布尔值",
 		},
 	}
 
@@ -689,6 +724,7 @@ func TestTranslations(t *testing.T) {
 			}
 		}
 
+		fmt.Printf("===================\n%v ---\n%v ----\n%v \n", t, tt, fe)
 		NotEqual(t, fe, nil)
 		Equal(t, tt.expected, fe.Translate(trans))
 	}

--- a/translations/zh_tw/zh_tw.go
+++ b/translations/zh_tw/zh_tw.go
@@ -30,6 +30,36 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "required_if",
+			translation: "{0}為必填欄位",
+			override:    false,
+		},
+		{
+			tag:         "required_unless",
+			translation: "{0}為必填欄位",
+			override:    false,
+		},
+		{
+			tag:         "required_with",
+			translation: "{0}為必填欄位",
+			override:    false,
+		},
+		{
+			tag:         "required_with_all",
+			translation: "{0}為必填欄位",
+			override:    false,
+		},
+		{
+			tag:         "required_without",
+			translation: "{0}為必填欄位",
+			override:    false,
+		},
+		{
+			tag:         "required_without_all",
+			translation: "{0}為必填欄位",
+			override:    false,
+		},
+		{
 			tag: "len",
 			customRegisFunc: func(ut ut.Translator) (err error) {
 
@@ -621,7 +651,9 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 					if idx := strings.Index(fe.Param(), "."); idx != -1 {
 						digits = uint64(len(fe.Param()[idx+1:]))
 					}
+
 					f64, err = strconv.ParseFloat(fe.Param(), 64)
+
 					return
 				}
 
@@ -997,6 +1029,16 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "alphanumunicode",
+			translation: "{0}只能包含字母數字和Unicode字元",
+			override:    false,
+		},
+		{
+			tag:         "alphaunicode",
+			translation: "{0}只能包含字母和Unicode字元",
+			override:    false,
+		},
+		{
 			tag:         "numeric",
 			translation: "{0}必須是一個有效的數值",
 			override:    false,
@@ -1034,6 +1076,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		{
 			tag:         "hsla",
 			translation: "{0}必須是一個有效的HSLA顏色",
+			override:    false,
+		},
+		{
+			tag:         "e164",
+			translation: "{0}必須是一個有效的E.164手機號",
 			override:    false,
 		},
 		{
@@ -1087,6 +1134,21 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			},
 		},
 		{
+			tag:         "containsrune",
+			translation: "{0}必須包含字元'{1}'",
+			override:    false,
+			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
+
+				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
+				if err != nil {
+					log.Printf("警告: 翻譯欄位錯誤: %#v", fe)
+					return fe.(error).Error()
+				}
+
+				return t
+			},
+		},
+		{
 			tag:         "excludes",
 			translation: "{0}不能包含文字'{1}'",
 			override:    false,
@@ -1119,6 +1181,36 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		{
 			tag:         "excludesrune",
 			translation: "{0}不能包含'{1}'",
+			override:    false,
+			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
+
+				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
+				if err != nil {
+					log.Printf("警告: 翻譯欄位錯誤: %#v", fe)
+					return fe.(error).Error()
+				}
+
+				return t
+			},
+		},
+		{
+			tag:         "endswith",
+			translation: "{0}必須以文本'{1}'結尾",
+			override:    false,
+			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
+
+				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
+				if err != nil {
+					log.Printf("警告: 翻譯欄位錯誤: %#v", fe)
+					return fe.(error).Error()
+				}
+
+				return t
+			},
+		},
+		{
+			tag:         "startswith",
+			translation: "{0}必須以文本'{1}'開頭",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
 
@@ -1292,6 +1384,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "unique",
+			translation: "{0}字段內的值必須唯一",
+			override:    false,
+		},
+		{
 			tag:         "iscolor",
 			translation: "{0}必須是一個有效的顏色",
 			override:    false,
@@ -1310,8 +1407,28 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			},
 		},
 		{
+			tag:         "json",
+			translation: "{0}必須是一個有效的JSON字符串",
+			override:    false,
+		},
+		{
+			tag:         "jwt",
+			translation: "{0}必須是一個有效的JWT字符串",
+			override:    false,
+		},
+		{
+			tag:         "lowercase",
+			translation: "{0}必須是小寫字母",
+			override:    false,
+		},
+		{
+			tag:         "uppercase",
+			translation: "{0}必須是大寫字母",
+			override:    false,
+		},
+		{
 			tag:         "datetime",
-			translation: "{0}與{1}格式不匹配",
+			translation: "{0}的格式必須是{1}",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
 
@@ -1323,6 +1440,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 
 				return t
 			},
+		},
+		{
+			tag:         "boolean",
+			translation: "{0}必須是一個有效的布爾值",
+			override:    false,
 		},
 	}
 

--- a/translations/zh_tw/zh_tw_test.go
+++ b/translations/zh_tw/zh_tw_test.go
@@ -31,115 +31,129 @@ func TestTranslations(t *testing.T) {
 	}
 
 	type Test struct {
-		Inner             Inner
-		RequiredString    string    `validate:"required"`
-		RequiredNumber    int       `validate:"required"`
-		RequiredMultiple  []string  `validate:"required"`
-		LenString         string    `validate:"len=1"`
-		LenNumber         float64   `validate:"len=1113.00"`
-		LenMultiple       []string  `validate:"len=7"`
-		MinString         string    `validate:"min=1"`
-		MinNumber         float64   `validate:"min=1113.00"`
-		MinMultiple       []string  `validate:"min=7"`
-		MaxString         string    `validate:"max=3"`
-		MaxNumber         float64   `validate:"max=1113.00"`
-		MaxMultiple       []string  `validate:"max=7"`
-		EqString          string    `validate:"eq=3"`
-		EqNumber          float64   `validate:"eq=2.33"`
-		EqMultiple        []string  `validate:"eq=7"`
-		NeString          string    `validate:"ne="`
-		NeNumber          float64   `validate:"ne=0.00"`
-		NeMultiple        []string  `validate:"ne=0"`
-		LtString          string    `validate:"lt=3"`
-		LtNumber          float64   `validate:"lt=5.56"`
-		LtMultiple        []string  `validate:"lt=2"`
-		LtTime            time.Time `validate:"lt"`
-		LteString         string    `validate:"lte=3"`
-		LteNumber         float64   `validate:"lte=5.56"`
-		LteMultiple       []string  `validate:"lte=2"`
-		LteTime           time.Time `validate:"lte"`
-		GtString          string    `validate:"gt=3"`
-		GtNumber          float64   `validate:"gt=5.56"`
-		GtMultiple        []string  `validate:"gt=2"`
-		GtTime            time.Time `validate:"gt"`
-		GteString         string    `validate:"gte=3"`
-		GteNumber         float64   `validate:"gte=5.56"`
-		GteMultiple       []string  `validate:"gte=2"`
-		GteTime           time.Time `validate:"gte"`
-		EqFieldString     string    `validate:"eqfield=MaxString"`
-		EqCSFieldString   string    `validate:"eqcsfield=Inner.EqCSFieldString"`
-		NeCSFieldString   string    `validate:"necsfield=Inner.NeCSFieldString"`
-		GtCSFieldString   string    `validate:"gtcsfield=Inner.GtCSFieldString"`
-		GteCSFieldString  string    `validate:"gtecsfield=Inner.GteCSFieldString"`
-		LtCSFieldString   string    `validate:"ltcsfield=Inner.LtCSFieldString"`
-		LteCSFieldString  string    `validate:"ltecsfield=Inner.LteCSFieldString"`
-		NeFieldString     string    `validate:"nefield=EqFieldString"`
-		GtFieldString     string    `validate:"gtfield=MaxString"`
-		GteFieldString    string    `validate:"gtefield=MaxString"`
-		LtFieldString     string    `validate:"ltfield=MaxString"`
-		LteFieldString    string    `validate:"ltefield=MaxString"`
-		AlphaString       string    `validate:"alpha"`
-		AlphanumString    string    `validate:"alphanum"`
-		NumericString     string    `validate:"numeric"`
-		NumberString      string    `validate:"number"`
-		HexadecimalString string    `validate:"hexadecimal"`
-		HexColorString    string    `validate:"hexcolor"`
-		RGBColorString    string    `validate:"rgb"`
-		RGBAColorString   string    `validate:"rgba"`
-		HSLColorString    string    `validate:"hsl"`
-		HSLAColorString   string    `validate:"hsla"`
-		Email             string    `validate:"email"`
-		URL               string    `validate:"url"`
-		URI               string    `validate:"uri"`
-		Base64            string    `validate:"base64"`
-		Contains          string    `validate:"contains=purpose"`
-		ContainsAny       string    `validate:"containsany=!@#$"`
-		Excludes          string    `validate:"excludes=text"`
-		ExcludesAll       string    `validate:"excludesall=!@#$"`
-		ExcludesRune      string    `validate:"excludesrune=☻"`
-		ISBN              string    `validate:"isbn"`
-		ISBN10            string    `validate:"isbn10"`
-		ISBN13            string    `validate:"isbn13"`
-		UUID              string    `validate:"uuid"`
-		UUID3             string    `validate:"uuid3"`
-		UUID4             string    `validate:"uuid4"`
-		UUID5             string    `validate:"uuid5"`
-		ULID              string    `validate:"ulid"`
-		ASCII             string    `validate:"ascii"`
-		PrintableASCII    string    `validate:"printascii"`
-		MultiByte         string    `validate:"multibyte"`
-		DataURI           string    `validate:"datauri"`
-		Latitude          string    `validate:"latitude"`
-		Longitude         string    `validate:"longitude"`
-		SSN               string    `validate:"ssn"`
-		IP                string    `validate:"ip"`
-		IPv4              string    `validate:"ipv4"`
-		IPv6              string    `validate:"ipv6"`
-		CIDR              string    `validate:"cidr"`
-		CIDRv4            string    `validate:"cidrv4"`
-		CIDRv6            string    `validate:"cidrv6"`
-		TCPAddr           string    `validate:"tcp_addr"`
-		TCPAddrv4         string    `validate:"tcp4_addr"`
-		TCPAddrv6         string    `validate:"tcp6_addr"`
-		UDPAddr           string    `validate:"udp_addr"`
-		UDPAddrv4         string    `validate:"udp4_addr"`
-		UDPAddrv6         string    `validate:"udp6_addr"`
-		IPAddr            string    `validate:"ip_addr"`
-		IPAddrv4          string    `validate:"ip4_addr"`
-		IPAddrv6          string    `validate:"ip6_addr"`
-		UinxAddr          string    `validate:"unix_addr"` // can't fail from within Go's net package currently, but maybe in the future
-		MAC               string    `validate:"mac"`
-		IsColor           string    `validate:"iscolor"`
-		StrPtrMinLen      *string   `validate:"min=10"`
-		StrPtrMaxLen      *string   `validate:"max=1"`
-		StrPtrLen         *string   `validate:"len=2"`
-		StrPtrLt          *string   `validate:"lt=1"`
-		StrPtrLte         *string   `validate:"lte=1"`
-		StrPtrGt          *string   `validate:"gt=10"`
-		StrPtrGte         *string   `validate:"gte=10"`
-		OneOfString       string    `validate:"oneof=red green"`
-		OneOfInt          int       `validate:"oneof=5 63"`
-		Datetime          string    `validate:"datetime=2006-01-02"`
+		Inner                 Inner
+		RequiredString        string            `validate:"required"`
+		RequiredNumber        int               `validate:"required"`
+		RequiredMultiple      []string          `validate:"required"`
+		LenString             string            `validate:"len=1"`
+		LenNumber             float64           `validate:"len=1113.00"`
+		LenMultiple           []string          `validate:"len=7"`
+		MinString             string            `validate:"min=1"`
+		MinNumber             float64           `validate:"min=1113.00"`
+		MinMultiple           []string          `validate:"min=7"`
+		MaxString             string            `validate:"max=3"`
+		MaxNumber             float64           `validate:"max=1113.00"`
+		MaxMultiple           []string          `validate:"max=7"`
+		EqString              string            `validate:"eq=3"`
+		EqNumber              float64           `validate:"eq=2.33"`
+		EqMultiple            []string          `validate:"eq=7"`
+		NeString              string            `validate:"ne="`
+		NeNumber              float64           `validate:"ne=0.00"`
+		NeMultiple            []string          `validate:"ne=0"`
+		LtString              string            `validate:"lt=3"`
+		LtNumber              float64           `validate:"lt=5.56"`
+		LtMultiple            []string          `validate:"lt=2"`
+		LtTime                time.Time         `validate:"lt"`
+		LteString             string            `validate:"lte=3"`
+		LteNumber             float64           `validate:"lte=5.56"`
+		LteMultiple           []string          `validate:"lte=2"`
+		LteTime               time.Time         `validate:"lte"`
+		GtString              string            `validate:"gt=3"`
+		GtNumber              float64           `validate:"gt=5.56"`
+		GtMultiple            []string          `validate:"gt=2"`
+		GtTime                time.Time         `validate:"gt"`
+		GteString             string            `validate:"gte=3"`
+		GteNumber             float64           `validate:"gte=5.56"`
+		GteMultiple           []string          `validate:"gte=2"`
+		GteTime               time.Time         `validate:"gte"`
+		EqFieldString         string            `validate:"eqfield=MaxString"`
+		EqCSFieldString       string            `validate:"eqcsfield=Inner.EqCSFieldString"`
+		NeCSFieldString       string            `validate:"necsfield=Inner.NeCSFieldString"`
+		GtCSFieldString       string            `validate:"gtcsfield=Inner.GtCSFieldString"`
+		GteCSFieldString      string            `validate:"gtecsfield=Inner.GteCSFieldString"`
+		LtCSFieldString       string            `validate:"ltcsfield=Inner.LtCSFieldString"`
+		LteCSFieldString      string            `validate:"ltecsfield=Inner.LteCSFieldString"`
+		NeFieldString         string            `validate:"nefield=EqFieldString"`
+		GtFieldString         string            `validate:"gtfield=MaxString"`
+		GteFieldString        string            `validate:"gtefield=MaxString"`
+		LtFieldString         string            `validate:"ltfield=MaxString"`
+		LteFieldString        string            `validate:"ltefield=MaxString"`
+		AlphaString           string            `validate:"alpha"`
+		AlphanumString        string            `validate:"alphanum"`
+		AlphanumUnicodeString string            `validate:"alphanumunicode"`
+		AlphaUnicodeString    string            `validate:"alphaunicode"`
+		NumericString         string            `validate:"numeric"`
+		NumberString          string            `validate:"number"`
+		HexadecimalString     string            `validate:"hexadecimal"`
+		HexColorString        string            `validate:"hexcolor"`
+		RGBColorString        string            `validate:"rgb"`
+		RGBAColorString       string            `validate:"rgba"`
+		HSLColorString        string            `validate:"hsl"`
+		HSLAColorString       string            `validate:"hsla"`
+		E164                  string            `validate:"e164"`
+		Email                 string            `validate:"email"`
+		URL                   string            `validate:"url"`
+		URI                   string            `validate:"uri"`
+		Base64                string            `validate:"base64"`
+		Contains              string            `validate:"contains=purpose"`
+		ContainsAny           string            `validate:"containsany=!@#$"`
+		ContainsRune          string            `validate:"containsrune=☻"`
+		Excludes              string            `validate:"excludes=text"`
+		ExcludesAll           string            `validate:"excludesall=!@#$"`
+		ExcludesRune          string            `validate:"excludesrune=☻"`
+		EndsWith              string            `validate:"endswith=end"`
+		StartsWith            string            `validate:"startswith=start"`
+		ISBN                  string            `validate:"isbn"`
+		ISBN10                string            `validate:"isbn10"`
+		ISBN13                string            `validate:"isbn13"`
+		UUID                  string            `validate:"uuid"`
+		UUID3                 string            `validate:"uuid3"`
+		UUID4                 string            `validate:"uuid4"`
+		UUID5                 string            `validate:"uuid5"`
+		ULID                  string            `validate:"ulid"`
+		ASCII                 string            `validate:"ascii"`
+		PrintableASCII        string            `validate:"printascii"`
+		MultiByte             string            `validate:"multibyte"`
+		DataURI               string            `validate:"datauri"`
+		Latitude              string            `validate:"latitude"`
+		Longitude             string            `validate:"longitude"`
+		SSN                   string            `validate:"ssn"`
+		IP                    string            `validate:"ip"`
+		IPv4                  string            `validate:"ipv4"`
+		IPv6                  string            `validate:"ipv6"`
+		CIDR                  string            `validate:"cidr"`
+		CIDRv4                string            `validate:"cidrv4"`
+		CIDRv6                string            `validate:"cidrv6"`
+		TCPAddr               string            `validate:"tcp_addr"`
+		TCPAddrv4             string            `validate:"tcp4_addr"`
+		TCPAddrv6             string            `validate:"tcp6_addr"`
+		UDPAddr               string            `validate:"udp_addr"`
+		UDPAddrv4             string            `validate:"udp4_addr"`
+		UDPAddrv6             string            `validate:"udp6_addr"`
+		IPAddr                string            `validate:"ip_addr"`
+		IPAddrv4              string            `validate:"ip4_addr"`
+		IPAddrv6              string            `validate:"ip6_addr"`
+		UinxAddr              string            `validate:"unix_addr"` // can't fail from within Go's net package currently, but maybe in the future
+		MAC                   string            `validate:"mac"`
+		IsColor               string            `validate:"iscolor"`
+		StrPtrMinLen          *string           `validate:"min=10"`
+		StrPtrMaxLen          *string           `validate:"max=1"`
+		StrPtrLen             *string           `validate:"len=2"`
+		StrPtrLt              *string           `validate:"lt=1"`
+		StrPtrLte             *string           `validate:"lte=1"`
+		StrPtrGt              *string           `validate:"gt=10"`
+		StrPtrGte             *string           `validate:"gte=10"`
+		OneOfString           string            `validate:"oneof=red green"`
+		OneOfInt              int               `validate:"oneof=5 63"`
+		UniqueSlice           []string          `validate:"unique"`
+		UniqueArray           [3]string         `validate:"unique"`
+		UniqueMap             map[string]string `validate:"unique"`
+		JSONString            string            `validate:"json"`
+		JWTString             string            `validate:"jwt"`
+		LowercaseString       string            `validate:"lowercase"`
+		UppercaseString       string            `validate:"uppercase"`
+		Datetime              string            `validate:"datetime=2006-01-02"`
+		BooleanString         string            `validate:"boolean"`
 	}
 
 	var test Test
@@ -170,12 +184,17 @@ func TestTranslations(t *testing.T) {
 
 	test.AlphaString = "abc3"
 	test.AlphanumString = "abc3!"
+	test.AlphanumUnicodeString = "abc3啊!"
+	test.AlphaUnicodeString = "abc3啊"
 	test.NumericString = "12E.00"
 	test.NumberString = "12E"
 
 	test.Excludes = "this is some test text"
 	test.ExcludesAll = "This is Great!"
 	test.ExcludesRune = "Love it ☻"
+
+	test.EndsWith = "this is some test text"
+	test.StartsWith = "this is some test text"
 
 	test.ASCII = "ｶﾀｶﾅ"
 	test.PrintableASCII = "ｶﾀｶﾅ"
@@ -186,7 +205,16 @@ func TestTranslations(t *testing.T) {
 	test.StrPtrMaxLen = &s
 	test.StrPtrLen = &s
 
-	test.Datetime = "2008-Feb-01"
+	test.JSONString = "{\"foo\":\"bar\",}"
+
+	test.LowercaseString = "ABCDEFG"
+	test.UppercaseString = "abcdefg"
+
+	test.UniqueSlice = []string{"1234", "1234"}
+	test.UniqueMap = map[string]string{"key1": "1234", "key2": "1234"}
+
+	test.Datetime = "20060102"
+	test.BooleanString = "A"
 
 	err = validate.Struct(test)
 	NotEqual(t, err, nil)
@@ -327,6 +355,14 @@ func TestTranslations(t *testing.T) {
 			expected: "ISBN13必須是一個有效的ISBN-13編號",
 		},
 		{
+			ns:       "Test.EndsWith",
+			expected: "EndsWith必須以文本'end'結尾",
+		},
+		{
+			ns:       "Test.StartsWith",
+			expected: "StartsWith必須以文本'start'開頭",
+		},
+		{
 			ns:       "Test.Excludes",
 			expected: "Excludes不能包含文字'text'",
 		},
@@ -339,6 +375,10 @@ func TestTranslations(t *testing.T) {
 			expected: "ExcludesRune不能包含'☻'",
 		},
 		{
+			ns:       "Test.ContainsRune",
+			expected: "ContainsRune必須包含字元'☻'",
+		},
+		{
 			ns:       "Test.ContainsAny",
 			expected: "ContainsAny必須包含至少一個以下字元'!@#$'",
 		},
@@ -349,6 +389,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.Base64",
 			expected: "Base64必須是一個有效的Base64字元串",
+		},
+		{
+			ns:       "Test.E164",
+			expected: "E164必須是一個有效的E.164手機號",
 		},
 		{
 			ns:       "Test.Email",
@@ -393,6 +437,14 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.NumericString",
 			expected: "NumericString必須是一個有效的數值",
+		},
+		{
+			ns:       "Test.AlphaUnicodeString",
+			expected: "AlphaUnicodeString只能包含字母和Unicode字元",
+		},
+		{
+			ns:       "Test.AlphanumUnicodeString",
+			expected: "AlphanumUnicodeString只能包含字母數字和Unicode字元",
 		},
 		{
 			ns:       "Test.AlphanumString",
@@ -623,8 +675,40 @@ func TestTranslations(t *testing.T) {
 			expected: "OneOfInt必須是[5 63]中的一個",
 		},
 		{
+			ns:       "Test.UniqueSlice",
+			expected: "UniqueSlice字段內的值必須唯一",
+		},
+		{
+			ns:       "Test.UniqueArray",
+			expected: "UniqueArray字段內的值必須唯一",
+		},
+		{
+			ns:       "Test.UniqueMap",
+			expected: "UniqueMap字段內的值必須唯一",
+		},
+		{
+			ns:       "Test.JSONString",
+			expected: "JSONString必須是一個有效的JSON字符串",
+		},
+		{
+			ns:       "Test.JWTString",
+			expected: "JWTString必須是一個有效的JWT字符串",
+		},
+		{
+			ns:       "Test.LowercaseString",
+			expected: "LowercaseString必須是小寫字母",
+		},
+		{
+			ns:       "Test.UppercaseString",
+			expected: "UppercaseString必須是大寫字母",
+		},
+		{
 			ns:       "Test.Datetime",
-			expected: "Datetime與2006-01-02格式不匹配",
+			expected: "Datetime的格式必須是2006-01-02",
+		},
+		{
+			ns:       "Test.BooleanString",
+			expected: "BooleanString必須是一個有效的布爾值",
 		},
 	}
 


### PR DESCRIPTION
## Fixes Or Enhances
zh translation packages add translations:
- e164
- unique
- jwt
- boolean 

zh_tw translation packages add translations:
- required_if
- required_unless
- required_with
- required_with_all
- required_without
- required_without_all
- alphanumunicode
- alphaunicode
- e164
- containsrune
- endswith
- startswith
- json
- jwt
- lowercase
- uppercase
- boolean

**Make sure that you've checked the boxes below before you submit PR:**
- [ ] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers