### PR TITLE
Fix typos and remove duplicated words in comments

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -33,7 +33,7 @@ type Func func(fl FieldLevel) bool
 // validation needs. The return value should be true when validation succeeds.
 type FuncCtx func(ctx context.Context, fl FieldLevel) bool
 
-// wrapFunc wraps noramal Func makes it compatible with FuncCtx
+// wrapFunc wraps normal Func makes it compatible with FuncCtx
 func wrapFunc(fn Func) FuncCtx {
 	if fn == nil {
 		return nil // be sure not to wrap a bad function.

--- a/doc.go
+++ b/doc.go
@@ -146,7 +146,7 @@ use the UTF-8 hex representation 0x7C, which is replaced in the code as a pipe,
 so the above will become excludesall=0x7C
 
 	type Test struct {
-		Field `validate:"excludesall=|"`    // BAD! Do not include a a pipe!
+		Field `validate:"excludesall=|"`    // BAD! Do not include a pipe!
 		Field `validate:"excludesall=0x7C"` // GOOD! Use the UTF-8 hex representation.
 	}
 
@@ -239,7 +239,7 @@ Example #2
 
 	map[[2]string]string with validation tag "gt=0,dive,keys,dive,eq=1|eq=2,endkeys,required"
 	// gt=0 will be applied to the map itself
-	// eq=1|eq=2 will be applied to each array element in the the map keys
+	// eq=1|eq=2 will be applied to each array element in the map keys
 	// required will be applied to map values
 
 # Required
@@ -916,7 +916,7 @@ this with the omitempty tag.
 # Base64URL String
 
 This validates that a string value contains a valid base64 URL safe value
-according the the RFC4648 spec.
+according the RFC4648 spec.
 Although an empty string is a valid base64 URL safe value, this will report
 an empty string as an error, if you wish to accept an empty string as valid
 you can use this with the omitempty tag.
@@ -927,7 +927,7 @@ you can use this with the omitempty tag.
 # Base64RawURL String
 
 This validates that a string value contains a valid base64 URL safe value,
-but without = padding, according the the RFC4648 spec, section 3.2.
+but without = padding, according the RFC4648 spec, section 3.2.
 Although an empty string is a valid base64 URL safe value, this will report
 an empty string as an error, if you wish to accept an empty string as valid
 you can use this with the omitempty tag.
@@ -1361,7 +1361,7 @@ More information on https://cve.mitre.org/
 
 # Credit Card
 
-This validates that a string value contains a valid credit card number using Luhn algoritm.
+This validates that a string value contains a valid credit card number using Luhn algorithm.
 
 	Usage: credit_card
 

--- a/struct_level.go
+++ b/struct_level.go
@@ -62,7 +62,7 @@ type StructLevel interface {
 	// existing namespace that validator is on.
 	// e.g. pass 'User.FirstName' or 'Users[0].FirstName' depending
 	// on the nesting. most of the time they will be blank, unless you validate
-	// at a level lower the the current field depth
+	// at a level lower the current field depth
 	ReportValidationErrors(relativeNamespace, relativeActualNamespace string, errs ValidationErrors)
 }
 
@@ -74,7 +74,7 @@ var _ StructLevel = new(validate)
 // if not is a nested struct.
 //
 // this is only called when within Struct and Field Level validation and
-// should not be relied upon for an acurate value otherwise.
+// should not be relied upon for an accurate value otherwise.
 func (v *validate) Top() reflect.Value {
 	return v.top
 }
@@ -85,7 +85,7 @@ func (v *validate) Top() reflect.Value {
 // if not is a nested struct.
 //
 // this is only called when within Struct and Field Level validation and
-// should not be relied upon for an acurate value otherwise.
+// should not be relied upon for an accurate value otherwise.
 func (v *validate) Parent() reflect.Value {
 	return v.slflParent
 }

--- a/util.go
+++ b/util.go
@@ -234,7 +234,7 @@ func asInt(param string) int64 {
 func asIntFromTimeDuration(param string) int64 {
 	d, err := time.ParseDuration(param)
 	if err != nil {
-		// attempt parsing as an an integer assuming nanosecond precision
+		// attempt parsing as an integer assuming nanosecond precision
 		return asInt(param)
 	}
 	return int64(d)

--- a/validator_instance.go
+++ b/validator_instance.go
@@ -57,7 +57,7 @@ var (
 
 // FilterFunc is the type used to filter fields using
 // StructFiltered(...) function.
-// returning true results in the field being filtered/skiped from
+// returning true results in the field being filtered/skipped from
 // validation
 type FilterFunc func(ns []byte) bool
 
@@ -151,7 +151,7 @@ func (v *Validate) SetTagName(name string) {
 }
 
 // ValidateMapCtx validates a map using a map of validation rules and allows passing of contextual
-// validation validation information via context.Context.
+// validation information via context.Context.
 func (v Validate) ValidateMapCtx(ctx context.Context, data map[string]interface{}, rules map[string]interface{}) map[string]interface{} {
 	errs := make(map[string]interface{})
 	for field, rule := range rules {
@@ -451,7 +451,7 @@ func (v *Validate) StructPartial(s interface{}, fields ...string) error {
 }
 
 // StructPartialCtx validates the fields passed in only, ignoring all others and allows passing of contextual
-// validation validation information via context.Context
+// validation information via context.Context
 // Fields may be provided in a namespaced fashion relative to the  struct provided
 // eg. NestedStruct.Field or NestedArrayField[0].Struct.Name
 //
@@ -541,7 +541,7 @@ func (v *Validate) StructExcept(s interface{}, fields ...string) error {
 }
 
 // StructExceptCtx validates all fields except the ones passed in and allows passing of contextual
-// validation validation information via context.Context
+// validation information via context.Context
 // Fields may be provided in a namespaced fashion relative to the  struct provided
 // i.e. NestedStruct.Field or NestedArrayField[0].Struct.Name
 //

--- a/validator_test.go
+++ b/validator_test.go
@@ -9319,11 +9319,11 @@ func TestStructFiltered(t *testing.T) {
 	errs = validate.StructFiltered(tPartial, p2)
 	Equal(t, errs, nil)
 
-	// this isn't really a robust test, but is ment to illustrate the ANON CASE below
+	// this isn't really a robust test, but is meant to illustrate the ANON CASE below
 	errs = validate.StructFiltered(tPartial.SubSlice[0], p3)
 	Equal(t, errs, nil)
 
-	// mod tParial for required feild and re-test making sure invalid fields are NOT required:
+	// mod tParial for required field and re-test making sure invalid fields are NOT required:
 	tPartial.Required = ""
 
 	// inversion and retesting Partial to generate failures:
@@ -9339,7 +9339,7 @@ func TestStructFiltered(t *testing.T) {
 	errs = validate.StructFiltered(tPartial, p1)
 	Equal(t, errs, nil)
 
-	// will fail as unset feild is tested
+	// will fail as unset field is tested
 	errs = validate.StructFiltered(tPartial, p2)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TestPartial.Anonymous.A", "TestPartial.Anonymous.A", "A", "A", "required")
@@ -9368,7 +9368,7 @@ func TestStructFiltered(t *testing.T) {
 	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "TestPartial.SubSlice[0].Test", "TestPartial.SubSlice[0].Test", "Test", "Test", "required")
 
-	// reset struct in slice, and unset struct in slice in unset posistion
+	// reset struct in slice, and unset struct in slice in unset position
 	tPartial.SubSlice[0].Test = "Required"
 
 	// these will pass as the unset item is NOT tested


### PR DESCRIPTION
## Fixes Or Enhances

This PR fixes typos and remove duplicates in comments.

- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers