### PR TITLE
doc(oneof): mention 'enum'

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -489,7 +489,7 @@ For strings, ints, and uints, oneof will ensure that the value
 is one of the values in the parameter.  The parameter should be
 a list of values separated by whitespace. Values may be
 strings or numbers. To match strings with spaces in them, include
-the target string between single quotes.
+the target string between single quotes. Kind of like an 'enum'.
 
 	Usage: oneof=red green
 	       oneof='red green' 'blue yellow'


### PR DESCRIPTION
## Fixes Or Enhances
Mention 'enum' in the documentation for `oneof`. One of our team member spent too much time looking for an 'enum-like' validation tag, only to find out later that `oneof` exists. This PR intends on making the discovery of this validation tag easier.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers