### PR TITLE
Added "http_url" tag to validate if the variable is a HTTP(s) URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Baked-in Validations
 | unix_addr | Unix domain socket end point Address |
 | uri | URI String |
 | url | URL String |
+| http_url | HTTP URL String |
 | url_encoded | URL Encoded |
 | urn_rfc2141 | Urn RFC 2141 String |
 

--- a/baked_in.go
+++ b/baked_in.go
@@ -121,6 +121,7 @@ var (
 		"e164":                          isE164,
 		"email":                         isEmail,
 		"url":                           isURL,
+		"http_url":                      isHttpURL,
 		"uri":                           isURI,
 		"urn_rfc2141":                   isUrnRFC2141, // RFC 2141
 		"file":                          isFile,
@@ -1365,6 +1366,24 @@ func isURL(fl FieldLevel) bool {
 		}
 
 		return true
+	}
+
+	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
+}
+
+// isHttpURL is the validation function for validating if the current field's value is a valid HTTP(s) URL.
+func isHttpURL(fl FieldLevel) bool {
+	if !isURL(fl) {
+		return false
+	}
+
+	field := fl.Field()
+
+	switch field.Kind() {
+	case reflect.String:
+
+		s := field.String()
+		return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
 	}
 
 	panic(fmt.Sprintf("Bad field type %T", field.Interface()))

--- a/baked_in.go
+++ b/baked_in.go
@@ -1378,11 +1378,10 @@ func isHttpURL(fl FieldLevel) bool {
 	}
 
 	field := fl.Field()
-
 	switch field.Kind() {
 	case reflect.String:
 
-		s := field.String()
+		s := strings.ToLower(field.String())
 		return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
 	}
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -7808,6 +7808,7 @@ func TestHttpUrl(t *testing.T) {
 		{"http://foobar.org:8080/", true},
 		{"ftp://foobar.ru/", false},
 		{"file:///etc/passwd", false},
+		{"file://C:/windows/win.ini", false},
 		{"http://user:pass@www.foobar.com/", true},
 		{"http://127.0.0.1/", true},
 		{"http://duckduckgo.com/?q=%2F", true},

--- a/validator_test.go
+++ b/validator_test.go
@@ -7793,6 +7793,74 @@ func TestUrl(t *testing.T) {
 	PanicMatches(t, func() { _ = validate.Var(i, "url") }, "Bad field type int")
 }
 
+func TestHttpUrl(t *testing.T) {
+	tests := []struct {
+		param    string
+		expected bool
+	}{
+		{"http://foo.bar#com", true},
+		{"http://foobar.com", true},
+		{"https://foobar.com", true},
+		{"foobar.com", false},
+		{"http://foobar.coffee/", true},
+		{"http://foobar.中文网/", true},
+		{"http://foobar.org/", true},
+		{"http://foobar.org:8080/", true},
+		{"ftp://foobar.ru/", false},
+		{"file:///etc/passwd", false},
+		{"http://user:pass@www.foobar.com/", true},
+		{"http://127.0.0.1/", true},
+		{"http://duckduckgo.com/?q=%2F", true},
+		{"http://localhost:3000/", true},
+		{"http://foobar.com/?foo=bar#baz=qux", true},
+		{"http://foobar.com?foo=bar", true},
+		{"http://www.xn--froschgrn-x9a.net/", true},
+		{"", false},
+		{"xyz://foobar.com", false},
+		{"invalid.", false},
+		{".com", false},
+		{"rtmp://foobar.com", false},
+		{"http://www.foo_bar.com/", true},
+		{"http://localhost:3000/", true},
+		{"http://foobar.com/#baz", true},
+		{"http://foobar.com#baz=qux", true},
+		{"http://foobar.com/t$-_.+!*\\'(),", true},
+		{"http://www.foobar.com/~foobar", true},
+		{"http://www.-foobar.com/", true},
+		{"http://www.foo---bar.com/", true},
+		{"mailto:someone@example.com", false},
+		{"irc://irc.server.org/channel", false},
+		{"irc://#channel@network", false},
+		{"/abs/test/dir", false},
+		{"./rel/test/dir", false},
+	}
+
+	validate := New()
+
+	for i, test := range tests {
+
+		errs := validate.Var(test.param, "http_url")
+
+		if test.expected {
+			if !IsEqual(errs, nil) {
+				t.Fatalf("Index: %d HTTP URL failed Error: %s", i, errs)
+			}
+		} else {
+			if IsEqual(errs, nil) {
+				t.Fatalf("Index: %d HTTP URL failed Error: %s", i, errs)
+			} else {
+				val := getError(errs, "", "")
+				if val.Tag() != "http_url" {
+					t.Fatalf("Index: %d HTTP URL failed Error: %s", i, errs)
+				}
+			}
+		}
+	}
+
+	i := 1
+	PanicMatches(t, func() { _ = validate.Var(i, "http_url") }, "Bad field type int")
+}
+
 func TestUri(t *testing.T) {
 	tests := []struct {
 		param    string

--- a/validator_test.go
+++ b/validator_test.go
@@ -7800,6 +7800,7 @@ func TestHttpUrl(t *testing.T) {
 	}{
 		{"http://foo.bar#com", true},
 		{"http://foobar.com", true},
+		{"HTTP://foobar.com", true},
 		{"https://foobar.com", true},
 		{"foobar.com", false},
 		{"http://foobar.coffee/", true},
@@ -7817,6 +7818,7 @@ func TestHttpUrl(t *testing.T) {
 		{"http://foobar.com?foo=bar", true},
 		{"http://www.xn--froschgrn-x9a.net/", true},
 		{"", false},
+		{"a://b", false},
 		{"xyz://foobar.com", false},
 		{"invalid.", false},
 		{".com", false},


### PR DESCRIPTION
## Enhances

In most cases, the application only accepts the HTTP URL as input. But we don't have a suitable tag to validate it.

For example, application use `url` tag to validate the user input then use it as the cURL's parameter to download a network file:

```go
package main

import (
	"os"
	"os/exec"

	"github.com/go-playground/validator/v10"
)

func main() {
	var input = os.Args[1]
	var v = validator.New()
	err := v.Var(input, "url")
	if err != nil {
		panic(err)
	}

	cmd := exec.Command("curl", input)
	cmd.Stdout = os.Stdout
	cmd.Stderr = os.Stderr
	err = cmd.Run()
	if err != nil {
		panic(err)
	}
}
```

But it's not safe if user use `file:///etc/passwd` as the input, it will download the local file unexpected.

So I added a new tag named "http_url" to enhance the current situation.

**Make sure that you've checked the boxes below before you submit PR:**
- [ ] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers