### PR TITLE
Fix filepath validator panic if the value is an existing dir

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -1561,6 +1561,10 @@ func isFilePath(fl FieldLevel) bool {
 
 	field := fl.Field()
 
+	// Not valid if it is a directory.
+	if isDir(fl) {
+		return false
+	}
 	// If it exists, it obviously is valid.
 	// This is done first to avoid code duplication and unnecessary additional logic.
 	if exists = isFile(fl); exists {

--- a/validator_test.go
+++ b/validator_test.go
@@ -5852,6 +5852,7 @@ func TestFilePathValidation(t *testing.T) {
 		{"valid filepath", filepath.Join("testdata", "a.go"), true},
 		{"invalid filepath", filepath.Join("testdata", "no\000.go"), false},
 		{"directory, not a filepath", "testdata" + string(os.PathSeparator), false},
+		{"directory", "testdata", false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Fixes Or Enhances
This PR adds an additional check for directories in the isFilePath() function.

Connected to #1102 

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers