### PR TITLE
Fix validation omitempty for empty String pointer

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -1716,6 +1716,11 @@ func hasValue(fl FieldLevel) bool {
 	switch field.Kind() {
 	case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func:
 		return !field.IsNil()
+	case reflect.String:
+		if fl.(*validate).fldIsPointer {
+			return !field.IsZero()
+		}
+		return field.IsValid() && field.Interface() != reflect.Zero(field.Type()).Interface()
 	default:
 		if fl.(*validate).fldIsPointer && field.Interface() != nil {
 			return true

--- a/validator_test.go
+++ b/validator_test.go
@@ -5618,6 +5618,27 @@ func TestBase64Validation(t *testing.T) {
 	AssertError(t, errs, "", "", "", "", "base64")
 }
 
+func TestValidationStringPtr(t *testing.T) {
+	validate := New()
+	emptyString := ""
+	testString := "test"
+	data := struct {
+		Str     string  `validate:"omitempty,base64,max=1500"`
+		StrPtr1 *string `validate:"omitempty,base64,max=1500"`
+		StrPtr2 *string `validate:"omitempty,base64,max=1500"`
+		StrPtr3 *string `validate:"omitempty,base64,max=1500"`
+	}{
+		Str:     emptyString,
+		StrPtr1: nil,
+		StrPtr2: &emptyString,
+		StrPtr3: &testString,
+	}
+
+	err := validate.Struct(data)
+
+	Equal(t, err, nil)
+}
+
 func TestBase64URLValidation(t *testing.T) {
 	validate := New()
 


### PR DESCRIPTION
## Fixes Or Enhances
Do not make an interface check if a field is a `String` pointer. 

Connected to #1129

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers