### PR TITLE
Unnecessary lock operation for reading from cache in extractStructCache method -  fixed double checknig/reading cStruct in validateStruct method

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -100,9 +100,6 @@ type cTag struct {
 }
 
 func (v *Validate) extractStructCache(current reflect.Value, sName string) *cStruct {
-	v.structCache.lock.Lock()
-	defer v.structCache.lock.Unlock() // leave as defer! because if inner panics, it will never get unlocked otherwise!
-
 	typ := current.Type()
 
 	// could have been multiple trying to access, but once first is done this ensures struct
@@ -111,6 +108,9 @@ func (v *Validate) extractStructCache(current reflect.Value, sName string) *cStr
 	if ok {
 		return cs
 	}
+
+	v.structCache.lock.Lock()
+	defer v.structCache.lock.Unlock() // leave as defer! because if inner panics, it will never get unlocked otherwise!
 
 	cs = &cStruct{name: sName, fields: make([]*cField, 0), fn: v.structLevelFuncs[typ]}
 

--- a/validator.go
+++ b/validator.go
@@ -31,11 +31,7 @@ type validate struct {
 
 // parent and current will be the same the first run of validateStruct
 func (v *validate) validateStruct(ctx context.Context, parent reflect.Value, current reflect.Value, typ reflect.Type, ns []byte, structNs []byte, ct *cTag) {
-
-	cs, ok := v.v.structCache.Get(typ)
-	if !ok {
-		cs = v.v.extractStructCache(current, typ.Name())
-	}
+	cs := v.v.extractStructCache(current, typ.Name())
 
 	if len(ns) == 0 && len(cs.name) != 0 {
 
@@ -66,7 +62,7 @@ func (v *validate) validateStruct(ctx context.Context, parent reflect.Value, cur
 
 				} else {
 					// used with StructPartial & StructExcept
-					_, ok = v.includeExclude[string(append(structNs, f.name...))]
+					_, ok := v.includeExclude[string(append(structNs, f.name...))]
 
 					if (ok && v.hasExcludes) || (!ok && !v.hasExcludes) {
 						continue


### PR DESCRIPTION
## Fixes Or Enhances
- Fixed unnecessary Lock, and UnLock Operations in `*Validate.extractStructCache` method while the struct (cStruct) has been cached.
- Fixed double-checking structCache for a Cached struct in `*validate.validateStruct` method, while it was done in `*Validate.extractStructCache` method.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers