### PR TITLE
feat: add eth_addr_checksum validation, update eth_addr

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -140,6 +140,7 @@ var (
 		"isbn10":                        isISBN10,
 		"isbn13":                        isISBN13,
 		"eth_addr":                      isEthereumAddress,
+		"eth_addr_checksum":             isEthereumAddressChecksum,
 		"btc_addr":                      isBitcoinAddress,
 		"btc_addr_bech32":               isBitcoinBech32Address,
 		"uuid":                          isUUID,
@@ -613,14 +614,16 @@ func isISBN10(fl FieldLevel) bool {
 func isEthereumAddress(fl FieldLevel) bool {
 	address := fl.Field().String()
 
+	return ethAddressRegex.MatchString(address)
+}
+
+// isEthereumAddressChecksum is the validation function for validating if the field's value is a valid checksumed Ethereum address.
+func isEthereumAddressChecksum(fl FieldLevel) bool {
+	address := fl.Field().String()
+
 	if !ethAddressRegex.MatchString(address) {
 		return false
 	}
-
-	if ethAddressRegexUpper.MatchString(address) || ethAddressRegexLower.MatchString(address) {
-		return true
-	}
-
 	// Checksum validation. Reference: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md
 	address = address[2:] // Skip "0x" prefix.
 	h := sha3.NewLegacyKeccak256()

--- a/regexes.go
+++ b/regexes.go
@@ -118,8 +118,6 @@ var (
 	btcUpperAddressRegexBech32 = regexp.MustCompile(btcAddressUpperRegexStringBech32)
 	btcLowerAddressRegexBech32 = regexp.MustCompile(btcAddressLowerRegexStringBech32)
 	ethAddressRegex            = regexp.MustCompile(ethAddressRegexString)
-	ethAddressRegexUpper       = regexp.MustCompile(ethAddressUpperRegexString)
-	ethAddressRegexLower       = regexp.MustCompile(ethAddressLowerRegexString)
 	uRLEncodedRegex            = regexp.MustCompile(uRLEncodedRegexString)
 	hTMLEncodedRegex           = regexp.MustCompile(hTMLEncodedRegexString)
 	hTMLRegex                  = regexp.MustCompile(hTMLRegexString)


### PR DESCRIPTION
**Rationale**

- ethereum addresses are derived from a public key (the last 20 bytes). The network accepts any case insensitive address as long as it is a 40 char alphanumeric (When the last 20 bytes are converted to hex). It is 0x prefixed so that it becomes 42 in length, hence the current eth_addr implementation is modified to reflect this.
- Checksum-ing is optional on ethereum and is a way of typo checking the address hence this is introduced as a new validation i.e. eth_addr_checksum.

refs:

- https://github.com/ethereum/go-ethereum/blob/master/crypto/crypto.go#L275
- https://goethereumbook.org/en/wallet-generate/
- https://goethereumbook.org/en/address-check/
- https://support.metamask.io/hc/en-us/articles/4702972178459-The-Ethereum-address-format-and-why-it-matters-when-using-MetaMask

other lib implemntations:

- https://github.com/chaintool-py/funga-eth/blob/master/funga/eth/encoding.py#L42

## Fixes Or Enhances

Fixes #1073 

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers