### PR TITLE
add reflect struct field on validate error

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -75,11 +75,12 @@ type cStruct struct {
 }
 
 type cField struct {
-	idx        int
-	name       string
-	altName    string
-	namesEqual bool
-	cTags      *cTag
+	idx         int
+	name        string
+	altName     string
+	namesEqual  bool
+	cTags       *cTag
+	structField reflect.StructField
 }
 
 type cTag struct {
@@ -120,7 +121,7 @@ func (v *Validate) extractStructCache(current reflect.Value, sName string) *cStr
 	var fld reflect.StructField
 	var tag string
 	var customName string
-	
+
 	for i := 0; i < numFields; i++ {
 
 		fld = typ.Field(i)
@@ -160,11 +161,12 @@ func (v *Validate) extractStructCache(current reflect.Value, sName string) *cStr
 		}
 
 		cs.fields = append(cs.fields, &cField{
-			idx:        i,
-			name:       fld.Name,
-			altName:    customName,
-			cTags:      ctag,
-			namesEqual: fld.Name == customName,
+			idx:         i,
+			name:        fld.Name,
+			altName:     customName,
+			cTags:       ctag,
+			namesEqual:  fld.Name == customName,
+			structField: fld,
 		})
 	}
 	v.structCache.Set(typ, cs)

--- a/errors.go
+++ b/errors.go
@@ -149,6 +149,8 @@ type FieldError interface {
 	// eg. time.Time's type is time.Time
 	Type() reflect.Type
 
+	ReflectStructField() reflect.StructField
+
 	// Translate returns the FieldError's translated error
 	// from the provided 'ut.Translator' and registered 'TranslationFunc'
 	//
@@ -179,6 +181,7 @@ type fieldError struct {
 	param          string
 	kind           reflect.Kind
 	typ            reflect.Type
+	structField    reflect.StructField
 }
 
 // Tag returns the validation tag that failed.
@@ -225,6 +228,12 @@ func (fe *fieldError) Field() string {
 func (fe *fieldError) StructField() string {
 	// return fe.structField
 	return fe.structNs[len(fe.structNs)-int(fe.structfieldLen):]
+}
+
+// ReflectStructField get reflect struct field
+func (fe *fieldError) ReflectStructField() reflect.StructField {
+	// return fe.structField
+	return fe.structField
 }
 
 // Value returns the actual field's value in case needed for creating the error

--- a/validator.go
+++ b/validator.go
@@ -129,6 +129,7 @@ func (v *validate) traverseField(ctx context.Context, parent reflect.Value, curr
 						structfieldLen: uint8(len(cf.name)),
 						param:          ct.param,
 						kind:           kind,
+						structField:    cf.structField,
 					},
 				)
 				return
@@ -154,6 +155,7 @@ func (v *validate) traverseField(ctx context.Context, parent reflect.Value, curr
 						param:          ct.param,
 						kind:           kind,
 						typ:            current.Type(),
+						structField:    cf.structField,
 					},
 				)
 				return
@@ -199,6 +201,7 @@ func (v *validate) traverseField(ctx context.Context, parent reflect.Value, curr
 								param:          ct.param,
 								kind:           kind,
 								typ:            typ,
+								structField:    cf.structField,
 							},
 						)
 						return
@@ -413,6 +416,7 @@ OUTER:
 								param:          ct.param,
 								kind:           kind,
 								typ:            typ,
+								structField:    cf.structField,
 							},
 						)
 
@@ -433,6 +437,7 @@ OUTER:
 								param:          ct.param,
 								kind:           kind,
 								typ:            typ,
+								structField:    cf.structField,
 							},
 						)
 					}
@@ -474,6 +479,7 @@ OUTER:
 						param:          ct.param,
 						kind:           kind,
 						typ:            typ,
+						structField:    cf.structField,
 					},
 				)
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -12264,25 +12264,47 @@ func TestCreditCardFormatValidation(t *testing.T) {
 }
 
 func TestMultiOrOperatorGroup(t *testing.T) {
- 	tests := []struct {
- 		Value    int `validate:"eq=1|gte=5,eq=1|lt=7"`
- 		expected bool
- 	}{
- 		{1, true}, {2, false}, {5, true}, {6, true}, {8, false},
- 	}
+	tests := []struct {
+		Value    int `validate:"eq=1|gte=5,eq=1|lt=7"`
+		expected bool
+	}{
+		{1, true}, {2, false}, {5, true}, {6, true}, {8, false},
+	}
 
- 	validate := New()
+	validate := New()
 
- 	for i, test := range tests {
- 		errs := validate.Struct(test)
- 		if test.expected {
- 			if !IsEqual(errs, nil) {
- 				t.Fatalf("Index: %d multi_group_of_OR_operators failed Error: %s", i, errs)
- 			}
- 		} else {
- 			if IsEqual(errs, nil) {
- 				t.Fatalf("Index: %d multi_group_of_OR_operators should have errs", i)
- 			}
- 		}
- 	}
- }
+	for i, test := range tests {
+		errs := validate.Struct(test)
+		if test.expected {
+			if !IsEqual(errs, nil) {
+				t.Fatalf("Index: %d multi_group_of_OR_operators failed Error: %s", i, errs)
+			}
+		} else {
+			if IsEqual(errs, nil) {
+				t.Fatalf("Index: %d multi_group_of_OR_operators should have errs", i)
+			}
+		}
+	}
+}
+
+type testTag struct {
+	CreatedAt *time.Time `validate:"required" langKey:"test.created_at"`
+	String    string     `validate:"required" langKey:"test.string"`
+	Int       int        `validate:"required" langKey:"test.int"`
+	Uint      uint       `validate:"required" langKey:"test.uint"`
+	Float     float64    `validate:"required" langKey:"test.float"`
+	Array     []string   `validate:"required" langKey:"test.array"`
+}
+
+func TestReflectStructField(t *testing.T) {
+	validate := New()
+	var test testTag
+	err := validate.Struct(test)
+	NotEqual(t, err, nil)
+
+	errs, ok := err.(ValidationErrors)
+	Equal(t, ok, true)
+
+	fe := errs[0]
+	Equal(t, fe.ReflectStructField().Tag.Get("langKey"), "test.created_at")
+}


### PR DESCRIPTION
add reflect on fields 

use case: 
I've added reflect.StructField for using for getting a tag for using my own custom validate message and getting the field name from the language
example use from my own project

`
	if validate, ok := err.(*validator.InvalidValidationError); ok {
		panic(validate)
	}

	errorsFields := make(map[string][]string, 0)
	for _, validate := range err.(validator.ValidationErrors) {
		fe := validate.ReflectStructField()
		fieldName := strings.Replace(fe.Tag.Get("json"), ",omitempty", "", 0)
		if _, ok := errorsFields[fieldName]; !ok {
			errorsFields[fieldName] = make([]string, 0)
		}
		msg := ""
		switch errTagName := validate.Tag(); errTagName {
		case "regexp":
			msg = i18n.ParseT(ct, "validator.regexp") // invalid format blabla
		}
		errorsFields[fieldName] = append(errorsFields[fieldName], msg)
	}
`

@go-playground/validator-maintainers