### PR TITLE
Add ObjectID validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Baked-in Validations
 | jwt | JSON Web Token (JWT) |
 | latitude | Latitude |
 | longitude | Longitude |
+| objectid | ObjectID |
 | postcode_iso3166_alpha2 | Postcode |
 | postcode_iso3166_alpha2_field | Postcode |
 | rgb | RGB String |

--- a/baked_in.go
+++ b/baked_in.go
@@ -439,11 +439,7 @@ func isObjectID(fl FieldLevel) bool {
 	}
 
 	_, err := hex.DecodeString(field)
-	if err != nil {
-		return false
-	}
-
-	return true
+	return err == nil
 }
 
 // isDataURI is the validation function for validating if the field's value is a valid data URI.

--- a/baked_in.go
+++ b/baked_in.go
@@ -167,6 +167,7 @@ var (
 		"datauri":                       isDataURI,
 		"latitude":                      isLatitude,
 		"longitude":                     isLongitude,
+		"objectid":                      isObjectID,
 		"ssn":                           isSSN,
 		"ipv4":                          isIPv4,
 		"ipv6":                          isIPv6,
@@ -427,6 +428,22 @@ func isLatitude(fl FieldLevel) bool {
 	}
 
 	return latitudeRegex.MatchString(v)
+}
+
+// isObjectID is the validation function for validating if the field's value is a valid hex-encoded representation of a MongoDB object id.
+func isObjectID(fl FieldLevel) bool {
+	field := fl.Field().String()
+
+	if len(field) != 24 {
+		return false
+	}
+
+	_, err := hex.DecodeString(field)
+	if err != nil {
+		return false
+	}
+
+	return true
 }
 
 // isDataURI is the validation function for validating if the field's value is a valid data URI.

--- a/doc.go
+++ b/doc.go
@@ -1087,6 +1087,12 @@ This validates that a string value contains a valid longitude.
 
 	Usage: longitude
 
+ObjectID
+
+This validate that a string value is a valid ObjectId.
+
+  Usage: objectid
+
 Social Security Number SSN
 
 This validates that a string value contains a valid U.S. Social Security Number.

--- a/translations/en/en.go
+++ b/translations/en/en.go
@@ -1177,6 +1177,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "objectid",
+			translation: "{0} must be a valid Object ID",
+			override:    false,
+		},
+		{
 			tag:         "ssn",
 			translation: "{0} must be a valid SSN number",
 			override:    false,

--- a/translations/en/en_test.go
+++ b/translations/en/en_test.go
@@ -112,6 +112,7 @@ func TestTranslations(t *testing.T) {
 		DataURI           string            `validate:"datauri"`
 		Latitude          string            `validate:"latitude"`
 		Longitude         string            `validate:"longitude"`
+		ObjectID          string            `validate:"objectid"`
 		SSN               string            `validate:"ssn"`
 		IP                string            `validate:"ip"`
 		IPv4              string            `validate:"ipv4"`
@@ -301,6 +302,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.Longitude",
 			expected: "Longitude must contain a valid longitude coordinates",
+		},
+		{
+			ns:       "Test.ObjectID",
+			expected: "ObjectID must be a valid Object ID",
 		},
 		{
 			ns:       "Test.MultiByte",

--- a/validator_test.go
+++ b/validator_test.go
@@ -3811,6 +3811,34 @@ func TestLatitudeValidation(t *testing.T) {
 	PanicMatches(t, func() { _ = validate.Var(true, "latitude") }, "Bad field type bool")
 }
 
+func TestObjectIDValidation(t *testing.T) {
+	tests := []struct {
+		param    string
+		expected bool
+	}{
+		{"", false},
+		{"abc", false},
+		{"5e95ee5803c6b76b270fd694", true},
+		{"000000000000000000000000", true},
+	}
+
+	validate := New()
+
+	for i, test := range tests {
+		errs := validate.Var(test.param, "objectid")
+		if test.expected {
+			if !IsEqual(errs, nil) {
+				t.Fatalf("Index %d ObjectID failed Error: %s", i, errs)
+			}
+		} else {
+			val := getError(errs, "", "")
+			if val.Tag() != "objectid" {
+				t.Fatalf("Index %d ObjectID failed Error: %s", i, errs)
+			}
+		}
+	}
+}
+
 func TestDataURIValidation(t *testing.T) {
 	tests := []struct {
 		param    string


### PR DESCRIPTION
## Fixes Or Enhances

Add a validator for [ObjectIDs](https://github.com/mongodb/specifications/blob/master/source/objectid.rst). I used the same validation as the [bson package](https://github.com/mongodb/mongo-go-driver/blob/v1.9.1/bson/primitive/objectid.go#L78) uses.

I've also added en translation. I'm not fluent in any of the other languages. How do you usually add translations? I guess I can copy and paste together translations for objectid by looking at the other translations. Should I do that?

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers