### PR TITLE
docs: Fix typos in comments

### DIFF
--- a/_examples/translations/main.go
+++ b/_examples/translations/main.go
@@ -35,7 +35,7 @@ var (
 
 func main() {
 
-	// NOTE: ommitting allot of error checking for brevity
+	// NOTE: omitting allot of error checking for brevity
 
 	en := en.New()
 	uni = ut.New(en, en)

--- a/validator_instance.go
+++ b/validator_instance.go
@@ -674,7 +674,7 @@ func (v *Validate) VarWithValue(field interface{}, other interface{}, tag string
 }
 
 // VarWithValueCtx validates a single variable, against another variable/field's value using tag style validation and
-// allows passing of contextual validation validation information via context.Context.
+// allows passing of contextual validation information via context.Context.
 // eg.
 // s1 := "abcd"
 // s2 := "abcd"

--- a/validator_test.go
+++ b/validator_test.go
@@ -799,7 +799,7 @@ func TestStructPartial(t *testing.T) {
 	errs = validate.StructPartial(tPartial, p2...)
 	Equal(t, errs, nil)
 
-	// this isn't really a robust test, but is ment to illustrate the ANON CASE below
+	// this isn't really a robust test, but is meant to illustrate the ANON CASE below
 	errs = validate.StructPartial(tPartial.SubSlice[0], p3...)
 	Equal(t, errs, nil)
 
@@ -809,7 +809,7 @@ func TestStructPartial(t *testing.T) {
 	errs = validate.StructExcept(tPartial, p2...)
 	Equal(t, errs, nil)
 
-	// mod tParial for required feild and re-test making sure invalid fields are NOT required:
+	// mod tPartial for required field and re-test making sure invalid fields are NOT required:
 	tPartial.Required = ""
 
 	errs = validate.StructExcept(tPartial, p1...)
@@ -841,7 +841,7 @@ func TestStructPartial(t *testing.T) {
 	errs = validate.StructExcept(tPartial.Anonymous, p4...)
 	Equal(t, errs, nil)
 
-	// will fail as unset feild is tested
+	// will fail as unset field is tested
 	errs = validate.StructPartial(tPartial, p2...)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TestPartial.Anonymous.A", "TestPartial.Anonymous.A", "A", "A", "required")
@@ -893,7 +893,7 @@ func TestStructPartial(t *testing.T) {
 	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "TestPartial.SubSlice[0].Test", "TestPartial.SubSlice[0].Test", "Test", "Test", "required")
 
-	// reset struct in slice, and unset struct in slice in unset posistion
+	// reset struct in slice, and unset struct in slice in unset position
 	tPartial.SubSlice[0].Test = "Required"
 
 	// these will pass as the unset item is NOT tested


### PR DESCRIPTION
## Fixes Or Enhances

This PR corrects spelling mistakes in comments.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers