### PR TITLE
Fix Type called on zero reflect.Value

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -162,6 +162,10 @@ func (v *validate) traverseField(ctx context.Context, parent reflect.Value, curr
 			}
 		}
 
+		if kind == reflect.Invalid {
+			return
+		}
+
 	case reflect.Struct:
 		isNestedStruct = !current.Type().ConvertibleTo(timeType)
 		// For backward compatibility before struct level validation tags were supported

--- a/validator_test.go
+++ b/validator_test.go
@@ -2317,6 +2317,13 @@ func TestSQLValueValidation(t *testing.T) {
 	Equal(t, len(errs.(ValidationErrors)), 2)
 	AssertError(t, errs, "CustomMadeUpStruct.MadeUp", "CustomMadeUpStruct.MadeUp", "MadeUp", "MadeUp", "required")
 	AssertError(t, errs, "CustomMadeUpStruct.OverriddenInt", "CustomMadeUpStruct.OverriddenInt", "OverriddenInt", "OverriddenInt", "gt")
+
+	// Test for empty field on structs without tags
+	type InvalidValuePanicSafetyTest struct {
+		V valuer
+	}
+	errs = validate.Struct(InvalidValuePanicSafetyTest{})
+	Equal(t, errs, nil)
 }
 
 func TestMACValidation(t *testing.T) {


### PR DESCRIPTION
## Fixes Or Enhances
#1155

Simply added back the check for invalid reflect types before calling `Type` on `reflect.Value`.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers