### PR TITLE
Make docs for required more explicit regarding boolean values

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -253,7 +253,7 @@ Example #2
 
 This validates that the value is not the data types default zero value.
 For numbers ensures value is not zero. For strings ensures value is
-not "". For slices, maps, pointers, interfaces, channels and functions
+not "". For booleans ensures value is not false. For slices, maps, pointers, interfaces, channels and functions
 ensures the value is not nil. For structs ensures value is not the zero value when using WithRequiredStructEnabled.
 
 	Usage: required


### PR DESCRIPTION
`required` validates that the value is not the data types default zero value. For `boolean` the default zero value is `false`. Therefore, a `false` boolean value would be interpreted as not matching the `required` validation and fail.

This, in my opinion, is a little unexpected. Judging from the name `required` only, I expected that a `false` boolean value would be ok, since a value was provided.

Nevertheless, in my opinion, this behavior should be documented a little more explicitly. Which is why I propose this change to the docs.

- [x] Tests exist or have been written that cover this particular change.
(this is only a docs change)

@go-playground/validator-maintainers