### PR TITLE
fix IPv4 mapped IPv6 address cannot verify for "ipv6" and "ipv4" tag

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -402,16 +402,18 @@ func isCIDR(fl FieldLevel) bool {
 
 // isIPv4 is the validation function for validating if a value is a valid v4 IP address.
 func isIPv4(fl FieldLevel) bool {
-	ip := net.ParseIP(fl.Field().String())
+	ipStr := fl.Field().String()
+	ip := net.ParseIP(ipStr)
 
-	return ip != nil && ip.To4() != nil
+	return ip != nil && strings.Contains(ipStr, ".") && !strings.Contains(ipStr, ":")
 }
 
 // isIPv6 is the validation function for validating if the field's value is a valid v6 IP address.
 func isIPv6(fl FieldLevel) bool {
-	ip := net.ParseIP(fl.Field().String())
+	ipStr := fl.Field().String()
+	ip := net.ParseIP(ipStr)
 
-	return ip != nil && ip.To4() == nil
+	return ip != nil && strings.Contains(ipStr, ":")
 }
 
 // isIP is the validation function for validating if the field's value is a valid v4 or v6 IP address.

--- a/validator_test.go
+++ b/validator_test.go
@@ -2419,6 +2419,8 @@ func TestIPv6Validation(t *testing.T) {
 		{"2001:cdba:0000:0000:0000:0000:3257:9652", true},
 		{"2001:cdba:0:0:0:0:3257:9652", true},
 		{"2001:cdba::3257:9652", true},
+		{"::ffff:192.168.1.1", true},
+		{"::ffff:c0a8:0101", true},
 	}
 
 	validate := New()
@@ -2459,6 +2461,8 @@ func TestIPv4Validation(t *testing.T) {
 		{"2001:cdba:0000:0000:0000:0000:3257:9652", false},
 		{"2001:cdba:0:0:0:0:3257:9652", false},
 		{"2001:cdba::3257:9652", false},
+		{"::ffff:192.168.1.1", false},
+		{"::ffff:c0a8:0101", false},
 	}
 
 	validate := New()


### PR DESCRIPTION
## Fixes Or Enhances


**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers