### PR TITLE
Update baked_in.go

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -1398,6 +1398,7 @@ func isPostcodeByIso3166Alpha2Field(fl FieldLevel) bool {
 		panic(fmt.Sprintf("Bad field type %T", currentField.Interface()))
 	}
 
+	postcodeRegexInit.Do(initPostcodes)
 	reg, found := postCodeRegexDict[currentField.String()]
 	if !found {
 		return false


### PR DESCRIPTION
## Fixes Or Enhances
init postcode in isPostcodeByIso3166Alpha2Field

**Make sure that you've checked the boxes below before you submit PR:**
- [ ] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers