### PR TITLE
Use strings.ReplaceAll(...) instead of strings.Replace(..., -1)

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -244,7 +244,7 @@ func parseOneOfParam2(s string) []string {
 		oneofValsCacheRWLock.Lock()
 		vals = splitParamsRegex.FindAllString(s, -1)
 		for i := 0; i < len(vals); i++ {
-			vals[i] = strings.Replace(vals[i], "'", "", -1)
+			vals[i] = strings.ReplaceAll(vals[i], "'", "")
 		}
 		oneofValsCache[s] = vals
 		oneofValsCacheRWLock.Unlock()

--- a/cache.go
+++ b/cache.go
@@ -299,7 +299,7 @@ func (v *Validate) parseFieldTagsRecursive(tag string, fieldName string, alias s
 				}
 
 				if len(vals) > 1 {
-					current.param = strings.Replace(strings.Replace(vals[1], utf8HexComma, ",", -1), utf8Pipe, "|", -1)
+					current.param = strings.ReplaceAll(strings.ReplaceAll(vals[1], utf8HexComma, ","), utf8Pipe, "|")
 				}
 			}
 			current.isBlockEnd = true


### PR DESCRIPTION
## Fixes Or Enhances

- Refactor to `strings.ReplaceAll`.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers