### PR TITLE
fix: add missing postcodeRegex init to isPostcodeByIso3166Alpha2Field…

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -1398,6 +1398,7 @@ func isPostcodeByIso3166Alpha2Field(fl FieldLevel) bool {
 		panic(fmt.Sprintf("Bad field type %T", currentField.Interface()))
 	}
 
+	postcodeRegexInit.Do(initPostcodes)
 	reg, found := postCodeRegexDict[currentField.String()]
 	if !found {
 		return false


### PR DESCRIPTION
isPostcodeByIso3166Alpha2Field

## Fixes
I have added the missing postcodeRegex init to the isPostcodeByIso3166Alpha2Field func. On the default isPostcodeByIso3166Alpha2 func it already exists. 


**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers