### PR TITLE
fix: oneof example's unclosed double quote

### DIFF
--- a/_examples/simple/main.go
+++ b/_examples/simple/main.go
@@ -12,7 +12,7 @@ type User struct {
 	LastName       string     `validate:"required"`
 	Age            uint8      `validate:"gte=0,lte=130"`
 	Email          string     `validate:"required,email"`
-	Gender         string     `validate:"oneof=male female prefer_not_to`
+	Gender         string     `validate:"oneof=male female prefer_not_to"`
 	FavouriteColor string     `validate:"iscolor"`                // alias for 'hexcolor|rgb|rgba|hsl|hsla'
 	Addresses      []*Address `validate:"required,dive,required"` // a person can have a home and cottage...
 }


### PR DESCRIPTION
## Fixes

This really small PR fixes the unclosed doublequote in `oneof` example. When example is executed, it does not give error but skips `oneof` validation. 

**Make sure that you've checked the boxes below before you submit PR:**
- [ ] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers