### PR TITLE
FastFail feature #1042

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -27,6 +27,7 @@ type validate struct {
 	fldIsPointer   bool          // StructLevel & FieldLevel
 	isPartial      bool
 	hasExcludes    bool
+	isFailFast     bool // Returns on first error encountered
 }
 
 // parent and current will be the same the first run of validateStruct
@@ -75,6 +76,10 @@ func (v *validate) validateStruct(ctx context.Context, parent reflect.Value, cur
 			}
 
 			v.traverseField(ctx, current, current.Field(f.idx), ns, structNs, f, f.cTags)
+
+			if v.isFailFast && len(v.errs) > 0 {
+				return
+			}
 		}
 	}
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -13135,3 +13135,119 @@ func TestCronExpressionValidation(t *testing.T) {
 		}
 	}
 }
+
+type Value struct {
+	Street string `validate:"required"`
+	City   string `validate:"required"`
+}
+
+func TestFailFastSettingStruct(t *testing.T) {
+
+	tests := []struct {
+		v              Value
+		failFast       bool
+		expectedErrLen int
+	}{
+		{
+			v: Value{
+				Street: "",
+				City:   "",
+			},
+			failFast:       true,
+			expectedErrLen: 1,
+		},
+		{
+			v: Value{
+				Street: "",
+				City:   "",
+			},
+			failFast:       false,
+			expectedErrLen: 2,
+		},
+	}
+
+	for _, t := range tests {
+		validate := New()
+		if t.failFast {
+			validate.FailFast()
+		}
+		errs := validate.Struct(t.v)
+
+		validationErrs := errs.(ValidationErrors)
+		IsEqual(len(validationErrs), t.expectedErrLen)
+	}
+}
+
+func TestFailFastSettingStructPartialCtx(t *testing.T) {
+
+	tests := []struct {
+		v              Value
+		failFast       bool
+		expectedErrLen int
+	}{
+		{
+			v: Value{
+				Street: "",
+				City:   "",
+			},
+			failFast:       true,
+			expectedErrLen: 1,
+		},
+		{
+			v: Value{
+				Street: "",
+				City:   "",
+			},
+			failFast:       false,
+			expectedErrLen: 2,
+		},
+	}
+
+	for _, t := range tests {
+		validate := New()
+		if t.failFast {
+			validate.FailFast()
+		}
+		errs := validate.StructPartialCtx(context.TODO(), t.v, "Street", "City")
+
+		validationErrs := errs.(ValidationErrors)
+		IsEqual(len(validationErrs), t.expectedErrLen)
+	}
+}
+
+func TestFailFastSettingStructExceptCtx(t *testing.T) {
+
+	tests := []struct {
+		v              Value
+		failFast       bool
+		expectedErrLen int
+	}{
+		{
+			v: Value{
+				Street: "",
+				City:   "",
+			},
+			failFast:       true,
+			expectedErrLen: 1,
+		},
+		{
+			v: Value{
+				Street: "",
+				City:   "",
+			},
+			failFast:       false,
+			expectedErrLen: 2,
+		},
+	}
+
+	for _, t := range tests {
+		validate := New()
+		if t.failFast {
+			validate.FailFast()
+		}
+		errs := validate.StructPartialCtx(context.TODO(), t.v, "Street", "City")
+
+		validationErrs := errs.(ValidationErrors)
+		IsEqual(len(validationErrs), t.expectedErrLen)
+	}
+}


### PR DESCRIPTION
## Fixes Or Enhances
Adds failfast feature which returns the first validation error encountered.  This can be set by a flag or function call.   This PR was based on [Issue 1042](https://github.com/go-playground/validator/issues/1042)

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers