### PR TITLE
feat: Add a tag validation method

### DIFF
--- a/validator_instance.go
+++ b/validator_instance.go
@@ -707,3 +707,22 @@ func (v *Validate) VarWithValueCtx(ctx context.Context, field interface{}, other
 	v.pool.Put(vd)
 	return
 }
+
+// ValidateTag validates a tag. It's main purpose is to be used when validating values directly via the Var, VarCtx,
+// VarWithValue and VarWithValueCtx methods to know beforehand if the tag is known by the library instead of managing
+// a panic error.
+//
+// Parameters:
+// tag (string): The tag to be validated.
+//
+// Returns:
+// error: An error signaling the given tag is invalid.
+func (v *Validate) ValidateTag(tag string) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("error parsing tag: %v", r)
+		}
+	}()
+	v.parseFieldTagsRecursive(tag, "", "", false)
+	return err
+}

--- a/validator_test.go
+++ b/validator_test.go
@@ -13692,3 +13692,11 @@ func TestOmitNilAndRequired(t *testing.T) {
 		AssertError(t, err2, "OmitNil.Inner.Str", "OmitNil.Inner.Str", "Str", "Str", "required")
 	})
 }
+
+func TestValidate_ValidateTag(t *testing.T) {
+	validate := New()
+	err := validate.ValidateTag("nonexsiting,nonexisting2")
+	NotEqual(t, err, nil)
+	err = validate.ValidateTag("required,email")
+	Equal(t, err, nil)
+}


### PR DESCRIPTION
## Enhances

Use case description : 

In an application where we let a user configure custom fields and validation, we want to make sure that the tag associated with the field is valid before using it (because the validation library panics if the tag is invalid, which is fine when the library is used with struct annotations, but not very nice when using methods `Var`, `VarCtx`, `VarWithValue` and `VarWithValueCtx` directly)

in order to validate a user validation tag input, I propose a new method that handles tag validation and returns an error if there is an invalid tag, allowing a library user to handle this error nicely.

The benefits of adding this here instead of in our codebase is that the tag list is always up to date and it handles custom validators too.

**Make sure that you've checked the boxes below before you submit PR:**
- [ ] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers