### PR TITLE
feat: add custom error message to struct field and to struct level validation

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -78,6 +78,7 @@ type cField struct {
 	idx        int
 	name       string
 	altName    string
+	errMsg     string
 	namesEqual bool
 	cTags      *cTag
 }
@@ -148,6 +149,12 @@ func (v *Validate) extractStructCache(current reflect.Value, sName string) *cStr
 			}
 		}
 
+		// check for any custom error message
+		errMsg := ""
+		if v.hasErrMsgFunc {
+			errMsg = v.errMsgFunc(fld)
+		}
+
 		// NOTE: cannot use shared tag cache, because tags may be equal, but things like alias may be different
 		// and so only struct level caching can be used instead of combined with Field tag caching
 
@@ -163,6 +170,7 @@ func (v *Validate) extractStructCache(current reflect.Value, sName string) *cStr
 			idx:        i,
 			name:       fld.Name,
 			altName:    customName,
+			errMsg:     errMsg,
 			cTags:      ctag,
 			namesEqual: fld.Name == customName,
 		})

--- a/errors.go
+++ b/errors.go
@@ -155,6 +155,9 @@ type FieldError interface {
 
 	// Error returns the FieldError's message
 	Error() string
+
+	// Error returns the custom error message
+	Msg() string
 }
 
 // compile time interface checks
@@ -166,6 +169,7 @@ var _ error = new(fieldError)
 // it complies with the FieldError interface
 type fieldError struct {
 	v              *Validate
+	msg            string
 	tag            string
 	actualTag      string
 	ns             string
@@ -176,6 +180,11 @@ type fieldError struct {
 	param          string
 	kind           reflect.Kind
 	typ            reflect.Type
+}
+
+// Msg returns the fieldError's custom error message
+func (fe *fieldError) Msg() string {
+	return fe.msg
 }
 
 // Tag returns the validation tag that failed.

--- a/struct_level.go
+++ b/struct_level.go
@@ -54,6 +54,10 @@ type StructLevel interface {
 	// and process on the flip side it's up to you.
 	ReportError(field interface{}, fieldName, structFieldName string, tag, param string)
 
+	// ReportErrorWithMsg reports an error just by passing the field and tag information, and custom error message
+	// ReportError calls this internally by passing empty custom error message
+	ReportErrorWithMsg(field interface{}, fieldName, structFieldName string, tag, param, msg string)
+
 	// ReportValidationErrors reports an error just by passing ValidationErrors
 	//
 	// NOTES:
@@ -107,7 +111,11 @@ func (v *validate) ExtractType(field reflect.Value) (reflect.Value, reflect.Kind
 
 // ReportError reports an error just by passing the field and tag information
 func (v *validate) ReportError(field interface{}, fieldName, structFieldName, tag, param string) {
+	v.ReportErrorWithMsg(field, fieldName, structFieldName, tag, param, "")
+}
 
+// ReportErrorWithMsg reports an error just by passing the field and tag information, and custom error message
+func (v *validate) ReportErrorWithMsg(field interface{}, fieldName, structFieldName, tag, param, msg string) {
 	fv, kind, _ := v.extractTypeInternal(reflect.ValueOf(field), false)
 
 	if len(structFieldName) == 0 {
@@ -127,6 +135,7 @@ func (v *validate) ReportError(field interface{}, fieldName, structFieldName, ta
 		v.errs = append(v.errs,
 			&fieldError{
 				v:              v.v,
+				msg:            msg,
 				tag:            tag,
 				actualTag:      tag,
 				ns:             v.str1,
@@ -143,6 +152,7 @@ func (v *validate) ReportError(field interface{}, fieldName, structFieldName, ta
 	v.errs = append(v.errs,
 		&fieldError{
 			v:              v.v,
+			msg:            msg,
 			tag:            tag,
 			actualTag:      tag,
 			ns:             v.str1,

--- a/validator.go
+++ b/validator.go
@@ -123,6 +123,7 @@ func (v *validate) traverseField(ctx context.Context, parent reflect.Value, curr
 				v.errs = append(v.errs,
 					&fieldError{
 						v:              v.v,
+						msg:            cf.errMsg,
 						tag:            ct.aliasTag,
 						actualTag:      ct.tag,
 						ns:             v.str1,
@@ -146,6 +147,7 @@ func (v *validate) traverseField(ctx context.Context, parent reflect.Value, curr
 				v.errs = append(v.errs,
 					&fieldError{
 						v:              v.v,
+						msg:            cf.errMsg,
 						tag:            ct.aliasTag,
 						actualTag:      ct.tag,
 						ns:             v.str1,
@@ -380,6 +382,7 @@ OUTER:
 						v.errs = append(v.errs,
 							&fieldError{
 								v:              v.v,
+								msg:            cf.errMsg,
 								tag:            ct.aliasTag,
 								actualTag:      ct.actualAliasTag,
 								ns:             v.str1,
@@ -400,6 +403,7 @@ OUTER:
 						v.errs = append(v.errs,
 							&fieldError{
 								v:              v.v,
+								msg:            cf.errMsg,
 								tag:            tVal,
 								actualTag:      tVal,
 								ns:             v.str1,
@@ -440,6 +444,7 @@ OUTER:
 				v.errs = append(v.errs,
 					&fieldError{
 						v:              v.v,
+						msg:            cf.errMsg,
 						tag:            ct.aliasTag,
 						actualTag:      ct.tag,
 						ns:             v.str1,

--- a/validator_instance.go
+++ b/validator_instance.go
@@ -82,6 +82,7 @@ type Validate struct {
 	tagName               string
 	pool                  *sync.Pool
 	tagNameFunc           TagNameFunc
+	errMsgFunc            TagNameFunc
 	structLevelFuncs      map[reflect.Type]StructLevelFuncCtx
 	customFuncs           map[reflect.Type]CustomTypeFunc
 	aliases               map[string]string
@@ -92,6 +93,7 @@ type Validate struct {
 	structCache           *structCache
 	hasCustomFuncs        bool
 	hasTagNameFunc        bool
+	hasErrMsgFunc         bool
 	requiredStructEnabled bool
 }
 
@@ -209,6 +211,18 @@ func (v *Validate) ValidateMap(data map[string]interface{}, rules map[string]int
 func (v *Validate) RegisterTagNameFunc(fn TagNameFunc) {
 	v.tagNameFunc = fn
 	v.hasTagNameFunc = true
+}
+
+// RegisterErrMsgFunc registers a function to get custom error message for StructFields.
+//
+// eg. to use custom error messages for struct fields:
+//
+//	validate.RegisterErrMsgFunc(func(fld reflect.StructField) string {
+//	    return fld.Tag.Get("msg")
+//	})
+func (v *Validate) RegisterErrMsgFunc(fn TagNameFunc) {
+	v.errMsgFunc = fn
+	v.hasErrMsgFunc = true
 }
 
 // RegisterValidation adds a validation with the given tag

--- a/validator_test.go
+++ b/validator_test.go
@@ -673,7 +673,7 @@ type TestCustomErrMsgStruct struct {
 	LastName  string `json:"lname" validate:"required"`
 	Age       uint8  `validate:"gte=0,lte=130" msg:"Age must be between 0 and 130, inclusive"`
 	Email     string `json:"email" validate:"required,email" msg:"Email is invalid"`
-	Addr11    string `json:"addr1sdf"`
+	Addr1     string `json:"addr1"`
 	Addr2     string
 	Addr3     string `json:"addr3"`
 }
@@ -681,8 +681,8 @@ type TestCustomErrMsgStruct struct {
 func StructValidationTestStructCustomErrorMessage(sl StructLevel) {
 	st := sl.Current().Interface().(TestCustomErrMsgStruct)
 
-	if st.Addr11 == "" && st.Addr2 == "" && st.Addr3 == "" {
-		sl.ReportErrorWithMsg(st.Addr11, "addr1", "Addr1", "addr1oraddr2oraddr3", "",
+	if st.Addr1 == "" && st.Addr2 == "" && st.Addr3 == "" {
+		sl.ReportErrorWithMsg(st.Addr1, "addr1", "Addr1", "addr1oraddr2oraddr3", "",
 			"Any one of Addr1 or Addr2 or Addr3 must be provided")
 		sl.ReportErrorWithMsg(st.Addr2, "Addr2", "Addr2", "addr1oraddr2oraddr3", "",
 			"Any one of Addr1 or Addr2 or Addr3 must be provided")


### PR DESCRIPTION
Add custom error message to struct field and to struct level validation.

##  Enhances

### struct field

We can now give a custom error message to a struct field by adding a struct tag and give that struct tag to `validate.RegisterErrMsgFunc`, like we give json struct tag to `validate.RegisterTagNameFunc`.

Custom error message can be accessed using `err.Msg()` as following.

```go
type User struct {
  Email string `validate:"required,email" msg:"User email is invalid"`
}

v = validator.New()

v.RegisterErrMsgFunc(func(fld reflect.StructField) string {
  return fld.Tag.Get("msg")
})

err = v.Struct(&User{})

for _, err := range err.(validator.ValidationErrors) {
  // err.Field() --> Email
  // err.Msg() --> User email is invalid
  // err.Error() --> Key: 'User.e-mail' Error:Field validation for 'e-mail' failed on the 'required' tag
}
```

### struct level

We can now add a custom error message while registering validation at struct level using `validate.RegisterStructValidation`.

Custom error message can be accessed using `err.Msg()` as following.

```go
type User1 struct {
  Addr1 string
  Addr2 string
  Addr3 string
}

v1 = validator.New()

v1.RegisterStructValidation(User1StructLevelValidation, User1{})

err = v1.Struct(&User1{})

for _, err := range err.(validator.ValidationErrors) {
  // err.Field() --> Addr1
  // err.Msg() --> Any one of Addr1 or Addr2 or Addr3 must be provided
  // err.Error() --> Key: 'User1.Addr1' Error:Field validation for 'Addr1' failed on the 'addr1oraddr2oraddr3' tag
}

...

func User1StructLevelValidation(sl StructLevel) {
  st := sl.Current().Interface().(User1)
  if st.Addr1 == "" && st.Addr2 == "" && st.Addr3 == "" {
    sl.ReportErrorWithMsg(st.Addr1, "Addr1", "Addr1", "addr1oraddr2oraddr3", "",
      "Any one of Addr1 or Addr2 or Addr3 must be provided")

    sl.ReportErrorWithMsg(st.Addr2, "Addr2", "Addr2", "addr1oraddr2oraddr3", "",
      "Any one of Addr1 or Addr2 or Addr3 must be provided")

    // without custom error message
    sl.ReportError(st.Addr3, "Addr3", "Addr3", "addr1oraddr2oraddr3", "")
  }
}
```

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Created a test --> TestCustomErrorMessages

@go-playground/validator-maintainers