### PR TITLE
Add FQDN en translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ _testmain.go
 *.txt
 cover.html
 README.html
+.idea

--- a/translations/en/en.go
+++ b/translations/en/en.go
@@ -1267,6 +1267,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "fqdn",
+			translation: "{0} must be a valid FQDN",
+			override:    false,
+		},
+		{
 			tag:         "unique",
 			translation: "{0} must contain unique values",
 			override:    false,

--- a/translations/en/en_test.go
+++ b/translations/en/en_test.go
@@ -130,6 +130,7 @@ func TestTranslations(t *testing.T) {
 		IPAddrv6          string            `validate:"ip6_addr"`
 		UinxAddr          string            `validate:"unix_addr"` // can't fail from within Go's net package currently, but maybe in the future
 		MAC               string            `validate:"mac"`
+		FQDN              string            `validate:"fqdn"`
 		IsColor           string            `validate:"iscolor"`
 		StrPtrMinLen      *string           `validate:"min=10"`
 		StrPtrMaxLen      *string           `validate:"max=1"`
@@ -225,6 +226,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.MAC",
 			expected: "MAC must contain a valid MAC address",
+		},
+		{
+			ns:       "Test.FQDN",
+			expected: "FQDN must be a valid FQDN",
 		},
 		{
 			ns:       "Test.IPAddr",


### PR DESCRIPTION
## Fixes Or Enhances
Adds an english translation for fqdn


**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers