### PR TITLE
add ISSN validator + tests + documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ validate := validator.New(validator.WithRequiredStructEnabled())
 | isbn | International Standard Book Number |
 | isbn10 | International Standard Book Number 10 |
 | isbn13 | International Standard Book Number 13 |
+| issn | International Standard Serial Number |
 | iso3166_1_alpha2 | Two-letter country code (ISO 3166-1 alpha-2) |
 | iso3166_1_alpha3 | Three-letter country code (ISO 3166-1 alpha-3) |
 | iso3166_1_alpha_numeric | Numeric country code (ISO 3166-1 numeric) |

--- a/baked_in.go
+++ b/baked_in.go
@@ -149,6 +149,7 @@ var (
 		"isbn":                          isISBN,
 		"isbn10":                        isISBN10,
 		"isbn13":                        isISBN13,
+		"issn":                          isISSN,
 		"eth_addr":                      isEthereumAddress,
 		"eth_addr_checksum":             isEthereumAddressChecksum,
 		"btc_addr":                      isBitcoinAddress,
@@ -645,6 +646,32 @@ func isISBN10(fl FieldLevel) bool {
 		checksum += 10 * 10
 	} else {
 		checksum += 10 * int32(s[9]-'0')
+	}
+
+	return checksum%11 == 0
+}
+
+// isISSN is the validation function for validating if the field's value is a valid ISSN.
+func isISSN(fl FieldLevel) bool {
+	s := fl.Field().String()
+
+	if !iSSNRegex.MatchString(s) {
+		return false
+	}
+	s = strings.ReplaceAll(s, "-", "")
+
+	pos := 8
+	checksum := 0
+
+	for i := 0; i < 7; i++ {
+		checksum += pos * int(s[i]-'0')
+		pos--
+	}
+
+	if s[7] == 'X' {
+		checksum += 10
+	} else {
+		checksum += int(s[7] - '0')
 	}
 
 	return checksum%11 == 0

--- a/regexes.go
+++ b/regexes.go
@@ -22,6 +22,7 @@ const (
 	base64RawURLRegexString          = "^(?:[A-Za-z0-9-_]{4})*(?:[A-Za-z0-9-_]{2,4})$"
 	iSBN10RegexString                = "^(?:[0-9]{9}X|[0-9]{10})$"
 	iSBN13RegexString                = "^(?:(?:97(?:8|9))[0-9]{10})$"
+	iSSNRegexString                  = "^(?:[0-9]{4}-[0-9]{3}[0-9X])$"
 	uUID3RegexString                 = "^[0-9a-f]{8}-[0-9a-f]{4}-3[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$"
 	uUID4RegexString                 = "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
 	uUID5RegexString                 = "^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
@@ -93,6 +94,7 @@ var (
 	base64RawURLRegex          = regexp.MustCompile(base64RawURLRegexString)
 	iSBN10Regex                = regexp.MustCompile(iSBN10RegexString)
 	iSBN13Regex                = regexp.MustCompile(iSBN13RegexString)
+	iSSNRegex                  = regexp.MustCompile(iSSNRegexString)
 	uUID3Regex                 = regexp.MustCompile(uUID3RegexString)
 	uUID4Regex                 = regexp.MustCompile(uUID4RegexString)
 	uUID5Regex                 = regexp.MustCompile(uUID5RegexString)

--- a/translations/ar/ar.go
+++ b/translations/ar/ar.go
@@ -1117,6 +1117,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "issn",
+			translation: "يجب أن يكون {0} رقم ISSN صالح",
+			override:    false,
+		},
+		{
 			tag:         "uuid",
 			translation: "يجب أن يكون {0} UUID صالح",
 			override:    false,

--- a/translations/ar/ar_test.go
+++ b/translations/ar/ar_test.go
@@ -99,6 +99,7 @@ func TestTranslations(t *testing.T) {
 		ISBN              string            `validate:"isbn"`
 		ISBN10            string            `validate:"isbn10"`
 		ISBN13            string            `validate:"isbn13"`
+		ISSN              string            `validate:"issn"`
 		UUID              string            `validate:"uuid"`
 		UUID3             string            `validate:"uuid3"`
 		UUID4             string            `validate:"uuid4"`
@@ -340,6 +341,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.ISBN13",
 			expected: "يجب أن يكون ISBN13 رقم ISBN-13 صالح",
+		},
+		{
+			ns:       "Test.ISSN",
+			expected: "يجب أن يكون ISSN رقم ISSN صالح",
 		},
 		{
 			ns:       "Test.Excludes",

--- a/translations/en/en.go
+++ b/translations/en/en.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-playground/locales"
 	ut "github.com/go-playground/universal-translator"
+
 	"github.com/go-playground/validator/v10"
 )
 
@@ -1119,6 +1120,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		{
 			tag:         "isbn13",
 			translation: "{0} must be a valid ISBN-13 number",
+			override:    false,
+		},
+		{
+			tag:         "issn",
+			translation: "{0} must be a valid ISSN number",
 			override:    false,
 		},
 		{

--- a/translations/en/en_test.go
+++ b/translations/en/en_test.go
@@ -101,6 +101,7 @@ func TestTranslations(t *testing.T) {
 		ISBN              string            `validate:"isbn"`
 		ISBN10            string            `validate:"isbn10"`
 		ISBN13            string            `validate:"isbn13"`
+		ISSN              string            `validate:"issn"`
 		UUID              string            `validate:"uuid"`
 		UUID3             string            `validate:"uuid3"`
 		UUID4             string            `validate:"uuid4"`
@@ -353,6 +354,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.ISBN13",
 			expected: "ISBN13 must be a valid ISBN-13 number",
+		},
+		{
+			ns:       "Test.ISSN",
+			expected: "ISSN must be a valid ISSN number",
 		},
 		{
 			ns:       "Test.Excludes",

--- a/translations/es/es.go
+++ b/translations/es/es.go
@@ -1164,6 +1164,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "issn",
+			translation: "{0} debe ser un número ISSN válido",
+			override:    false,
+		},
+		{
 			tag:         "uuid",
 			translation: "{0} debe ser un UUID válido",
 			override:    false,

--- a/translations/es/es_test.go
+++ b/translations/es/es_test.go
@@ -101,6 +101,7 @@ func TestTranslations(t *testing.T) {
 		ISBN              string            `validate:"isbn"`
 		ISBN10            string            `validate:"isbn10"`
 		ISBN13            string            `validate:"isbn13"`
+		ISSN              string            `validate:"issn"`
 		UUID              string            `validate:"uuid"`
 		UUID3             string            `validate:"uuid3"`
 		UUID4             string            `validate:"uuid4"`
@@ -330,6 +331,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.ISBN13",
 			expected: "ISBN13 debe ser un número ISBN-13 válido",
+		},
+		{
+			ns:       "Test.ISSN",
+			expected: "ISSN debe ser un número ISSN válido",
 		},
 		{
 			ns:       "Test.Excludes",

--- a/translations/fa/fa.go
+++ b/translations/fa/fa.go
@@ -1117,6 +1117,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "issn",
+			translation: "{0} باید یک شابک(ISSN) معتبر باشد",
+			override:    false,
+		},
+		{
 			tag:         "uuid",
 			translation: "{0} باید یک UUID معتبر باشد",
 			override:    false,

--- a/translations/fa/fa_test.go
+++ b/translations/fa/fa_test.go
@@ -99,6 +99,7 @@ func TestTranslations(t *testing.T) {
 		ISBN              string            `validate:"isbn"`
 		ISBN10            string            `validate:"isbn10"`
 		ISBN13            string            `validate:"isbn13"`
+		ISSN              string            `validate:"issn"`
 		UUID              string            `validate:"uuid"`
 		UUID3             string            `validate:"uuid3"`
 		UUID4             string            `validate:"uuid4"`
@@ -339,6 +340,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.ISBN13",
 			expected: "ISBN13 باید یک شابک(ISBN-13) معتبر باشد",
+		},
+		{
+			ns:       "Test.ISSN",
+			expected: "ISSN باید یک شابک(ISSN) معتبر باشد",
 		},
 		{
 			ns:       "Test.Excludes",

--- a/translations/fr/fr.go
+++ b/translations/fr/fr.go
@@ -1154,6 +1154,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "issn",
+			translation: "{0} doit être un numéro ISSN valid",
+			override:    false,
+		},
+		{
 			tag:         "uuid",
 			translation: "{0} doit être un UUID valid",
 			override:    false,

--- a/translations/fr/fr_test.go
+++ b/translations/fr/fr_test.go
@@ -100,6 +100,7 @@ func TestTranslations(t *testing.T) {
 		ISBN              string    `validate:"isbn"`
 		ISBN10            string    `validate:"isbn10"`
 		ISBN13            string    `validate:"isbn13"`
+		ISSN              string    `validate:"issn"`
 		UUID              string    `validate:"uuid"`
 		UUID3             string    `validate:"uuid3"`
 		UUID4             string    `validate:"uuid4"`
@@ -323,6 +324,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.ISBN13",
 			expected: "ISBN13 doit être un numéro ISBN-13 valid",
+		},
+		{
+			ns:       "Test.ISSN",
+			expected: "ISSN doit être un numéro ISSN valid",
 		},
 		{
 			ns:       "Test.Excludes",

--- a/translations/id/id.go
+++ b/translations/id/id.go
@@ -1154,6 +1154,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "issn",
+			translation: "{0} harus berupa nomor ISSN yang valid",
+			override:    false,
+		},
+		{
 			tag:         "uuid",
 			translation: "{0} harus berupa UUID yang valid",
 			override:    false,

--- a/translations/id/id_test.go
+++ b/translations/id/id_test.go
@@ -100,6 +100,7 @@ func TestTranslations(t *testing.T) {
 		ISBN              string    `validate:"isbn"`
 		ISBN10            string    `validate:"isbn10"`
 		ISBN13            string    `validate:"isbn13"`
+		ISSN              string    `validate:"issn"`
 		UUID              string    `validate:"uuid"`
 		UUID3             string    `validate:"uuid3"`
 		UUID4             string    `validate:"uuid4"`
@@ -323,6 +324,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.ISBN13",
 			expected: "ISBN13 harus berupa nomor ISBN-13 yang valid",
+		},
+		{
+			ns:       "Test.ISSN",
+			expected: "ISSN harus berupa nomor ISSN yang valid",
 		},
 		{
 			ns:       "Test.Excludes",

--- a/translations/it/it.go
+++ b/translations/it/it.go
@@ -978,6 +978,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "issn",
+			translation: "{0} deve essere un numero ISSN valido",
+			override:    false,
+		},
+		{
 			tag:         "uuid",
 			translation: "{0} deve essere un UUID valido",
 			override:    false,

--- a/translations/it/it_test.go
+++ b/translations/it/it_test.go
@@ -99,6 +99,7 @@ func TestTranslations(t *testing.T) {
 		ISBN                string            `validate:"isbn"`
 		ISBN10              string            `validate:"isbn10"`
 		ISBN13              string            `validate:"isbn13"`
+		ISSN                string            `validate:"issn"`
 		UUID                string            `validate:"uuid"`
 		UUID3               string            `validate:"uuid3"`
 		UUID4               string            `validate:"uuid4"`
@@ -350,6 +351,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.ISBN13",
 			expected: "ISBN13 deve essere un numero ISBN-13 valido",
+		},
+		{
+			ns:       "Test.ISSN",
+			expected: "ISSN deve essere un numero ISSN valido",
 		},
 		{
 			ns:       "Test.Excludes",

--- a/translations/ja/ja.go
+++ b/translations/ja/ja.go
@@ -1187,6 +1187,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "issn",
+			translation: "{0}は正しいISSN番号でなければなりません",
+			override:    false,
+		},
+		{
 			tag:         "uuid",
 			translation: "{0}は正しいUUIDでなければなりません",
 			override:    false,

--- a/translations/ja/ja_test.go
+++ b/translations/ja/ja_test.go
@@ -101,6 +101,7 @@ func TestTranslations(t *testing.T) {
 		ISBN              string            `validate:"isbn"`
 		ISBN10            string            `validate:"isbn10"`
 		ISBN13            string            `validate:"isbn13"`
+		ISSN              string            `validate:"issn"`
 		UUID              string            `validate:"uuid"`
 		UUID3             string            `validate:"uuid3"`
 		UUID4             string            `validate:"uuid4"`
@@ -346,6 +347,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.ISBN13",
 			expected: "ISBN13は正しいISBN-13番号でなければなりません",
+		},
+		{
+			ns:       "Test.ISSN",
+			expected: "ISSNは正しいISSN番号でなければなりません",
 		},
 		{
 			ns:       "Test.Excludes",

--- a/translations/lv/lv.go
+++ b/translations/lv/lv.go
@@ -1122,6 +1122,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "issn",
+			translation: "{0} jābūt derīgam ISSN numuram",
+			override:    false,
+		},
+		{
 			tag:         "uuid",
 			translation: "{0} jābūt derīgam UUID",
 			override:    false,

--- a/translations/lv/lv_test.go
+++ b/translations/lv/lv_test.go
@@ -101,6 +101,7 @@ func TestTranslations(t *testing.T) {
 		ISBN              string            `validate:"isbn"`
 		ISBN10            string            `validate:"isbn10"`
 		ISBN13            string            `validate:"isbn13"`
+		ISSN              string            `validate:"issn"`
 		UUID              string            `validate:"uuid"`
 		UUID3             string            `validate:"uuid3"`
 		UUID4             string            `validate:"uuid4"`
@@ -345,6 +346,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.ISBN13",
 			expected: "ISBN13 jābūt derīgam ISBN-13 numuram",
+		},
+		{
+			ns:       "Test.ISSN",
+			expected: "ISSN jābūt derīgam ISSN numuram",
 		},
 		{
 			ns:       "Test.Excludes",

--- a/translations/nl/nl.go
+++ b/translations/nl/nl.go
@@ -1154,6 +1154,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "issn",
+			translation: "{0} moet een geldig ISSN nummer zijn",
+			override:    false,
+		},
+		{
 			tag:         "uuid",
 			translation: "{0} moet een geldige UUID zijn",
 			override:    false,

--- a/translations/nl/nl_test.go
+++ b/translations/nl/nl_test.go
@@ -100,6 +100,7 @@ func TestTranslations(t *testing.T) {
 		ISBN              string    `validate:"isbn"`
 		ISBN10            string    `validate:"isbn10"`
 		ISBN13            string    `validate:"isbn13"`
+		ISSN              string    `validate:"issn"`
 		UUID              string    `validate:"uuid"`
 		UUID3             string    `validate:"uuid3"`
 		UUID4             string    `validate:"uuid4"`
@@ -323,6 +324,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.ISBN13",
 			expected: "ISBN13 moet een geldig ISBN-13 nummer zijn",
+		},
+		{
+			ns:       "Test.ISSN",
+			expected: "ISSN moet een geldig ISSN nummer zijn",
 		},
 		{
 			ns:       "Test.Excludes",

--- a/translations/pt/pt.go
+++ b/translations/pt/pt.go
@@ -1159,6 +1159,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "issn",
+			translation: "{0} deve ser um número ISSN válido",
+			override:    false,
+		},
+		{
 			tag:         "uuid",
 			translation: "{0} deve ser um UUID válido",
 			override:    false,

--- a/translations/pt/pt_test.go
+++ b/translations/pt/pt_test.go
@@ -101,6 +101,7 @@ func TestTranslations(t *testing.T) {
 		ISBN              string            `validate:"isbn"`
 		ISBN10            string            `validate:"isbn10"`
 		ISBN13            string            `validate:"isbn13"`
+		ISSN              string            `validate:"issn"`
 		UUID              string            `validate:"uuid"`
 		UUID3             string            `validate:"uuid3"`
 		UUID4             string            `validate:"uuid4"`
@@ -338,6 +339,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.ISBN13",
 			expected: "ISBN13 deve ser um número ISBN-13 válido",
+		},
+		{
+			ns:       "Test.ISSN",
+			expected: "ISSN deve ser um número ISSN válido",
 		},
 		{
 			ns:       "Test.Excludes",

--- a/translations/pt_BR/pt_BR.go
+++ b/translations/pt_BR/pt_BR.go
@@ -1154,6 +1154,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "issn",
+			translation: "{0} deve ser um número ISSN válido",
+			override:    false,
+		},
+		{
 			tag:         "uuid",
 			translation: "{0} deve ser um UUID válido",
 			override:    false,

--- a/translations/pt_BR/pt_BR_test.go
+++ b/translations/pt_BR/pt_BR_test.go
@@ -100,6 +100,7 @@ func TestTranslations(t *testing.T) {
 		ISBN              string    `validate:"isbn"`
 		ISBN10            string    `validate:"isbn10"`
 		ISBN13            string    `validate:"isbn13"`
+		ISSN              string    `validate:"issn"`
 		UUID              string    `validate:"uuid"`
 		UUID3             string    `validate:"uuid3"`
 		UUID4             string    `validate:"uuid4"`
@@ -327,6 +328,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.ISBN13",
 			expected: "ISBN13 deve ser um número ISBN-13 válido",
+		},
+		{
+			ns:       "Test.ISSN",
+			expected: "ISSN deve ser um número ISSN válido",
 		},
 		{
 			ns:       "Test.Excludes",

--- a/translations/ru/ru.go
+++ b/translations/ru/ru.go
@@ -1272,6 +1272,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "issn",
+			translation: "{0} должен быть ISSN номером",
+			override:    false,
+		},
+		{
 			tag:         "uuid",
 			translation: "{0} должен быть UUID",
 			override:    false,

--- a/translations/ru/ru_test.go
+++ b/translations/ru/ru_test.go
@@ -116,6 +116,7 @@ func TestTranslations(t *testing.T) {
 		ISBN                    string            `validate:"isbn"`
 		ISBN10                  string            `validate:"isbn10"`
 		ISBN13                  string            `validate:"isbn13"`
+		ISSN                    string            `validate:"issn"`
 		UUID                    string            `validate:"uuid"`
 		UUID3                   string            `validate:"uuid3"`
 		UUID4                   string            `validate:"uuid4"`
@@ -357,6 +358,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.ISBN13",
 			expected: "ISBN13 должен быть ISBN-13 номером",
+		},
+		{
+			ns:       "Test.ISSN",
+			expected: "ISSN должен быть ISSN номером",
 		},
 		{
 			ns:       "Test.Excludes",

--- a/translations/tr/tr.go
+++ b/translations/tr/tr.go
@@ -1154,6 +1154,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "issn",
+			translation: "{0} geçerli bir ISSN numarası olmalıdır",
+			override:    false,
+		},
+		{
 			tag:         "uuid",
 			translation: "{0} geçerli bir UUID olmalıdır",
 			override:    false,

--- a/translations/tr/tr_test.go
+++ b/translations/tr/tr_test.go
@@ -100,6 +100,7 @@ func TestTranslations(t *testing.T) {
 		ISBN              string            `validate:"isbn"`
 		ISBN10            string            `validate:"isbn10"`
 		ISBN13            string            `validate:"isbn13"`
+		ISSN              string            `validate:"issn"`
 		UUID              string            `validate:"uuid"`
 		UUID3             string            `validate:"uuid3"`
 		UUID4             string            `validate:"uuid4"`
@@ -329,6 +330,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.ISBN13",
 			expected: "ISBN13 geçerli bir ISBN-13 numarası olmalıdır",
+		},
+		{
+			ns:       "Test.ISSN",
+			expected: "ISSN geçerli bir ISSN numarası olmalıdır",
 		},
 		{
 			ns:       "Test.Excludes",

--- a/translations/vi/vi.go
+++ b/translations/vi/vi.go
@@ -1117,6 +1117,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "issn",
+			translation: "{0} phải là số ISSN",
+			override:    false,
+		},
+		{
 			tag:         "uuid",
 			translation: "{0} phải là giá trị UUID",
 			override:    false,

--- a/translations/vi/vi_test.go
+++ b/translations/vi/vi_test.go
@@ -99,6 +99,7 @@ func TestTranslations(t *testing.T) {
 		ISBN              string            `validate:"isbn"`
 		ISBN10            string            `validate:"isbn10"`
 		ISBN13            string            `validate:"isbn13"`
+		ISSN              string            `validate:"issn"`
 		UUID              string            `validate:"uuid"`
 		UUID3             string            `validate:"uuid3"`
 		UUID4             string            `validate:"uuid4"`
@@ -335,6 +336,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.ISBN13",
 			expected: "ISBN13 phải là số ISBN-13",
+		},
+		{
+			ns:       "Test.ISSN",
+			expected: "ISSN phải là số ISSN",
 		},
 		{
 			ns:       "Test.Excludes",

--- a/translations/zh/zh.go
+++ b/translations/zh/zh.go
@@ -1236,6 +1236,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "issn",
+			translation: "{0}必须是一个有效的ISSN编号",
+			override:    false,
+		},
+		{
 			tag:         "uuid",
 			translation: "{0}必须是一个有效的UUID",
 			override:    false,

--- a/translations/zh/zh_test.go
+++ b/translations/zh/zh_test.go
@@ -105,6 +105,7 @@ func TestTranslations(t *testing.T) {
 		ISBN                  string    `validate:"isbn"`
 		ISBN10                string    `validate:"isbn10"`
 		ISBN13                string    `validate:"isbn13"`
+		ISSN                  string    `validate:"issn"`
 		UUID                  string    `validate:"uuid"`
 		UUID3                 string    `validate:"uuid3"`
 		UUID4                 string    `validate:"uuid4"`
@@ -344,6 +345,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.ISBN13",
 			expected: "ISBN13必须是一个有效的ISBN-13编号",
+		},
+		{
+			ns:       "Test.ISSN",
+			expected: "ISSN必须是一个有效的ISSN编号",
 		},
 		{
 			ns:       "Test.EndsWith",

--- a/translations/zh_tw/zh_tw.go
+++ b/translations/zh_tw/zh_tw.go
@@ -1147,6 +1147,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "issn",
+			translation: "{0}必須是一個有效的ISSN編號",
+			override:    false,
+		},
+		{
 			tag:         "uuid",
 			translation: "{0}必須是一個有效的UUID",
 			override:    false,

--- a/translations/zh_tw/zh_tw_test.go
+++ b/translations/zh_tw/zh_tw_test.go
@@ -100,6 +100,7 @@ func TestTranslations(t *testing.T) {
 		ISBN              string    `validate:"isbn"`
 		ISBN10            string    `validate:"isbn10"`
 		ISBN13            string    `validate:"isbn13"`
+		ISSN              string    `validate:"issn"`
 		UUID              string    `validate:"uuid"`
 		UUID3             string    `validate:"uuid3"`
 		UUID4             string    `validate:"uuid4"`
@@ -326,6 +327,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.ISBN13",
 			expected: "ISBN13必須是一個有效的ISBN-13編號",
+		},
+		{
+			ns:       "Test.ISSN",
+			expected: "ISSN必須是一個有效的ISSN編號",
 		},
 		{
 			ns:       "Test.Excludes",

--- a/validator_test.go
+++ b/validator_test.go
@@ -4800,6 +4800,42 @@ func TestISBN10Validation(t *testing.T) {
 	}
 }
 
+func TestISSNValidation(t *testing.T) {
+	tests := []struct {
+		param    string
+		expected bool
+	}{
+		{"", false},
+		{"foo", false},
+		{"20519990", false},
+		{"2051-9991", false},
+		{"2051-999X", false},
+		{"1050-124X", true},
+		{"0317-8471", true},
+	}
+
+	validate := New()
+
+	for i, test := range tests {
+		errs := validate.Var(test.param, "issn")
+
+		if test.expected {
+			if !IsEqual(errs, nil) {
+				t.Fatalf("Index: %d ISSN failed Error: %s", i, errs)
+			}
+		} else {
+			if IsEqual(errs, nil) {
+				t.Fatalf("Index: %d ISSN failed Error: %s", i, errs)
+			} else {
+				val := getError(errs, "", "")
+				if val.Tag() != "issn" {
+					t.Fatalf("Index: %d ISSN failed Error: %s", i, errs)
+				}
+			}
+		}
+	}
+}
+
 func TestExcludesRuneValidation(t *testing.T) {
 	tests := []struct {
 		Value       string `validate:"excludesrune=☻"`


### PR DESCRIPTION
## International Standard Serial Number (ISSN) validator

"_An ISSN is an 8-digit code used to identify newspapers, journals, magazines and periodicals of all kinds and on all media–print and electronic._" -- [issn.org](https://www.issn.org/understanding-the-issn/what-is-an-issn/)

This PR adds a new `issn` validator, along with updating all translation files and tests. This validator is very similar to that of the ISBN so I believe all translations will be okay. The _valid_ ISSNs used in the tests are examples taken from issn.org.

**Make sure that you've checked the boxes below before you submit PR:**
- [X] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers