### PR TITLE
feat: custom error mgs with tag (generic function)

### DIFF
--- a/validator_mgserror.go
+++ b/validator_mgserror.go
@@ -1,0 +1,79 @@
+package validator
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// Help valid struct with tag custom
+const tagCustom = "errormgs"
+
+func errorTagFunc[T interface{}](obj interface{}, snp string, fieldname, actualTag string) error {
+	o := obj.(T)
+
+	if !strings.Contains(snp, fieldname) {
+		return nil
+	}
+
+	fieldArr := strings.Split(snp, ".")
+	rsf := reflect.TypeOf(&o).Elem()
+
+	for i := 1; i < len(fieldArr); i++ {
+		field, found := rsf.FieldByName(fieldArr[i])
+		if found {
+			if fieldArr[i] == fieldname {
+				customMessage := field.Tag.Get(tagCustom)
+				if customMessage != "" {
+					return fmt.Errorf("%s: %s (%s)", fieldname, customMessage, actualTag)
+				}
+				return nil
+			} else {
+				nestedFieldType := field.Type
+				rsf = nestedFieldType
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateFunc validates (error message with tag) the given object obj against the struct tags defined using
+// the "validator v10" package. The type of the object is defined by the generic type T.
+// It returns an error indicating the validation failure(s), if any.
+// If a panic occurs during the validation process, the function recovers and returns
+// an error indicating the panic. The function also uses the errorTagFunc function to
+// generate error messages with custom messages defined in the struct tags.
+// If no validation errors or panics occur, the function returns nil.
+// https://dev.to/thanhphuchuynh/customizing-error-messages-in-struct-validation-using-tags-in-go-4k0j
+func ValidateFunc[T interface{}](obj interface{}, validate *Validate) (errs error) {
+
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Recovered in Validate:", r)
+			errs = fmt.Errorf("can't validate %+v", r)
+		}
+	}()
+
+	o := obj.(T)
+
+	if err := validate.Struct(o); err != nil {
+		errorValid := err.(ValidationErrors)
+		for _, e := range errorValid {
+			// snp  X.Y.Z
+			snp := e.StructNamespace()
+			errmgs := errorTagFunc[T](obj, snp, e.Field(), e.ActualTag())
+			if errmgs != nil {
+				errs = errors.Join(errs, fmt.Errorf("%w", errmgs))
+			} else {
+				errs = errors.Join(errs, fmt.Errorf("%w", e))
+			}
+		}
+	}
+
+	if errs != nil {
+		return errs
+	}
+
+	return nil
+}

--- a/validator_mgserror_test.go
+++ b/validator_mgserror_test.go
@@ -1,0 +1,118 @@
+package validator
+
+import (
+	"strings"
+	"testing"
+)
+
+// Define a struct for testing
+type Person struct {
+	Name  string `validate:"required" errormgs:"Name is required"`
+	Email string `validate:"required,email" errormgs:"Invalid email"`
+	Age   int    `validate:"gte=0,lte=130" errormgs:"Invalid age"`
+}
+
+func TestValidateFunc(t *testing.T) {
+	validate := New()
+
+	// Create an instance of the struct to validate
+	person := Person{
+		Name:  "",        // Invalid: Name is required
+		Email: "invalid", // Invalid: Invalid email
+		Age:   150,       // Invalid: Invalid age
+	}
+
+	// Call the ValidateFunc and check for expected errors
+	err := ValidateFunc[Person](person, validate)
+
+	// Check if there are validation errors
+	if err == nil {
+		t.Error("Expected validation errors, but got nil")
+		return
+	}
+
+	// Check the error messages
+	expectedErrs := []string{
+		"Name: Name is required (required)",
+		"Email: Invalid email (email)",
+		"Age: Invalid age (lte)",
+	}
+
+	for _, expected := range expectedErrs {
+		if !strings.Contains(err.Error(), expected) {
+			t.Errorf("Expected error message '%s' not found", expected)
+		}
+	}
+}
+
+func TestValidateFuncV2(t *testing.T) {
+	validate := New()
+
+	// Create an instance of the struct to validate
+	person := Person{
+		Name:  "John Doe",            // Valid
+		Email: "johndoe@example.com", // Valid
+		Age:   30,                    // Valid
+	}
+
+	// Call the ValidateFunc and check for expected errors
+	err := ValidateFunc[Person](person, validate)
+
+	// Check if there are validation errors
+	if err != nil {
+		t.Errorf("Expected no validation errors, but got error: %s", err)
+		return
+	}
+
+	// Test case where the validation fails with custom error message
+	person.Name = "" // Invalid: Name is required
+
+	err = ValidateFunc[Person](person, validate)
+
+	// Check if there are validation errors
+	if err == nil {
+		t.Error("Expected validation errors, but got nil")
+		return
+	}
+
+	// Check the error message
+	expectedErr := "Name: Name is required (required)"
+	if err.Error() != expectedErr {
+		t.Errorf("Expected error message '%s', but got '%s'", expectedErr, err.Error())
+	}
+
+	// Test case where the validation fails without custom error message
+	person.Email = "invalid" // Invalid: Invalid email
+	person.Name = "a"
+	err = ValidateFunc[Person](person, validate)
+
+	// Check if there are validation errors
+	if err == nil {
+		t.Error("Expected validation errors, but got nil")
+		return
+	}
+
+	// Check the error message
+	expectedErr = "Email: Invalid email (email)"
+	if err.Error() != expectedErr {
+		t.Errorf("Expected error message '%s', but got '%s'", expectedErr, err.Error())
+	}
+
+	// Test case where the validation fails with panic
+	person.Age = 150 // Invalid: Invalid age
+	person.Email = "a@gmail.com"
+	// Mock a panic during validation
+	// defer func() {
+	// 	if r := recover(); r == nil {
+	// 		t.Error("Expected panic, but no panic occurred")
+	// 	}
+	// }()
+
+	err = ValidateFunc[Person](person, validate)
+
+	expectedErr = "Age: Invalid age (lte)"
+	if err.Error() != expectedErr {
+		t.Errorf("Expected error message '%s', but got '%s'", expectedErr, err.Error())
+	}
+
+}


### PR DESCRIPTION
## Customizing Error Messages with Tags 


In addition to specifying constraints for struct fields, we can also customize error messages using tags. To do this, we add a `message` tag to our struct field tags.

```go
type PaymentInfo struct {
    CreditCardNumber string `validate:"required" errormgs:"Invalid credit card is required xxx"`
    CVV              string `validate:"required,len=3" errormgs:"CVV code must be three digits long"`
}
