### PR TITLE
Update Japanese translations

### DIFF
--- a/translations/ja/ja.go
+++ b/translations/ja/ja.go
@@ -30,6 +30,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "required_if",
+			translation: "{0}は必須フィールドです",
+			override:    false,
+		},
+		{
 			tag: "len",
 			customRegisFunc: func(ut ut.Translator) (err error) {
 
@@ -1355,6 +1360,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "unique",
+			translation: "{0}は一意な値のみを含まなければなりません",
+			override:    false,
+		},
+		{
 			tag:         "iscolor",
 			translation: "{0}は正しい色でなければなりません",
 			override:    false,
@@ -1371,6 +1381,73 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 				}
 				return s
 			},
+		},
+		{
+			tag:         "json",
+			translation: "{0}は正しいJSON文字列でなければなりません",
+			override:    false,
+		},
+		{
+			tag:         "jwt",
+			translation: "{0}は正しいJWT文字列でなければなりません",
+			override:    false,
+		},
+		{
+			tag:         "lowercase",
+			translation: "{0}は小文字でなければなりません",
+			override:    false,
+		},
+		{
+			tag:         "uppercase",
+			translation: "{0}は大文字でなければなりません",
+			override:    false,
+		},
+		{
+			tag:         "datetime",
+			translation: "{0}は{1}の書式と一致しません",
+			override:    false,
+			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
+				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
+				if err != nil {
+					log.Printf("warning: error translating FieldError: %#v", fe)
+					return fe.(error).Error()
+				}
+
+				return t
+			},
+		},
+		{
+			tag:         "postcode_iso3166_alpha2",
+			translation: "{0}は国名コード{1}の郵便番号形式と一致しません",
+			override:    false,
+			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
+				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
+				if err != nil {
+					log.Printf("warning: error translating FieldError: %#v", fe)
+					return fe.(error).Error()
+				}
+
+				return t
+			},
+		},
+		{
+			tag:         "postcode_iso3166_alpha2_field",
+			translation: "{0}は{1}フィールドで指定された国名コードの郵便番号形式と一致しません",
+			override:    false,
+			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
+				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
+				if err != nil {
+					log.Printf("warning: error translating FieldError: %#v", fe)
+					return fe.(error).Error()
+				}
+
+				return t
+			},
+		},
+		{
+			tag:         "boolean",
+			translation: "{0}は正しいブール値でなければなりません",
+			override:    false,
 		},
 	}
 

--- a/translations/ja/ja.go
+++ b/translations/ja/ja.go
@@ -16,7 +16,6 @@ import (
 // RegisterDefaultTranslations registers a set of default translations
 // for all built in tag's in validator; you may add your own as desired.
 func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (err error) {
-
 	translations := []struct {
 		tag             string
 		translation     string
@@ -37,7 +36,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		{
 			tag: "len",
 			customRegisFunc: func(ut ut.Translator) (err error) {
-
 				if err = ut.Add("len-string", "{0}の長さは{1}でなければなりません", false); err != nil {
 					return
 				}
@@ -69,7 +67,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 
 			},
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				var err error
 				var t string
 
@@ -128,7 +125,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		{
 			tag: "min",
 			customRegisFunc: func(ut ut.Translator) (err error) {
-
 				if err = ut.Add("min-string", "{0}の長さは少なくとも{1}はなければなりません", false); err != nil {
 					return
 				}
@@ -160,7 +156,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 
 			},
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				var err error
 				var t string
 
@@ -219,7 +214,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		{
 			tag: "max",
 			customRegisFunc: func(ut ut.Translator) (err error) {
-
 				if err = ut.Add("max-string", "{0}の長さは最大でも{1}でなければなりません", false); err != nil {
 					return
 				}
@@ -312,7 +306,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0}は{1}と等しくありません",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					fmt.Printf("warning: error translating FieldError: %#v", fe)
@@ -396,7 +389,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		{
 			tag: "lt",
 			customRegisFunc: func(ut ut.Translator) (err error) {
-
 				if err = ut.Add("lt-string", "{0}の長さは{1}よりも少なくなければなりません", false); err != nil {
 					return
 				}
@@ -517,7 +509,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		{
 			tag: "lte",
 			customRegisFunc: func(ut ut.Translator) (err error) {
-
 				if err = ut.Add("lte-string", "{0}の長さは最大でも{1}でなければなりません", false); err != nil {
 					return
 				}
@@ -637,7 +628,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		{
 			tag: "gt",
 			customRegisFunc: func(ut ut.Translator) (err error) {
-
 				if err = ut.Add("gt-string", "{0}の長さは{1}よりも多くなければなりません", false); err != nil {
 					return
 				}
@@ -757,7 +747,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		{
 			tag: "gte",
 			customRegisFunc: func(ut ut.Translator) (err error) {
-
 				if err = ut.Add("gte-string", "{0}の長さは少なくとも{1}以上はなければなりません", false); err != nil {
 					return
 				}
@@ -879,7 +868,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0}は{1}と等しくなければなりません",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -894,7 +882,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0}は{1}と等しくなければなりません",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -909,7 +896,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0}は{1}とは異ならなければなりません",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -924,7 +910,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0}は{1}よりも大きくなければなりません",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -939,7 +924,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0}は{1}以上でなければなりません",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -954,7 +938,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0}は{1}よりも小さくなければなりません",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -969,7 +952,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0}は{1}以下でなければなりません",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -984,7 +966,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0}は{1}とは異ならなければなりません",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -999,7 +980,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0}は{1}よりも大きくなければなりません",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -1014,7 +994,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0}は{1}以上でなければなりません",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -1029,7 +1008,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0}は{1}よりも小さくなければなりません",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -1044,7 +1022,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0}は{1}以下でなければなりません",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -1129,7 +1106,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0}は'{1}'を含まなければなりません",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -1144,7 +1120,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0}は'{1}'の少なくとも1つを含まなければなりません",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -1159,7 +1134,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0}には'{1}'というテキストを含むことはできません",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -1174,7 +1148,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0}には'{1}'のどれも含めることはできません",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -1189,7 +1162,6 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			translation: "{0}には'{1}'を含めることはできません",
 			override:    false,
 			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
-
 				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
 				if err != nil {
 					log.Printf("warning: error translating FieldError: %#v", fe)
@@ -1454,17 +1426,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 	for _, t := range translations {
 
 		if t.customTransFunc != nil && t.customRegisFunc != nil {
-
 			err = v.RegisterTranslation(t.tag, trans, t.customRegisFunc, t.customTransFunc)
-
 		} else if t.customTransFunc != nil && t.customRegisFunc == nil {
-
 			err = v.RegisterTranslation(t.tag, trans, registrationFunc(t.tag, t.translation, t.override), t.customTransFunc)
-
 		} else if t.customTransFunc == nil && t.customRegisFunc != nil {
-
 			err = v.RegisterTranslation(t.tag, trans, t.customRegisFunc, translateFunc)
-
 		} else {
 			err = v.RegisterTranslation(t.tag, trans, registrationFunc(t.tag, t.translation, t.override), translateFunc)
 		}
@@ -1478,9 +1444,7 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 }
 
 func registrationFunc(tag string, translation string, override bool) validator.RegisterTranslationsFunc {
-
 	return func(ut ut.Translator) (err error) {
-
 		if err = ut.Add(tag, translation, override); err != nil {
 			return
 		}
@@ -1492,7 +1456,6 @@ func registrationFunc(tag string, translation string, override bool) validator.R
 }
 
 func translateFunc(ut ut.Translator, fe validator.FieldError) string {
-
 	t, err := ut.T(fe.Tag(), fe.Field())
 	if err != nil {
 		log.Printf("warning: error translating FieldError: %#v", fe)

--- a/translations/ja/ja_test.go
+++ b/translations/ja/ja_test.go
@@ -28,117 +28,131 @@ func TestTranslations(t *testing.T) {
 		GteCSFieldString string
 		LtCSFieldString  string
 		LteCSFieldString string
+		RequiredIf       string
 	}
 
 	type Test struct {
 		Inner             Inner
-		RequiredString    string    `validate:"required"`
-		RequiredNumber    int       `validate:"required"`
-		RequiredMultiple  []string  `validate:"required"`
-		LenString         string    `validate:"len=1"`
-		LenNumber         float64   `validate:"len=1113.00"`
-		LenMultiple       []string  `validate:"len=7"`
-		MinString         string    `validate:"min=1"`
-		MinNumber         float64   `validate:"min=1113.00"`
-		MinMultiple       []string  `validate:"min=7"`
-		MaxString         string    `validate:"max=3"`
-		MaxNumber         float64   `validate:"max=1113.00"`
-		MaxMultiple       []string  `validate:"max=7"`
-		EqString          string    `validate:"eq=3"`
-		EqNumber          float64   `validate:"eq=2.33"`
-		EqMultiple        []string  `validate:"eq=7"`
-		NeString          string    `validate:"ne="`
-		NeNumber          float64   `validate:"ne=0.00"`
-		NeMultiple        []string  `validate:"ne=0"`
-		LtString          string    `validate:"lt=3"`
-		LtNumber          float64   `validate:"lt=5.56"`
-		LtMultiple        []string  `validate:"lt=2"`
-		LtTime            time.Time `validate:"lt"`
-		LteString         string    `validate:"lte=3"`
-		LteNumber         float64   `validate:"lte=5.56"`
-		LteMultiple       []string  `validate:"lte=2"`
-		LteTime           time.Time `validate:"lte"`
-		GtString          string    `validate:"gt=3"`
-		GtNumber          float64   `validate:"gt=5.56"`
-		GtMultiple        []string  `validate:"gt=2"`
-		GtTime            time.Time `validate:"gt"`
-		GteString         string    `validate:"gte=3"`
-		GteNumber         float64   `validate:"gte=5.56"`
-		GteMultiple       []string  `validate:"gte=2"`
-		GteTime           time.Time `validate:"gte"`
-		EqFieldString     string    `validate:"eqfield=MaxString"`
-		EqCSFieldString   string    `validate:"eqcsfield=Inner.EqCSFieldString"`
-		NeCSFieldString   string    `validate:"necsfield=Inner.NeCSFieldString"`
-		GtCSFieldString   string    `validate:"gtcsfield=Inner.GtCSFieldString"`
-		GteCSFieldString  string    `validate:"gtecsfield=Inner.GteCSFieldString"`
-		LtCSFieldString   string    `validate:"ltcsfield=Inner.LtCSFieldString"`
-		LteCSFieldString  string    `validate:"ltecsfield=Inner.LteCSFieldString"`
-		NeFieldString     string    `validate:"nefield=EqFieldString"`
-		GtFieldString     string    `validate:"gtfield=MaxString"`
-		GteFieldString    string    `validate:"gtefield=MaxString"`
-		LtFieldString     string    `validate:"ltfield=MaxString"`
-		LteFieldString    string    `validate:"ltefield=MaxString"`
-		AlphaString       string    `validate:"alpha"`
-		AlphanumString    string    `validate:"alphanum"`
-		NumericString     string    `validate:"numeric"`
-		NumberString      string    `validate:"number"`
-		HexadecimalString string    `validate:"hexadecimal"`
-		HexColorString    string    `validate:"hexcolor"`
-		RGBColorString    string    `validate:"rgb"`
-		RGBAColorString   string    `validate:"rgba"`
-		HSLColorString    string    `validate:"hsl"`
-		HSLAColorString   string    `validate:"hsla"`
-		Email             string    `validate:"email"`
-		URL               string    `validate:"url"`
-		URI               string    `validate:"uri"`
-		Base64            string    `validate:"base64"`
-		Contains          string    `validate:"contains=purpose"`
-		ContainsAny       string    `validate:"containsany=!@#$"`
-		Excludes          string    `validate:"excludes=text"`
-		ExcludesAll       string    `validate:"excludesall=!@#$"`
-		ExcludesRune      string    `validate:"excludesrune=☻"`
-		ISBN              string    `validate:"isbn"`
-		ISBN10            string    `validate:"isbn10"`
-		ISBN13            string    `validate:"isbn13"`
-		UUID              string    `validate:"uuid"`
-		UUID3             string    `validate:"uuid3"`
-		UUID4             string    `validate:"uuid4"`
-		UUID5             string    `validate:"uuid5"`
-		ULID              string    `validate:"ulid"`
-		ASCII             string    `validate:"ascii"`
-		PrintableASCII    string    `validate:"printascii"`
-		MultiByte         string    `validate:"multibyte"`
-		DataURI           string    `validate:"datauri"`
-		Latitude          string    `validate:"latitude"`
-		Longitude         string    `validate:"longitude"`
-		SSN               string    `validate:"ssn"`
-		IP                string    `validate:"ip"`
-		IPv4              string    `validate:"ipv4"`
-		IPv6              string    `validate:"ipv6"`
-		CIDR              string    `validate:"cidr"`
-		CIDRv4            string    `validate:"cidrv4"`
-		CIDRv6            string    `validate:"cidrv6"`
-		TCPAddr           string    `validate:"tcp_addr"`
-		TCPAddrv4         string    `validate:"tcp4_addr"`
-		TCPAddrv6         string    `validate:"tcp6_addr"`
-		UDPAddr           string    `validate:"udp_addr"`
-		UDPAddrv4         string    `validate:"udp4_addr"`
-		UDPAddrv6         string    `validate:"udp6_addr"`
-		IPAddr            string    `validate:"ip_addr"`
-		IPAddrv4          string    `validate:"ip4_addr"`
-		IPAddrv6          string    `validate:"ip6_addr"`
-		UinxAddr          string    `validate:"unix_addr"` // can't fail from within Go's net package currently, but maybe in the future
-		MAC               string    `validate:"mac"`
-		IsColor           string    `validate:"iscolor"`
-		StrPtrMinLen      *string   `validate:"min=10"`
-		StrPtrMaxLen      *string   `validate:"max=1"`
-		StrPtrLen         *string   `validate:"len=2"`
-		StrPtrLt          *string   `validate:"lt=1"`
-		StrPtrLte         *string   `validate:"lte=1"`
-		StrPtrGt          *string   `validate:"gt=10"`
-		StrPtrGte         *string   `validate:"gte=10"`
-		OneOfString       string    `validate:"oneof=red green"`
-		OneOfInt          int       `validate:"oneof=5 63"`
+		RequiredString    string            `validate:"required"`
+		RequiredNumber    int               `validate:"required"`
+		RequiredMultiple  []string          `validate:"required"`
+		RequiredIf        string            `validate:"required_if=Inner.RequiredIf abcd"`
+		LenString         string            `validate:"len=1"`
+		LenNumber         float64           `validate:"len=1113.00"`
+		LenMultiple       []string          `validate:"len=7"`
+		MinString         string            `validate:"min=1"`
+		MinNumber         float64           `validate:"min=1113.00"`
+		MinMultiple       []string          `validate:"min=7"`
+		MaxString         string            `validate:"max=3"`
+		MaxNumber         float64           `validate:"max=1113.00"`
+		MaxMultiple       []string          `validate:"max=7"`
+		EqString          string            `validate:"eq=3"`
+		EqNumber          float64           `validate:"eq=2.33"`
+		EqMultiple        []string          `validate:"eq=7"`
+		NeString          string            `validate:"ne="`
+		NeNumber          float64           `validate:"ne=0.00"`
+		NeMultiple        []string          `validate:"ne=0"`
+		LtString          string            `validate:"lt=3"`
+		LtNumber          float64           `validate:"lt=5.56"`
+		LtMultiple        []string          `validate:"lt=2"`
+		LtTime            time.Time         `validate:"lt"`
+		LteString         string            `validate:"lte=3"`
+		LteNumber         float64           `validate:"lte=5.56"`
+		LteMultiple       []string          `validate:"lte=2"`
+		LteTime           time.Time         `validate:"lte"`
+		GtString          string            `validate:"gt=3"`
+		GtNumber          float64           `validate:"gt=5.56"`
+		GtMultiple        []string          `validate:"gt=2"`
+		GtTime            time.Time         `validate:"gt"`
+		GteString         string            `validate:"gte=3"`
+		GteNumber         float64           `validate:"gte=5.56"`
+		GteMultiple       []string          `validate:"gte=2"`
+		GteTime           time.Time         `validate:"gte"`
+		EqFieldString     string            `validate:"eqfield=MaxString"`
+		EqCSFieldString   string            `validate:"eqcsfield=Inner.EqCSFieldString"`
+		NeCSFieldString   string            `validate:"necsfield=Inner.NeCSFieldString"`
+		GtCSFieldString   string            `validate:"gtcsfield=Inner.GtCSFieldString"`
+		GteCSFieldString  string            `validate:"gtecsfield=Inner.GteCSFieldString"`
+		LtCSFieldString   string            `validate:"ltcsfield=Inner.LtCSFieldString"`
+		LteCSFieldString  string            `validate:"ltecsfield=Inner.LteCSFieldString"`
+		NeFieldString     string            `validate:"nefield=EqFieldString"`
+		GtFieldString     string            `validate:"gtfield=MaxString"`
+		GteFieldString    string            `validate:"gtefield=MaxString"`
+		LtFieldString     string            `validate:"ltfield=MaxString"`
+		LteFieldString    string            `validate:"ltefield=MaxString"`
+		AlphaString       string            `validate:"alpha"`
+		AlphanumString    string            `validate:"alphanum"`
+		NumericString     string            `validate:"numeric"`
+		NumberString      string            `validate:"number"`
+		HexadecimalString string            `validate:"hexadecimal"`
+		HexColorString    string            `validate:"hexcolor"`
+		RGBColorString    string            `validate:"rgb"`
+		RGBAColorString   string            `validate:"rgba"`
+		HSLColorString    string            `validate:"hsl"`
+		HSLAColorString   string            `validate:"hsla"`
+		Email             string            `validate:"email"`
+		URL               string            `validate:"url"`
+		URI               string            `validate:"uri"`
+		Base64            string            `validate:"base64"`
+		Contains          string            `validate:"contains=purpose"`
+		ContainsAny       string            `validate:"containsany=!@#$"`
+		Excludes          string            `validate:"excludes=text"`
+		ExcludesAll       string            `validate:"excludesall=!@#$"`
+		ExcludesRune      string            `validate:"excludesrune=☻"`
+		ISBN              string            `validate:"isbn"`
+		ISBN10            string            `validate:"isbn10"`
+		ISBN13            string            `validate:"isbn13"`
+		UUID              string            `validate:"uuid"`
+		UUID3             string            `validate:"uuid3"`
+		UUID4             string            `validate:"uuid4"`
+		UUID5             string            `validate:"uuid5"`
+		ULID              string            `validate:"ulid"`
+		ASCII             string            `validate:"ascii"`
+		PrintableASCII    string            `validate:"printascii"`
+		MultiByte         string            `validate:"multibyte"`
+		DataURI           string            `validate:"datauri"`
+		Latitude          string            `validate:"latitude"`
+		Longitude         string            `validate:"longitude"`
+		SSN               string            `validate:"ssn"`
+		IP                string            `validate:"ip"`
+		IPv4              string            `validate:"ipv4"`
+		IPv6              string            `validate:"ipv6"`
+		CIDR              string            `validate:"cidr"`
+		CIDRv4            string            `validate:"cidrv4"`
+		CIDRv6            string            `validate:"cidrv6"`
+		TCPAddr           string            `validate:"tcp_addr"`
+		TCPAddrv4         string            `validate:"tcp4_addr"`
+		TCPAddrv6         string            `validate:"tcp6_addr"`
+		UDPAddr           string            `validate:"udp_addr"`
+		UDPAddrv4         string            `validate:"udp4_addr"`
+		UDPAddrv6         string            `validate:"udp6_addr"`
+		IPAddr            string            `validate:"ip_addr"`
+		IPAddrv4          string            `validate:"ip4_addr"`
+		IPAddrv6          string            `validate:"ip6_addr"`
+		UinxAddr          string            `validate:"unix_addr"` // can't fail from within Go's net package currently, but maybe in the future
+		MAC               string            `validate:"mac"`
+		IsColor           string            `validate:"iscolor"`
+		StrPtrMinLen      *string           `validate:"min=10"`
+		StrPtrMaxLen      *string           `validate:"max=1"`
+		StrPtrLen         *string           `validate:"len=2"`
+		StrPtrLt          *string           `validate:"lt=1"`
+		StrPtrLte         *string           `validate:"lte=1"`
+		StrPtrGt          *string           `validate:"gt=10"`
+		StrPtrGte         *string           `validate:"gte=10"`
+		OneOfString       string            `validate:"oneof=red green"`
+		OneOfInt          int               `validate:"oneof=5 63"`
+		UniqueSlice       []string          `validate:"unique"`
+		UniqueArray       [3]string         `validate:"unique"`
+		UniqueMap         map[string]string `validate:"unique"`
+		JSONString        string            `validate:"json"`
+		JWTString         string            `validate:"jwt"`
+		LowercaseString   string            `validate:"lowercase"`
+		UppercaseString   string            `validate:"uppercase"`
+		Datetime          string            `validate:"datetime=2006-01-02"`
+		PostCode          string            `validate:"postcode_iso3166_alpha2=SG"`
+		PostCodeCountry   string
+		PostCodeByField   string `validate:"postcode_iso3166_alpha2_field=PostCodeCountry"`
+		BooleanString     string `validate:"boolean"`
 	}
 
 	var test Test
@@ -181,9 +195,19 @@ func TestTranslations(t *testing.T) {
 
 	test.MultiByte = "1234feerf"
 
+	test.LowercaseString = "ABCDEFG"
+	test.UppercaseString = "abcdefg"
+
 	s := "toolong"
 	test.StrPtrMaxLen = &s
 	test.StrPtrLen = &s
+
+	test.UniqueSlice = []string{"1234", "1234"}
+	test.UniqueMap = map[string]string{"key1": "1234", "key2": "1234"}
+	test.Datetime = "2008-Feb-01"
+	test.BooleanString = "A"
+
+	test.Inner.RequiredIf = "abcd"
 
 	err = validate.Struct(test)
 	NotEqual(t, err, nil)
@@ -576,6 +600,10 @@ func TestTranslations(t *testing.T) {
 			expected: "RequiredStringは必須フィールドです",
 		},
 		{
+			ns:       "Test.RequiredIf",
+			expected: "RequiredIfは必須フィールドです",
+		},
+		{
 			ns:       "Test.RequiredNumber",
 			expected: "RequiredNumberは必須フィールドです",
 		},
@@ -618,6 +646,50 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.OneOfInt",
 			expected: "OneOfIntは[5 63]のうちのいずれかでなければなりません",
+		},
+		{
+			ns:       "Test.UniqueSlice",
+			expected: "UniqueSliceは一意な値のみを含まなければなりません",
+		},
+		{
+			ns:       "Test.UniqueArray",
+			expected: "UniqueArrayは一意な値のみを含まなければなりません",
+		},
+		{
+			ns:       "Test.UniqueMap",
+			expected: "UniqueMapは一意な値のみを含まなければなりません",
+		},
+		{
+			ns:       "Test.JSONString",
+			expected: "JSONStringは正しいJSON文字列でなければなりません",
+		},
+		{
+			ns:       "Test.JWTString",
+			expected: "JWTStringは正しいJWT文字列でなければなりません",
+		},
+		{
+			ns:       "Test.LowercaseString",
+			expected: "LowercaseStringは小文字でなければなりません",
+		},
+		{
+			ns:       "Test.UppercaseString",
+			expected: "UppercaseStringは大文字でなければなりません",
+		},
+		{
+			ns:       "Test.Datetime",
+			expected: "Datetimeは2006-01-02の書式と一致しません",
+		},
+		{
+			ns:       "Test.PostCode",
+			expected: "PostCodeは国名コードSGの郵便番号形式と一致しません",
+		},
+		{
+			ns:       "Test.PostCodeByField",
+			expected: "PostCodeByFieldはPostCodeCountryフィールドで指定された国名コードの郵便番号形式と一致しません",
+		},
+		{
+			ns:       "Test.BooleanString",
+			expected: "BooleanStringは正しいブール値でなければなりません",
 		},
 	}
 

--- a/translations/ja/ja_test.go
+++ b/translations/ja/ja_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestTranslations(t *testing.T) {
-
 	japanese := ja_locale.New()
 	uni := ut.New(japanese, japanese)
 	trans, _ := uni.GetTranslator("ja")


### PR DESCRIPTION
## Enhances

Add Japanese translations

* `required_if`
* `unique`
* `json`
* `jwt`
* `lowercase`
* `uppercase`
* `datetime`
* `postcode_iso3166_alpha2`
* `postcode_iso3166_alpha2_field`
* `boolean`

### For Japanese

日本語訳が未実装だった10種のタグの翻訳を追加しました
特筆すべきタグについて以下に補足します

* `unique`
  * 原文: `{0} must contain unique values`
    * 日本語訳として以下3パターンが想定されました
      1. `{0}は一意な値を含まなければなりません` 
      2. `{0}は一意な値のみを含まなければなりません`
      3. `{0}は一意な値でなければなりません`
    * `a` の翻訳は最低1個一意であれば良いとも受け取れる点と、`c` の翻訳は原文に `contain` という英単語が含まれる点から、`b` が自然と考えました 
* `postcode_iso3166_alpha2_field`
  * そもそもの仕様がわかりにくいです
    * `postcode_iso3166_alpha2_field ` タグが記述されたフィールドの『値』には郵便番号を格納する
    * `postcode_iso3166_alpha2_field` タグの `=` の右側に同じ構造体の別のフィールド名を記述する
    * 記述された別のフィールドの値に国名コードを指定する
  * https://go.dev/play/p/G75GPiK78O1?v=goprev.go?download=true
  * わかりにくかったので翻訳文は原文にはない `指定された` というワードで補足しました
    * 原文: `{0} does not match postcode format of country in {1} field`
    * 翻訳: `{0}は{1}フィールドで指定された国名コードの郵便番号形式と一致しません`



----

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers