### PR TITLE
feat: add validator for numeric ports

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -213,6 +213,7 @@ var (
 		"json":                          isJSON,
 		"jwt":                           isJWT,
 		"hostname_port":                 isHostnamePort,
+		"port":                          isPort,
 		"lowercase":                     isLowercase,
 		"uppercase":                     isUppercase,
 		"datetime":                      isDatetime,
@@ -2702,6 +2703,13 @@ func isHostnamePort(fl FieldLevel) bool {
 		return hostnameRegexRFC1123().MatchString(host)
 	}
 	return true
+}
+
+// IsPort validates if the current field's value represents a valid port
+func isPort(fl FieldLevel) bool {
+	val := fl.Field().Uint()
+
+	return val >= 1 && val <= 65535
 }
 
 // isLowercase is the validation function for validating if the current field's value is a lowercase string.

--- a/validator_test.go
+++ b/validator_test.go
@@ -12377,6 +12377,32 @@ func Test_hostnameport_validator(t *testing.T) {
 	}
 }
 
+func Test_port_validator(t *testing.T) {
+	type Host struct {
+		Port uint32 `validate:"port"`
+	}
+
+	type testInput struct {
+		data     uint32
+		expected bool
+	}
+	testData := []testInput{
+		{0, false},
+		{1, true},
+		{65535, true},
+		{65536, false},
+		{65538, false},
+	}
+	for _, td := range testData {
+		h := Host{Port: td.data}
+		v := New()
+		err := v.Struct(h)
+		if td.expected != (err == nil) {
+			t.Fatalf("Test failed for data: %v Error: %v", td.data, err)
+		}
+	}
+}
+
 func TestLowercaseValidation(t *testing.T) {
 	tests := []struct {
 		param    string


### PR DESCRIPTION
## Fixes Or Enhances
This PR adds a new validation for numeric ports.
Connected to: #1216 

```
	type Host struct {
		Port uint32 `validate:"port"`
	}

```
**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers