### PR TITLE
Fix grammar issues in comments, tests, field names

### DIFF
--- a/_examples/translations/main.go
+++ b/_examples/translations/main.go
@@ -27,7 +27,7 @@ type Address struct {
 	Phone  string `validate:"required"`
 }
 
-// use a single instance , it caches struct info
+// use a single instance, it caches struct info
 var (
 	uni      *ut.UniversalTranslator
 	validate *validator.Validate
@@ -35,7 +35,7 @@ var (
 
 func main() {
 
-	// NOTE: ommitting allot of error checking for brevity
+	// NOTE: omitting allot of error checking for brevity
 
 	en := en.New()
 	uni = ut.New(en, en)

--- a/baked_in.go
+++ b/baked_in.go
@@ -690,7 +690,7 @@ func isEthereumAddress(fl FieldLevel) bool {
 	return ethAddressRegex.MatchString(address)
 }
 
-// isEthereumAddressChecksum is the validation function for validating if the field's value is a valid checksumed Ethereum address.
+// isEthereumAddressChecksum is the validation function for validating if the field's value is a valid checksummed Ethereum address.
 func isEthereumAddressChecksum(fl FieldLevel) bool {
 	address := fl.Field().String()
 

--- a/cache.go
+++ b/cache.go
@@ -294,7 +294,7 @@ func (v *Validate) parseFieldTagsRecursive(tag string, fieldName string, alias s
 
 				if wrapper, ok := v.validations[current.tag]; ok {
 					current.fn = wrapper.fn
-					current.runValidationWhenNil = wrapper.runValidatinOnNil
+					current.runValidationWhenNil = wrapper.runValidationOnNil
 				} else {
 					panic(strings.TrimSpace(fmt.Sprintf(undefinedValidation, current.tag, fieldName)))
 				}

--- a/doc.go
+++ b/doc.go
@@ -911,7 +911,7 @@ This will accept any uri the golang request uri accepts
 
 # Urn RFC 2141 String
 
-This validataes that a string value contains a valid URN
+This validates that a string value contains a valid URN
 according to the RFC 2141 spec.
 
 	Usage: urn_rfc2141
@@ -966,7 +966,7 @@ Bitcoin Bech32 Address (segwit)
 
 This validates that a string value contains a valid bitcoin Bech32 address as defined
 by bip-0173 (https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)
-Special thanks to Pieter Wuille for providng reference implementations.
+Special thanks to Pieter Wuille for providing reference implementations.
 
 	Usage: btc_addr_bech32
 
@@ -1299,7 +1299,7 @@ may not exist at the time of validation.
 # HostPort
 
 This validates that a string value contains a valid DNS hostname and port that
-can be used to valiate fields typically passed to sockets and connections.
+can be used to validate fields typically passed to sockets and connections.
 
 	Usage: hostname_port
 

--- a/validator_instance.go
+++ b/validator_instance.go
@@ -74,8 +74,8 @@ type CustomTypeFunc func(field reflect.Value) interface{}
 type TagNameFunc func(field reflect.StructField) string
 
 type internalValidationFuncWrapper struct {
-	fn                FuncCtx
-	runValidatinOnNil bool
+	fn                 FuncCtx
+	runValidationOnNil bool
 }
 
 // Validate contains the validator settings and cache
@@ -245,7 +245,7 @@ func (v *Validate) registerValidation(tag string, fn FuncCtx, bakedIn bool, nilC
 	if !bakedIn && (ok || strings.ContainsAny(tag, restrictedTagChars)) {
 		panic(fmt.Sprintf(restrictedTagErr, tag))
 	}
-	v.validations[tag] = internalValidationFuncWrapper{fn: fn, runValidatinOnNil: nilCheckable}
+	v.validations[tag] = internalValidationFuncWrapper{fn: fn, runValidationOnNil: nilCheckable}
 	return nil
 }
 
@@ -676,7 +676,7 @@ func (v *Validate) VarWithValue(field interface{}, other interface{}, tag string
 }
 
 // VarWithValueCtx validates a single variable, against another variable/field's value using tag style validation and
-// allows passing of contextual validation validation information via context.Context.
+// allows passing of contextual validation information via context.Context.
 // eg.
 // s1 := "abcd"
 // s2 := "abcd"

--- a/validator_test.go
+++ b/validator_test.go
@@ -27,8 +27,8 @@ import (
 
 // NOTES:
 // - Run "go test" to run tests
-// - Run "gocov test | gocov report" to report on test converage by file
-// - Run "gocov test | gocov annotate -" to report on all code and functions, those ,marked with "MISS" were never called
+// - Run "gocov test | gocov report" to report on test coverage by file
+// - Run "gocov test | gocov annotate -" to report on all code and functions, those, marked with "MISS" were never called
 //
 // or
 //
@@ -799,7 +799,7 @@ func TestStructPartial(t *testing.T) {
 	errs = validate.StructPartial(tPartial, p2...)
 	Equal(t, errs, nil)
 
-	// this isn't really a robust test, but is ment to illustrate the ANON CASE below
+	// this isn't really a robust test, but is meant to illustrate the ANON CASE below
 	errs = validate.StructPartial(tPartial.SubSlice[0], p3...)
 	Equal(t, errs, nil)
 
@@ -809,7 +809,7 @@ func TestStructPartial(t *testing.T) {
 	errs = validate.StructExcept(tPartial, p2...)
 	Equal(t, errs, nil)
 
-	// mod tParial for required feild and re-test making sure invalid fields are NOT required:
+	// mod tPartial for required field and re-test making sure invalid fields are NOT required:
 	tPartial.Required = ""
 
 	errs = validate.StructExcept(tPartial, p1...)
@@ -830,7 +830,7 @@ func TestStructPartial(t *testing.T) {
 	tPartial.Required = "Required"
 	tPartial.Anonymous.A = ""
 
-	// will pass as unset feilds is not going to be tested
+	// will pass as unset fields is not going to be tested
 	errs = validate.StructPartial(tPartial, p1...)
 	Equal(t, errs, nil)
 
@@ -841,7 +841,7 @@ func TestStructPartial(t *testing.T) {
 	errs = validate.StructExcept(tPartial.Anonymous, p4...)
 	Equal(t, errs, nil)
 
-	// will fail as unset feild is tested
+	// will fail as unset field is tested
 	errs = validate.StructPartial(tPartial, p2...)
 	NotEqual(t, errs, nil)
 	AssertError(t, errs, "TestPartial.Anonymous.A", "TestPartial.Anonymous.A", "A", "A", "required")
@@ -893,7 +893,7 @@ func TestStructPartial(t *testing.T) {
 	Equal(t, len(errs.(ValidationErrors)), 1)
 	AssertError(t, errs, "TestPartial.SubSlice[0].Test", "TestPartial.SubSlice[0].Test", "Test", "Test", "required")
 
-	// reset struct in slice, and unset struct in slice in unset posistion
+	// reset struct in slice, and unset struct in slice in unset position
 	tPartial.SubSlice[0].Test = "Required"
 
 	// these will pass as the unset item is NOT tested
@@ -9268,7 +9268,7 @@ func TestCustomFieldName(t *testing.T) {
 	Equal(t, getError(errs, "A.E", "A.E").Field(), "E")
 }
 
-func TestMutipleRecursiveExtractStructCache(t *testing.T) {
+func TestMultipleRecursiveExtractStructCache(t *testing.T) {
 	validate := New()
 
 	type Recursive struct {
@@ -9609,7 +9609,7 @@ func TestStructFiltered(t *testing.T) {
 	errs = validate.StructFiltered(tPartial.SubSlice[0], p3)
 	Equal(t, errs, nil)
 
-	// mod tParial for required field and re-test making sure invalid fields are NOT required:
+	// mod tPartial for required field and re-test making sure invalid fields are NOT required:
 	tPartial.Required = ""
 
 	// inversion and retesting Partial to generate failures:
@@ -9621,7 +9621,7 @@ func TestStructFiltered(t *testing.T) {
 	tPartial.Required = "Required"
 	tPartial.Anonymous.A = ""
 
-	// will pass as unset feilds is not going to be tested
+	// will pass as unset fields is not going to be tested
 	errs = validate.StructFiltered(tPartial, p1)
 	Equal(t, errs, nil)
 
@@ -10558,7 +10558,7 @@ func TestHTMLEncodedValidation(t *testing.T) {
 			}
 		} else {
 			if IsEqual(errs, nil) {
-				t.Fatalf("Index: %d html_enocded failed Error: %v", i, errs)
+				t.Fatalf("Index: %d html_encoded failed Error: %v", i, errs)
 			} else {
 				val := getError(errs, "", "")
 				if val.Tag() != "html_encoded" {
@@ -10599,7 +10599,7 @@ func TestURLEncodedValidation(t *testing.T) {
 			}
 		} else {
 			if IsEqual(errs, nil) {
-				t.Fatalf("Index: %d url_enocded failed Error: %v", i, errs)
+				t.Fatalf("Index: %d url_encoded failed Error: %v", i, errs)
 			} else {
 				val := getError(errs, "", "")
 				if val.Tag() != "url_encoded" {


### PR DESCRIPTION
## Fixes Or Enhances

Typos and other grammar issues in comments, tests, and field names.

@go-playground/validator-maintainers