### PR TITLE
fix: excluded functions not triggering on structs

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -14,6 +14,7 @@ const (
 	typeDefault tagType = iota
 	typeOmitEmpty
 	typeIsDefault
+	typeExcluded
 	typeNoStructLevel
 	typeStructOnly
 	typeDive
@@ -263,6 +264,8 @@ func (v *Validate) parseFieldTagsRecursive(tag string, fieldName string, alias s
 		default:
 			if t == isdefault {
 				current.typeof = typeIsDefault
+			} else if len(t) >= 8 && t[:8] == "excluded" {
+				current.typeof = typeExcluded
 			}
 			// if a pipe character is needed within the param you must use the utf8Pipe representation "0x7C"
 			orVals := strings.Split(t, orSeparator)

--- a/validator.go
+++ b/validator.go
@@ -170,7 +170,7 @@ func (v *validate) traverseField(ctx context.Context, parent reflect.Value, curr
 
 				if ct.typeof == typeStructOnly {
 					goto CONTINUE
-				} else if ct.typeof == typeIsDefault {
+				} else if ct.typeof == typeIsDefault || ct.typeof == typeExcluded {
 					// set Field Level fields
 					v.slflParent = parent
 					v.flField = current
@@ -201,7 +201,9 @@ func (v *validate) traverseField(ctx context.Context, parent reflect.Value, curr
 								typ:            typ,
 							},
 						)
-						return
+						if ct.typeof == typeIsDefault {
+							return
+						}
 					}
 				}
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -11516,7 +11516,7 @@ func TestExcludedWithoutAll(t *testing.T) {
 	ve = errs.(ValidationErrors)
 	Equal(t, len(ve), 1)
 
-	AssertError(t, errs, "Inner", "Inner", "Inner", "Inner", "excluded_with_all")
+	AssertError(t, errs, "Inner", "Inner", "Inner", "Inner", "excluded_without_all")
 }
 
 func TestRequiredWithAll(t *testing.T) {

--- a/validator_test.go
+++ b/validator_test.go
@@ -11182,6 +11182,24 @@ func TestExcludedWith(t *testing.T) {
 
 	errs = validate.Struct(test3)
 	Equal(t, errs, nil)
+
+	test4 := struct {
+		Inner  *Inner `validate:"excluded_with=Inner2"`
+		Inner2 *Inner
+	}{
+		Inner:  &Inner{FieldE: "populated"},
+		Inner2: &Inner{FieldE: "populated"},
+	}
+
+	validate = New()
+
+	errs = validate.Struct(test4)
+	NotEqual(t, errs, nil)
+
+	ve = errs.(ValidationErrors)
+	Equal(t, len(ve), 1)
+
+	AssertError(t, errs, "Inner", "Inner", "Inner", "Inner", "excluded_with")
 }
 
 func TestExcludedWithout(t *testing.T) {
@@ -11266,6 +11284,23 @@ func TestExcludedWithout(t *testing.T) {
 
 	errs = validate.Struct(test3)
 	Equal(t, errs, nil)
+
+	test4 := struct {
+		Inner  *Inner `validate:"excluded_without=Inner2"`
+		Inner2 *Inner
+	}{
+		Inner: &Inner{FieldE: "populated"},
+	}
+
+	validate = New()
+
+	errs = validate.Struct(test4)
+	NotEqual(t, errs, nil)
+
+	ve = errs.(ValidationErrors)
+	Equal(t, len(ve), 1)
+
+	AssertError(t, errs, "Inner", "Inner", "Inner", "Inner", "excluded_without")
 }
 
 func TestExcludedWithAll(t *testing.T) {
@@ -11357,6 +11392,26 @@ func TestExcludedWithAll(t *testing.T) {
 
 	errs = validate.Struct(test3)
 	Equal(t, errs, nil)
+
+	test4 := struct {
+		Inner  *Inner `validate:"excluded_with_all=Inner2 Inner3"`
+		Inner2 *Inner
+		Inner3 *Inner
+	}{
+		Inner:  &Inner{FieldE: "populated"},
+		Inner2: &Inner{FieldE: "populated"},
+		Inner3: &Inner{FieldE: "populated"},
+	}
+
+	validate = New()
+
+	errs = validate.Struct(test4)
+	NotEqual(t, errs, nil)
+
+	ve = errs.(ValidationErrors)
+	Equal(t, len(ve), 1)
+
+	AssertError(t, errs, "Inner", "Inner", "Inner", "Inner", "excluded_with_all")
 }
 
 func TestExcludedWithoutAll(t *testing.T) {
@@ -11444,6 +11499,24 @@ func TestExcludedWithoutAll(t *testing.T) {
 
 	errs = validate.Struct(test3)
 	Equal(t, errs, nil)
+
+	test4 := struct {
+		Inner  *Inner `validate:"excluded_without_all=Inner2 Inner3"`
+		Inner2 *Inner
+		Inner3 *Inner
+	}{
+		Inner: &Inner{FieldE: "populated"},
+	}
+
+	validate = New()
+
+	errs = validate.Struct(test4)
+	NotEqual(t, errs, nil)
+
+	ve = errs.(ValidationErrors)
+	Equal(t, len(ve), 1)
+
+	AssertError(t, errs, "Inner", "Inner", "Inner", "Inner", "excluded_with_all")
 }
 
 func TestRequiredWithAll(t *testing.T) {
@@ -11729,6 +11802,26 @@ func TestExcludedIf(t *testing.T) {
 	errs = validate.Struct(test10)
 	Equal(t, errs, nil)
 
+	test11 := struct {
+		Inner  *Inner `validate:"excluded_if=Inner2.Field exclude"`
+		Inner2 *Inner
+	}{
+		Inner: &Inner{},
+		Inner2: &Inner{
+			Field: &shouldExclude,
+		},
+	}
+
+	validate = New()
+
+	errs = validate.Struct(test11)
+	NotEqual(t, errs, nil)
+
+	ve = errs.(ValidationErrors)
+	Equal(t, len(ve), 1)
+
+	AssertError(t, errs, "Inner", "Inner", "Inner", "Inner", "excluded_if")
+
 	// Checks number of params in struct tag is correct
 	defer func() {
 		if r := recover(); r == nil {
@@ -11839,6 +11932,24 @@ func TestExcludedUnless(t *testing.T) {
 	}
 	errs = validate.Struct(test8)
 	Equal(t, errs, nil)
+
+	test9 := struct {
+		Inner *Inner `validate:"excluded_unless=Field exclude"`
+		Field string `validate:"omitempty" json:"field"`
+	}{
+		Inner: &Inner{},
+		Field: "test",
+	}
+
+	validate = New()
+
+	errs = validate.Struct(test9)
+	NotEqual(t, errs, nil)
+
+	ve = errs.(ValidationErrors)
+	Equal(t, len(ve), 1)
+
+	AssertError(t, errs, "Inner", "Inner", "Inner", "Inner", "excluded_unless")
 
 	// Checks number of params in struct tag is correct
 	defer func() {


### PR DESCRIPTION
## Fixes Or Enhances
Fix for baked in excluded tags such as `excluded_with` to properly validate structs
#906 

**Make sure that you've checked the boxes below before you submit PR:**
- [ ] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers