### PR TITLE
Docs: fix `Base64RawURL` usage

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -959,7 +959,7 @@ Although an empty string is a valid base64 URL safe value, this will report
 an empty string as an error, if you wish to accept an empty string as valid
 you can use this with the omitempty tag.
 
-	Usage: base64url
+	Usage: base64rawurl
 
 # Bitcoin Address
 


### PR DESCRIPTION
## Fixes Or Enhances
The usage of Base64RawURL was incorrect.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers