### PR TITLE
Feat: add SpiceDB validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Baked-in Validations
 | credit_card | Credit Card Number |
 | mongodb | MongoDB ObjectID |
 | cron | Cron |
+| spicedb | SpiceDb ObjectID/Permission/Type |
 | datetime | Datetime |
 | e164 | e164 formatted phone number |
 | email | E-mail String

--- a/baked_in.go
+++ b/baked_in.go
@@ -230,6 +230,7 @@ var (
 		"luhn_checksum":                 hasLuhnChecksum,
 		"mongodb":                       isMongoDB,
 		"cron":                          isCron,
+		"spicedb":                       isSpiceDB,
 	}
 )
 
@@ -2806,6 +2807,23 @@ func digitsHaveLuhnChecksum(digits []string) bool {
 func isMongoDB(fl FieldLevel) bool {
 	val := fl.Field().String()
 	return mongodbRegex.MatchString(val)
+}
+
+// isSpiceDB is the validation function for validating if the current field's value is valid for use with Authzed SpiceDB in the indicated way
+func isSpiceDB(fl FieldLevel) bool {
+	val := fl.Field().String()
+	param := fl.Param()
+
+	switch param {
+	case "permission":
+		return spicedbPermissionRegex.MatchString(val)
+	case "type":
+		return spicedbTypeRegex.MatchString(val)
+	case "id", "":
+		return spicedbIDRegex.MatchString(val)
+	}
+
+	panic("Unrecognized parameter: " + param)
 }
 
 // isCreditCard is the validation function for validating if the current field's value is a valid credit card number

--- a/doc.go
+++ b/doc.go
@@ -1384,6 +1384,12 @@ This validates that a string value contains a valid cron expression.
 
 	Usage: cron
 
+# SpiceDb ObjectID/Permission/Object Type
+
+This validates that a string is valid for use with SpiceDb for the indicated purpose. If no purpose is given, a purpose of 'id' is assumed.
+
+	Usage: spicedb=id|permission|type
+
 # Alias Validators and Tags
 
 Alias Validators and Tags

--- a/regexes.go
+++ b/regexes.go
@@ -68,6 +68,9 @@ const (
 	cveRegexString                   = `^CVE-(1999|2\d{3})-(0[^0]\d{2}|0\d[^0]\d{1}|0\d{2}[^0]|[1-9]{1}\d{3,})$` // CVE Format Id https://cve.mitre.org/cve/identifiers/syntaxchange.html
 	mongodbRegexString               = "^[a-f\\d]{24}$"
 	cronRegexString                  = `(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\d+(ns|us|µs|ms|s|m|h))+)|((((\d+,)+\d+|(\d+(\/|-)\d+)|\d+|\*) ?){5,7})`
+	spicedbIDRegexString             = `^(([a-zA-Z0-9/_|\-=+]{1,})|\*)$`
+	spicedbPermissionRegexString     = "^([a-z][a-z0-9_]{1,62}[a-z0-9])?$"
+	spicedbTypeRegexString           = "^([a-z][a-z0-9_]{1,61}[a-z0-9]/)?[a-z][a-z0-9_]{1,62}[a-z0-9]$"
 )
 
 var (
@@ -134,4 +137,7 @@ var (
 	cveRegex                   = regexp.MustCompile(cveRegexString)
 	mongodbRegex               = regexp.MustCompile(mongodbRegexString)
 	cronRegex                  = regexp.MustCompile(cronRegexString)
+	spicedbIDRegex             = regexp.MustCompile(spicedbIDRegexString)
+	spicedbPermissionRegex     = regexp.MustCompile(spicedbPermissionRegexString)
+	spicedbTypeRegex           = regexp.MustCompile(spicedbTypeRegexString)
 )


### PR DESCRIPTION
## Fixes Or Enhances
Adds support for validating [SpiceDB](https://github.com/authzed/spicedb) object ids, types, and permissions

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers