### PR TITLE
added IsEqIgnoreCase and IsNeIgnoreCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,11 +207,13 @@ Baked-in Validations
 | Tag | Description |
 | - | - |
 | eq | Equals |
+| eqIgnoreCase | Equals ignoring case |
 | gt | Greater than|
 | gte | Greater than or equal |
 | lt | Less Than |
 | lte | Less Than or Equal |
 | ne | Not Equal |
+| neIgnoreCase | Not Equal ignoring case |
 
 ### Other:
 | Tag | Description |

--- a/baked_in.go
+++ b/baked_in.go
@@ -86,7 +86,9 @@ var (
 		"min":                           hasMinOf,
 		"max":                           hasMaxOf,
 		"eq":                            isEq,
+		"eqIgnoreCase":                  isEqIgnoreCase,
 		"ne":                            isNe,
+		"neIgnoreCase":                  isNeIgnoreCase,
 		"lt":                            isLt,
 		"lte":                           isLte,
 		"gt":                            isGt,
@@ -889,6 +891,12 @@ func isNe(fl FieldLevel) bool {
 	return !isEq(fl)
 }
 
+// isNe is the validation function for validating that the field's string value does not equal the
+// provided param value. The comparison is case-insensitive
+func isNeIgnoreCase(fl FieldLevel) bool {
+	return !isEqIgnoreCase(fl)
+}
+
 // isLteCrossStructField is the validation function for validating if the current field's value is less than or equal to the field, within a separate struct, specified by the param's value.
 func isLteCrossStructField(fl FieldLevel) bool {
 	field := fl.Field()
@@ -1260,6 +1268,22 @@ func isEq(fl FieldLevel) bool {
 	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
 }
 
+// isEqIgnoreCase is the validation function for validating if the current field's string value is
+//equal to the param's value.
+// The comparison is case-insensitive.
+func isEqIgnoreCase(fl FieldLevel) bool {
+	field := fl.Field()
+	param := fl.Param()
+
+	switch field.Kind() {
+
+	case reflect.String:
+		return strings.ToLower(field.String()) == strings.ToLower(param)
+	}
+
+	panic(fmt.Sprintf("Bad field type %T", field.Interface()))
+}
+
 // isPostcodeByIso3166Alpha2 validates by value which is country code in iso 3166 alpha 2
 // example: `postcode_iso3166_alpha2=US`
 func isPostcodeByIso3166Alpha2(fl FieldLevel) bool {
@@ -1539,7 +1563,9 @@ func requireCheckFieldKind(fl FieldLevel, param string, defaultNotFoundValue boo
 }
 
 // requireCheckFieldValue is a func for check field value
-func requireCheckFieldValue(fl FieldLevel, param string, value string, defaultNotFoundValue bool) bool {
+func requireCheckFieldValue(
+	fl FieldLevel, param string, value string, defaultNotFoundValue bool,
+) bool {
 	field, kind, _, found := fl.GetStructFieldOKAdvanced2(fl.Parent(), param)
 	if !found {
 		return defaultNotFoundValue
@@ -2316,7 +2342,9 @@ func isHostnamePort(fl FieldLevel) bool {
 		return false
 	}
 	// Port must be a iny <= 65535.
-	if portNum, err := strconv.ParseInt(port, 10, 32); err != nil || portNum > 65535 || portNum < 1 {
+	if portNum, err := strconv.ParseInt(
+		port, 10, 32,
+	); err != nil || portNum > 65535 || portNum < 1 {
 		return false
 	}
 

--- a/baked_in.go
+++ b/baked_in.go
@@ -1278,7 +1278,7 @@ func isEqIgnoreCase(fl FieldLevel) bool {
 	switch field.Kind() {
 
 	case reflect.String:
-		return strings.ToLower(field.String()) == strings.ToLower(param)
+		return strings.EqualFold(field.String(), param)
 	}
 
 	panic(fmt.Sprintf("Bad field type %T", field.Interface()))

--- a/validator_test.go
+++ b/validator_test.go
@@ -5207,6 +5207,24 @@ func TestIsNeValidation(t *testing.T) {
 	Equal(t, errs, nil)
 }
 
+func TestIsNeIgnoreCaseValidation(t *testing.T) {
+	var errs error
+	validate := New()
+	s := "abcd"
+	now := time.Now()
+
+	errs = validate.Var(s, "neIgnoreCase=efgh")
+	Equal(t, errs, nil)
+
+	errs = validate.Var(s, "neIgnoreCase=AbCd")
+	NotEqual(t, errs, nil)
+	AssertError(t, errs, "", "", "", "", "neIgnoreCase")
+
+	PanicMatches(
+		t, func() { _ = validate.Var(now, "eqIgnoreCase=abcd") }, "Bad field type time.Time",
+	)
+}
+
 func TestIsEqFieldValidation(t *testing.T) {
 	var errs error
 	validate := New()
@@ -5482,6 +5500,23 @@ func TestIsEqValidation(t *testing.T) {
 	timeDurationOmitemptyTest := &TimeDurationOmitemptyTest{time.Duration(0)}
 	errs = validate.Struct(timeDurationOmitemptyTest)
 	Equal(t, errs, nil)
+}
+
+func TestIsEqIgnoreCaseValidation(t *testing.T) {
+	var errs error
+	validate := New()
+	s := "abcd"
+	now := time.Now()
+
+	errs = validate.Var(s, "eqIgnoreCase=abcd")
+	Equal(t, errs, nil)
+
+	errs = validate.Var(s, "eqIgnoreCase=AbCd")
+	Equal(t, errs, nil)
+
+	PanicMatches(
+		t, func() { _ = validate.Var(now, "eqIgnoreCase=abcd") }, "Bad field type time.Time",
+	)
 }
 
 func TestOneOfValidation(t *testing.T) {


### PR DESCRIPTION
## Fixes Or Enhances
I added the functions isEqIgnoreCase and isNeIgnoreCase to make case-insensitive validation.

**Make sure that you've checked the boxes below before you submit PR:**
- [ x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers