### PR TITLE
fix: removed unnecessary cast so we can mock `ValidationErrors` (#980)

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -44,12 +44,9 @@ func (ve ValidationErrors) Error() string {
 
 	buff := bytes.NewBufferString("")
 
-	var fe *fieldError
-
 	for i := 0; i < len(ve); i++ {
 
-		fe = ve[i].(*fieldError)
-		buff.WriteString(fe.Error())
+		buff.WriteString(ve[i].Error())
 		buff.WriteString("\n")
 	}
 


### PR DESCRIPTION
## Fixes Or Enhances
Removed unnecessary cast so we can mock `ValidationErrors`. For more details, please check here #980.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers