### PR TITLE
Add more unit tests

### DIFF
--- a/validator_test.go
+++ b/validator_test.go
@@ -10951,6 +10951,32 @@ func TestStartsWithValidation(t *testing.T) {
 		}
 	}
 }
+func TestStartsNotWithValidation(t *testing.T) {
+	tests := []struct {
+		Value       string `validate:"startsnotwith=(/^ヮ^)/*:・ﾟ✧"`
+		Tag         string
+		ExpectedNil bool
+	}{
+		{Value: "(/^ヮ^)/*:・ﾟ✧ glitter", Tag: "startsnotwith=(/^ヮ^)/*:・ﾟ✧", ExpectedNil: false},
+		{Value: "abcd", Tag: "startsnotwith=(/^ヮ^)/*:・ﾟ✧", ExpectedNil: true},
+	}
+
+	validate := New()
+
+	for i, s := range tests {
+		errs := validate.Var(s.Value, s.Tag)
+
+		if (s.ExpectedNil && errs != nil) || (!s.ExpectedNil && errs == nil) {
+			t.Fatalf("Index: %d failed Error: %s", i, errs)
+		}
+
+		errs = validate.Struct(s)
+
+		if (s.ExpectedNil && errs != nil) || (!s.ExpectedNil && errs == nil) {
+			t.Fatalf("Index: %d failed Error: %s", i, errs)
+		}
+	}
+}
 
 func TestEndsWithValidation(t *testing.T) {
 	tests := []struct {
@@ -10960,6 +10986,33 @@ func TestEndsWithValidation(t *testing.T) {
 	}{
 		{Value: "glitter (/^ヮ^)/*:・ﾟ✧", Tag: "endswith=(/^ヮ^)/*:・ﾟ✧", ExpectedNil: true},
 		{Value: "(/^ヮ^)/*:・ﾟ✧ glitter", Tag: "endswith=(/^ヮ^)/*:・ﾟ✧", ExpectedNil: false},
+	}
+
+	validate := New()
+
+	for i, s := range tests {
+		errs := validate.Var(s.Value, s.Tag)
+
+		if (s.ExpectedNil && errs != nil) || (!s.ExpectedNil && errs == nil) {
+			t.Fatalf("Index: %d failed Error: %s", i, errs)
+		}
+
+		errs = validate.Struct(s)
+
+		if (s.ExpectedNil && errs != nil) || (!s.ExpectedNil && errs == nil) {
+			t.Fatalf("Index: %d failed Error: %s", i, errs)
+		}
+	}
+}
+
+func TestEndsNotWithValidation(t *testing.T) {
+	tests := []struct {
+		Value       string `validate:"endsnotwith=(/^ヮ^)/*:・ﾟ✧"`
+		Tag         string
+		ExpectedNil bool
+	}{
+		{Value: "glitter (/^ヮ^)/*:・ﾟ✧", Tag: "endsnotwith=(/^ヮ^)/*:・ﾟ✧", ExpectedNil: false},
+		{Value: "(/^ヮ^)/*:・ﾟ✧ glitter", Tag: "endsnotwith=(/^ヮ^)/*:・ﾟ✧", ExpectedNil: true},
 	}
 
 	validate := New()
@@ -12790,7 +12843,7 @@ func TestIsIso4217Validation(t *testing.T) {
 }
 
 func TestIsIso4217NumericValidation(t *testing.T) {
-	tests := []struct {
+	testsInt := []struct {
 		value    int `validate:"iso4217_numeric"`
 		expected bool
 	}{
@@ -12801,7 +12854,7 @@ func TestIsIso4217NumericValidation(t *testing.T) {
 
 	validate := New()
 
-	for i, test := range tests {
+	for i, test := range testsInt {
 
 		errs := validate.Var(test.value, "iso4217_numeric")
 
@@ -12815,6 +12868,32 @@ func TestIsIso4217NumericValidation(t *testing.T) {
 			}
 		}
 	}
+
+	testsUInt := []struct {
+		value    uint `validate:"iso4217_numeric"`
+		expected bool
+	}{
+		{8, true},
+		{12, true},
+		{13, false},
+	}
+
+	for i, test := range testsUInt {
+
+		errs := validate.Var(test.value, "iso4217_numeric")
+
+		if test.expected {
+			if !IsEqual(errs, nil) {
+				t.Fatalf("Index: %d iso4217 failed Error: %s", i, errs)
+			}
+		} else {
+			if IsEqual(errs, nil) {
+				t.Fatalf("Index: %d iso4217 failed Error: %s", i, errs)
+			}
+		}
+	}
+
+	PanicMatches(t, func() { _ = validate.Var(2.0, "iso4217_numeric") }, "Bad field type float64")
 }
 
 func TestTimeZoneValidation(t *testing.T) {


### PR DESCRIPTION
## Fixes Or Enhances
This PR adds a few unit tests to increase test coverage:
- `startsnotwith` validation
- `endsnotwith` validation
- iso4217_numeric for UINT

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers