### PR TITLE
Allow registering translations without a Validate instance

### DIFF
--- a/translations/en/en.go
+++ b/translations/en/en.go
@@ -16,6 +16,19 @@ import (
 // RegisterDefaultTranslations registers a set of default translations
 // for all built in tag's in validator; you may add your own as desired.
 func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (err error) {
+	tf, err := RegisterDefaultTranslationsFunc(trans)
+	if err != nil {
+		return err
+	}
+
+	return v.RegisterTranslationsFunc(trans, tf)
+}
+
+// RegisterDefaultTranslationsFunc registers a set of default translations
+// for all built in tag's in validator; you may add your own as desired.
+// This version returns a map[tag]validator.TranslationFunc, which can be set on a validator using
+// validator.Validate.RegisterTranslationsFunc.
+func RegisterDefaultTranslationsFunc(trans ut.Translator) (map[string]validator.TranslationFunc, error) {
 	translations := []struct {
 		tag             string
 		translation     string
@@ -1363,24 +1376,31 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		},
 	}
 
+	var err error
+	ret := map[string]validator.TranslationFunc{}
+
 	for _, t := range translations {
 
 		if t.customTransFunc != nil && t.customRegisFunc != nil {
-			err = v.RegisterTranslation(t.tag, trans, t.customRegisFunc, t.customTransFunc)
+			ret[t.tag] = t.customTransFunc
+			err = t.customRegisFunc(trans)
 		} else if t.customTransFunc != nil && t.customRegisFunc == nil {
-			err = v.RegisterTranslation(t.tag, trans, registrationFunc(t.tag, t.translation, t.override), t.customTransFunc)
+			ret[t.tag] = t.customTransFunc
+			err = registrationFunc(t.tag, t.translation, t.override)(trans)
 		} else if t.customTransFunc == nil && t.customRegisFunc != nil {
-			err = v.RegisterTranslation(t.tag, trans, t.customRegisFunc, translateFunc)
+			ret[t.tag] = translateFunc
+			err = t.customRegisFunc(trans)
 		} else {
-			err = v.RegisterTranslation(t.tag, trans, registrationFunc(t.tag, t.translation, t.override), translateFunc)
+			ret[t.tag] = translateFunc
+			err = registrationFunc(t.tag, t.translation, t.override)(trans)
 		}
 
 		if err != nil {
-			return
+			return nil, err
 		}
 	}
 
-	return
+	return ret, nil
 }
 
 func registrationFunc(tag string, translation string, override bool) validator.RegisterTranslationsFunc {

--- a/validator_instance.go
+++ b/validator_instance.go
@@ -190,14 +190,14 @@ func (v *Validate) ValidateMap(data map[string]interface{}, rules map[string]int
 //
 // eg. to use the names which have been specified for JSON representations of structs, rather than normal Go field names:
 //
-//    validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
-//        name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
-//        // skip if tag key says it should be ignored
-//        if name == "-" {
-//            return ""
-//        }
-//        return name
-//    })
+//	validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
+//	    name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
+//	    // skip if tag key says it should be ignored
+//	    if name == "-" {
+//	        return ""
+//	    }
+//	    return name
+//	})
 func (v *Validate) RegisterTagNameFunc(fn TagNameFunc) {
 	v.tagNameFunc = fn
 	v.hasTagNameFunc = true
@@ -346,6 +346,27 @@ func (v *Validate) RegisterTranslation(tag string, trans ut.Translator, register
 	}
 
 	m[tag] = translationFn
+
+	return
+}
+
+// RegisterTranslationsFunc registers translations against the provided tag.
+// This assumes that the tag translations have already been added to the Translator.
+func (v *Validate) RegisterTranslationsFunc(trans ut.Translator, translationsFn map[string]TranslationFunc) (err error) {
+
+	if v.transTagFunc == nil {
+		v.transTagFunc = make(map[ut.Translator]map[string]TranslationFunc)
+	}
+
+	m, ok := v.transTagFunc[trans]
+	if !ok {
+		m = make(map[string]TranslationFunc)
+		v.transTagFunc[trans] = m
+	}
+
+	for tag, fn := range translationsFn {
+		m[tag] = fn
+	}
 
 	return
 }


### PR DESCRIPTION
## Fixes Or Enhances

The function `Validate.RegisterTranslation(tag string, trans ut.Translator, registerFn RegisterTranslationsFunc, translationFn TranslationFunc) (err error)` does 2 things: it adds tags translations to `ut.Translator`, and register a `TranslationFunc` for each tag in `Validate.

This method prevents creating new `Validate` instances using the same `ut.Translator`, as a second instantiation would try to add again each translation, which would return an `ErrConflictingTranslation` error, and none of the translations functions would be set.

This PR creates a `Validate.RegisterTranslationsFunc(trans ut.Translator, translationsFn map[string]TranslationFunc)` function which allows setting the translation functions for each tag without registering with `ut.Translator`, and also creates a `RegisterDefaultTranslationsFunc(trans ut.Translator) (map[string]validator.TranslationFunc, error)` for each language which returns a map of the tag=>TranslationFunc, which can be sent on the new `Validate` method.

The current `RegisterDefaultTranslations` method for the languages keeps working as today, calling both of the new functions, so it is totally compatible with the current implemenation.

With this change, I can call `tf, err := en_translations.RegisterDefaultTranslationsFunc(trans)` a single time during initialization, and for each new `Validate` instance I create, I call `validate.RegisterTranslationsFunc(trans, tf)`, reusing all the language loading.

This initial PR just updates the english language, I will update all others if this is ok.

**Make sure that you've checked the boxes below before you submit PR:**
- [X] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers