### PR TITLE
allow byte slice and json raw message in IsJson

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -2575,11 +2575,6 @@ func isJSON(fl FieldLevel) bool {
 	case reflect.Slice:
 		fieldType := field.Type()
 
-		if fieldType.ConvertibleTo(jsonRawMessageType) {
-			rawMsg := field.Convert(jsonRawMessageType).Interface().(json.RawMessage)
-			return json.Valid(rawMsg)
-		}
-
 		if fieldType.ConvertibleTo(byteSliceType) {
 			b := field.Convert(byteSliceType).Interface().([]byte)
 			return json.Valid(b)

--- a/validator_instance.go
+++ b/validator_instance.go
@@ -2,7 +2,6 @@ package validator
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -54,8 +53,7 @@ var (
 	timeDurationType = reflect.TypeOf(time.Duration(0))
 	timeType         = reflect.TypeOf(time.Time{})
 
-	jsonRawMessageType = reflect.TypeOf(json.RawMessage{})
-	byteSliceType      = reflect.TypeOf([]byte{})
+	byteSliceType = reflect.TypeOf([]byte{})
 
 	defaultCField = &cField{namesEqual: true}
 )

--- a/validator_instance.go
+++ b/validator_instance.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -52,6 +53,9 @@ const (
 var (
 	timeDurationType = reflect.TypeOf(time.Duration(0))
 	timeType         = reflect.TypeOf(time.Time{})
+
+	jsonRawMessageType = reflect.TypeOf(json.RawMessage{})
+	byteSliceType      = reflect.TypeOf([]byte{})
 
 	defaultCField = &cField{namesEqual: true}
 )

--- a/validator_test.go
+++ b/validator_test.go
@@ -11958,7 +11958,7 @@ func TestGetTag(t *testing.T) {
 
 func TestJSONValidation(t *testing.T) {
 	tests := []struct {
-		param    string
+		param    interface{}
 		expected bool
 	}{
 		{`foo`, false},
@@ -11975,6 +11975,34 @@ func TestJSONValidation(t *testing.T) {
 		{`true`, true},
 		{`null`, true},
 		{`"null"`, true},
+		{json.RawMessage(`foo`), false},
+		{json.RawMessage(`}{`), false},
+		{json.RawMessage(`{]`), false},
+		{json.RawMessage(`{}`), true},
+		{json.RawMessage(`{"foo":"bar"}`), true},
+		{json.RawMessage(`{"foo":"bar","bar":{"baz":["qux"]}}`), true},
+		{json.RawMessage(`{"foo": 3 "bar": 4}`), false},
+		{json.RawMessage(`{"foo": 3 ,"bar": 4`), false},
+		{json.RawMessage(`{foo": 3, "bar": 4}`), false},
+		{json.RawMessage(`foo`), false},
+		{json.RawMessage(`1`), true},
+		{json.RawMessage(`true`), true},
+		{json.RawMessage(`null`), true},
+		{json.RawMessage(`"null"`), true},
+		{[]byte(`foo`), false},
+		{[]byte(`}{`), false},
+		{[]byte(`{]`), false},
+		{[]byte(`{}`), true},
+		{[]byte(`{"foo":"bar"}`), true},
+		{[]byte(`{"foo":"bar","bar":{"baz":["qux"]}}`), true},
+		{[]byte(`{"foo": 3 "bar": 4}`), false},
+		{[]byte(`{"foo": 3 ,"bar": 4`), false},
+		{[]byte(`{foo": 3, "bar": 4}`), false},
+		{[]byte(`foo`), false},
+		{[]byte(`1`), true},
+		{[]byte(`true`), true},
+		{[]byte(`null`), true},
+		{[]byte(`"null"`), true},
 	}
 
 	validate := New()


### PR DESCRIPTION
## Fixes Or Enhances

* json.RawMessage and []byte can be validated as JSON 

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers