### PR TITLE
remove go 1.17 from CI tests job

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x,1.18.x,1.21.x,1.22.x]
+        go-version: [1.18.x,1.21.x,1.22.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Fixes Or Enhances

Removes Go 1.17 from the test CI job to speed up pipeline execution.

Testing with Go 1.17 is not needed because the minimum supported version is Go 1.18, as stated in the [go.mod](https://github.com/go-playground/validator/blob/master/go.mod#L3).

@go-playground/validator-maintainers