### PR TITLE
Fix Bad Field type panic

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -445,6 +445,27 @@ OUTER:
 			}
 
 		default:
+			switch current.Kind() {
+			case reflect.Ptr, reflect.Interface:
+				if !ct.runValidationWhenNil && current.IsNil() {
+					v.errs = append(v.errs,
+						&fieldError{
+							v:              v.v,
+							tag:            ct.aliasTag,
+							actualTag:      ct.tag,
+							ns:             v.str1,
+							structNs:       v.str2,
+							fieldLen:       uint8(len(cf.altName)),
+							structfieldLen: uint8(len(cf.name)),
+							value:          current.Interface(),
+							param:          ct.param,
+							kind:           kind,
+							typ:            current.Type(),
+						},
+					)
+					return
+				}
+			}
 
 			// set Field Level fields
 			v.slflParent = parent

--- a/validator_test.go
+++ b/validator_test.go
@@ -697,6 +697,19 @@ func TestAliasTags(t *testing.T) {
 	PanicMatches(t, func() { validate.RegisterAlias("exists!", "gt=5,lt=10") }, "Alias 'exists!' either contains restricted characters or is the same as a restricted tag needed for normal operation")
 }
 
+func TestNoPanicOnRequiredIfBeforeGTEWithPointer(t *testing.T) {
+	val := New()
+
+	type WithPointer struct {
+		Type     string `validate:"required"`
+		Quantity *int64 `validate:"required_if=Type special,gte=2"`
+	}
+	structWithPointer := &WithPointer{Quantity: nil, Type: "notspecial"}
+
+	errs := val.Struct(structWithPointer)
+	NotEqual(t, errs, nil)
+}
+
 func TestNilValidator(t *testing.T) {
 	type TestStruct struct {
 		Test string `validate:"required"`


### PR DESCRIPTION
## Fixes Or Enhances
Fixes #907 (and possibly others?)

At first I found it weird that the `required_if` affected the behavior of the `gte` tag, but after some debugging it seems that the condition `runValidationWhenNil` is not checked for each field tag, but only for the first one. 
In this case it was set to true for the `required_if` tag, but set to false for `gte`, so when the `required_if` preceded the `gte` tag it meant that the field was incorrectly validated through `gte` even when it was nil. 

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers