### PR TITLE
Fix oneof tag in simple example

### DIFF
--- a/_examples/simple/main.go
+++ b/_examples/simple/main.go
@@ -12,7 +12,7 @@ type User struct {
 	LastName       string     `validate:"required"`
 	Age            uint8      `validate:"gte=0,lte=130"`
 	Email          string     `validate:"required,email"`
-	Gender         string     `validate:"oneof=male female prefer_not_to`
+	Gender         string     `validate:"oneof=male female prefer_not_to"`
 	FavouriteColor string     `validate:"iscolor"`                // alias for 'hexcolor|rgb|rgba|hsl|hsla'
 	Addresses      []*Address `validate:"required,dive,required"` // a person can have a home and cottage...
 }


### PR DESCRIPTION
Just a minor fix for the `oneof` tag in examples.

@go-playground/validator-maintainers