### PR TITLE
Fix postcode_iso3166_alpha2_field validation

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -1417,6 +1417,7 @@ func isPostcodeByIso3166Alpha2Field(fl FieldLevel) bool {
 		panic(fmt.Sprintf("Bad field type %T", currentField.Interface()))
 	}
 
+	postcodeRegexInit.Do(initPostcodes)
 	reg, found := postCodeRegexDict[currentField.String()]
 	if !found {
 		return false


### PR DESCRIPTION
Fixed an issue where the post codes regexes would not get initialised for postcode_iso3166_alpha2_field validation.

## Fixes Or Enhances


**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers