### PR TITLE
RegisterTagNameFunc doc update

### DIFF
--- a/validator_instance.go
+++ b/validator_instance.go
@@ -190,7 +190,7 @@ func (v *Validate) ValidateMap(data map[string]interface{}, rules map[string]int
 	return v.ValidateMapCtx(context.Background(), data, rules)
 }
 
-// RegisterTagNameFunc registers a function to get alternate names for StructFields.
+// RegisterTagNameFunc registers a function to get alternate names (other than sturct field names) from FieldName.
 //
 // eg. to use the names which have been specified for JSON representations of structs, rather than normal Go field names:
 //


### PR DESCRIPTION
## Fixes Or Enhances
RegisterTagNameFunc document was misleading. I updated the description to be more clear.
It doesn't affect the strings return from `StructField` so I added where it affect.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers