### PR TITLE
fix: ValidateMapCtx support for more baked-in validators

### DIFF
--- a/validator_instance.go
+++ b/validator_instance.go
@@ -172,9 +172,16 @@ func (v Validate) ValidateMapCtx(ctx context.Context, data map[string]interface{
 				errs[field] = errors.New("The field: '" + field + "' is not a map to dive")
 			}
 		} else if ruleStr, ok := rule.(string); ok {
-			err := v.VarCtx(ctx, data[field], ruleStr)
-			if err != nil {
-				errs[field] = err
+			if dataField, ok := data[field]; ok {
+				err := v.VarWithValueCtx(ctx, dataField, data, ruleStr)
+				if err != nil {
+					errs[field] = err
+				}
+			} else {
+				err := v.VarWithValueCtx(ctx, "", data, ruleStr)
+				if err != nil {
+					errs[field] = err
+				}
 			}
 		}
 	}

--- a/validator_test.go
+++ b/validator_test.go
@@ -12214,6 +12214,48 @@ func TestValidate_ValidateMapCtx(t *testing.T) {
 			},
 			want: 1,
 		},
+
+		{
+			name: "test map with relative rules",
+			args: args{
+				data: map[string]interface{}{
+					"Test_A": "Test_A",
+					"Test_B": "Test_B",
+					"Test_C": "Test_C",
+					"Test_D": "Test_D",
+					"Test_F": "Test_F",
+				},
+				rules: map[string]interface{}{
+					"Test_A": "required_if=[Test_B] Test_B",
+					"Test_B": "required_with=[Test_A]",
+					"Test_C": "required_with_all=[Test_A] [Test_B]",
+					"Test_D": "required_without=[Test_F]",
+					"Test_E": "required_without_all=[Test_D] [Test_F]",
+					"Test_F": "required_unless=[Test_E] Test_E",
+				},
+			},
+			want: 0,
+		},
+
+		{
+			name: "test map err with relative rules",
+			args: args{
+				data: map[string]interface{}{
+					"Test_B": "Test_B",
+					"Test_C": "Test_C",
+					"Test_D": "Test_D",
+				},
+				rules: map[string]interface{}{
+					"Test_A": "required_if=[Test_B] Test_B",
+					"Test_B": "required_with=[Test_A]",
+					"Test_C": "required_with_all=[Test_A] [Test_B]",
+					"Test_D": "required_without=[Test_F]",
+					"Test_E": "required_without_all=[Test_F] [Test_G]",
+					"Test_F": "required_unless=[Test_E] Test_E",
+				},
+			},
+			want: 3,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -12264,25 +12306,25 @@ func TestCreditCardFormatValidation(t *testing.T) {
 }
 
 func TestMultiOrOperatorGroup(t *testing.T) {
- 	tests := []struct {
- 		Value    int `validate:"eq=1|gte=5,eq=1|lt=7"`
- 		expected bool
- 	}{
- 		{1, true}, {2, false}, {5, true}, {6, true}, {8, false},
- 	}
+	tests := []struct {
+		Value    int `validate:"eq=1|gte=5,eq=1|lt=7"`
+		expected bool
+	}{
+		{1, true}, {2, false}, {5, true}, {6, true}, {8, false},
+	}
 
- 	validate := New()
+	validate := New()
 
- 	for i, test := range tests {
- 		errs := validate.Struct(test)
- 		if test.expected {
- 			if !IsEqual(errs, nil) {
- 				t.Fatalf("Index: %d multi_group_of_OR_operators failed Error: %s", i, errs)
- 			}
- 		} else {
- 			if IsEqual(errs, nil) {
- 				t.Fatalf("Index: %d multi_group_of_OR_operators should have errs", i)
- 			}
- 		}
- 	}
- }
+	for i, test := range tests {
+		errs := validate.Struct(test)
+		if test.expected {
+			if !IsEqual(errs, nil) {
+				t.Fatalf("Index: %d multi_group_of_OR_operators failed Error: %s", i, errs)
+			}
+		} else {
+			if IsEqual(errs, nil) {
+				t.Fatalf("Index: %d multi_group_of_OR_operators should have errs", i)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Fixes Or Enhances

Fixes #893 , #943.

Specifying other keys of the map requires brackets.

### Example:

```go
v := validator.New()

data := map[string]interface{}{
    "foo": "bar",
    "foo2": "",
}
rules := map[string]interface{}{
    "foo": "required_without=[foo2]",
}

res := v.ValidateMap(data, rules)
````

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers