### PR TITLE
Remove extra URL string header

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -879,8 +879,6 @@ This is done using os.Stat and github.com/gabriel-vasile/mimetype
 
 	Usage: image
 
-# URL String
-
 # File Path
 
 This validates that a string value contains a valid file path but does not


### PR DESCRIPTION
## Fixes Or Enhances
Removes an extra header from the docs.

![image](https://github.com/go-playground/validator/assets/8585244/ebe19a77-0fc1-442e-a8e1-95e96b4f2c62)

Here is the direct link https://pkg.go.dev/github.com/go-playground/validator/v10#hdr-URL_String

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers