### PR TITLE
Change to allow multiple errors be returned from single field when option "WithMultipleErrorsReturned" is set.

### DIFF
--- a/options.go
+++ b/options.go
@@ -24,3 +24,13 @@ func WithPrivateFieldValidation() Option {
 		v.privateFieldValidation = true
 	}
 }
+
+// WithMultipleErrorsReturned enables multi error return from a single struct field.
+//
+// By opting into this feature you are acknowledging that you are aware of the risks and accept any current or future
+// consequences of using this feature.
+func WithMultipleErrorsReturned() Option {
+	return func(v *Validate) {
+		v.multipleErrorsReturned = true
+	}
+}

--- a/validator.go
+++ b/validator.go
@@ -138,7 +138,9 @@ func (v *validate) traverseField(ctx context.Context, parent reflect.Value, curr
 						kind:           kind,
 					},
 				)
-				return
+				if !v.Validator().multipleErrorsReturned {
+					return
+				}
 			}
 
 			v.str1 = string(append(ns, cf.altName...))
@@ -163,7 +165,9 @@ func (v *validate) traverseField(ctx context.Context, parent reflect.Value, curr
 						typ:            current.Type(),
 					},
 				)
-				return
+				if !v.Validator().multipleErrorsReturned {
+					return
+				}
 			}
 		}
 
@@ -439,7 +443,9 @@ OUTER:
 						)
 					}
 
-					return
+					if !v.Validator().multipleErrorsReturned {
+						return
+					}
 				}
 
 				ct = ct.next
@@ -478,7 +484,9 @@ OUTER:
 					},
 				)
 
-				return
+				if !v.Validator().multipleErrorsReturned {
+					return
+				}
 			}
 			ct = ct.next
 		}

--- a/validator_instance.go
+++ b/validator_instance.go
@@ -95,6 +95,7 @@ type Validate struct {
 	hasTagNameFunc         bool
 	requiredStructEnabled  bool
 	privateFieldValidation bool
+	multipleErrorsReturned bool
 }
 
 // New returns a new instance of 'validate' with sane defaults.

--- a/validator_test.go
+++ b/validator_test.go
@@ -14001,3 +14001,98 @@ func TestPrivateFieldsStruct(t *testing.T) {
 		Equal(t, len(errs), tc.errorNum)
 	}
 }
+
+func TestMultipleErrorsOption(t *testing.T) {
+	type tc struct {
+		stct     interface{}
+		errorNum int
+	}
+
+	tcs := []tc{
+		{
+			stct: &struct {
+				F1 int8  `validate:"eq=10,gte=10"`
+				F2 int16 `validate:"eq=10,gte=10"`
+				F3 int32 `validate:"eq=10,gte=10"`
+				F4 int64 `validate:"eq=10,gte=10"`
+			}{},
+			errorNum: 8,
+		},
+		{
+			stct: &struct {
+				F1 uint8  `validate:"eq=10,gte=10"`
+				F2 uint16 `validate:"eq=10,gte=10"`
+				F3 uint32 `validate:"eq=10,gte=10"`
+				F4 uint64 `validate:"eq=10,gte=10"`
+			}{},
+			errorNum: 8,
+		},
+		{
+			stct: &struct {
+				F1 string `validate:"eq=10,gte=10"`
+				F2 string `validate:"eq=10,gte=10"`
+			}{},
+			errorNum: 4,
+		},
+		{
+			stct: &struct {
+				F1 float32 `validate:"eq=10,gte=10"`
+				F2 float64 `validate:"eq=10,gte=10"`
+			}{},
+			errorNum: 4,
+		},
+		{
+			stct: struct {
+				F1 int8  `validate:"eq=10,gte=10"`
+				F2 int16 `validate:"eq=10,gte=10"`
+				F3 int32 `validate:"eq=10,gte=10"`
+				F4 int64 `validate:"eq=10,gte=10"`
+			}{},
+			errorNum: 8,
+		},
+		{
+			stct: struct {
+				F1 uint8  `validate:"eq=10,gte=10"`
+				F2 uint16 `validate:"eq=10,gte=10"`
+				F3 uint32 `validate:"eq=10,gte=10"`
+				F4 uint64 `validate:"eq=10,gte=10"`
+			}{},
+			errorNum: 8,
+		},
+		{
+			stct: struct {
+				F1 float32 `validate:"eq=10,gte=10"`
+				F2 float64 `validate:"eq=10,gte=10"`
+			}{},
+			errorNum: 4,
+		},
+		{
+			stct: struct {
+				F1 int `validate:"eq=10,gte=10"`
+				F2 struct {
+					F3 int `validate:"eq=10,gte=10"`
+				}
+			}{},
+			errorNum: 4,
+		},
+		{
+			stct: &struct {
+				F1 int `validate:"eq=10,gte=10"`
+				F2 struct {
+					F3 int `validate:"eq=10,gte=10"`
+				}
+			}{},
+			errorNum: 4,
+		},
+	}
+
+	validate := New(WithMultipleErrorsReturned())
+
+	for _, tc := range tcs {
+		err := validate.Struct(tc.stct)
+		NotEqual(t, err, nil)
+
+		errs := err.(ValidationErrors)
+		Equal(t, len(errs), tc.errorNum)
+	}
+}


### PR DESCRIPTION
Hello, I would like to propose a change that will allow the user to decide if from a single field multiple validation errors may arise.
This was already reported as issue here: https://github.com/go-playground/validator/issues/1268 
## Fixes Or Enhances

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers