### PR TITLE
fix: excluded_* and required_* checks aren't triggered on pointers to structs

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -166,11 +166,11 @@ func (v *validate) traverseField(ctx context.Context, parent reflect.Value, curr
 
 		if !typ.ConvertibleTo(timeType) {
 
-			if ct != nil {
+			for ct != nil {
 
-				if ct.typeof == typeStructOnly {
+				if ct.typeof == typeStructOnly || ct.typeof == typeNoStructLevel {
 					goto CONTINUE
-				} else if ct.typeof == typeIsDefault {
+				} else if ct.typeof == typeIsDefault || ct.typeof == typeDefault && ct.runValidationWhenNil && v.fldIsPointer {
 					// set Field Level fields
 					v.slflParent = parent
 					v.flField = current


### PR DESCRIPTION
## Fixes Or Enhances
Fix for https://github.com/go-playground/validator/issues/906
Trigger `excluded_*` and `required_*` checks on pointers to structs.
Before fix all default backed-in tags were ignored for non-nil pointers to structs.   
Now it's possible to check whether pointer to struct is nil or not depending on another field value.

**Make sure that you've checked the boxes below before you submit PR:**
- [ ] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers