### PR TITLE
Fix: panic in struct level example

### DIFF
--- a/_examples/struct-level/main.go
+++ b/_examples/struct-level/main.go
@@ -36,7 +36,7 @@ func (gender Gender) String() string {
 	if gender < Male || gender > Intersex {
 		return "unknown"
 	}
-	return terms[gender]
+	return terms[gender-1]
 }
 
 // User contains user information


### PR DESCRIPTION
Accessing an array element at index 3 causes index out of range panic

## Fixes Or Enhances


**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers