### PR TITLE
Added support for validating OCI tags

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -241,6 +241,7 @@ var (
 		"mongodb_connection_string":     isMongoDBConnectionString,
 		"cron":                          isCron,
 		"spicedb":                       isSpiceDB,
+		"oci_tag":                       isOciTag,
 	}
 )
 
@@ -3044,4 +3045,9 @@ func hasLuhnChecksum(fl FieldLevel) bool {
 func isCron(fl FieldLevel) bool {
 	cronString := fl.Field().String()
 	return cronRegex().MatchString(cronString)
+}
+
+// isOciTag is the validation function for validating if the current field's value is a valid OCI tag, as described in the OCI Distribution Specification: https://github.com/opencontainers/distribution-spec/blob/main/spec.md
+func isOciTag(fl FieldLevel) bool {
+	return ociTagRegex().MatchString(fl.Field().String())
 }

--- a/regexes.go
+++ b/regexes.go
@@ -77,6 +77,7 @@ const (
 	spicedbIDRegexString             = `^(([a-zA-Z0-9/_|\-=+]{1,})|\*)$`
 	spicedbPermissionRegexString     = "^([a-z][a-z0-9_]{1,62}[a-z0-9])?$"
 	spicedbTypeRegexString           = "^([a-z][a-z0-9_]{1,61}[a-z0-9]/)?[a-z][a-z0-9_]{1,62}[a-z0-9]$"
+	ociTagRegexString                = "^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$"
 )
 
 func lazyRegexCompile(str string) func() *regexp.Regexp {
@@ -160,4 +161,5 @@ var (
 	spicedbIDRegex             = lazyRegexCompile(spicedbIDRegexString)
 	spicedbPermissionRegex     = lazyRegexCompile(spicedbPermissionRegexString)
 	spicedbTypeRegex           = lazyRegexCompile(spicedbTypeRegexString)
+	ociTagRegex                = lazyRegexCompile(ociTagRegexString)
 )

--- a/validator_test.go
+++ b/validator_test.go
@@ -9417,6 +9417,32 @@ func TestPointerAndOmitEmpty(t *testing.T) {
 	Equal(t, errs, nil)
 }
 
+func TestOciTag(t *testing.T) {
+	validate := New()
+
+	type Test struct {
+		Value string `validate:"oci_tag"`
+	}
+
+	var test Test
+
+	err := validate.Struct(test)
+	NotEqual(t, err, nil)
+	AssertError(t, err.(ValidationErrors), "Test.Value", "Test.Value", "Value", "Value", "oci_tag")
+
+	test.Value = "latest"
+	err = validate.Struct(test)
+	Equal(t, err, nil)
+
+	test.Value = "thisismorethanonehundredandtwentyeightcharactersthisismorethanonehundredandtwentyeightcharactersthisismorethanonehundredandtwenty"
+	err = validate.Struct(test)
+	AssertError(t, err.(ValidationErrors), "Test.Value", "Test.Value", "Value", "Value", "oci_tag")
+
+	test.Value = ""
+	err = validate.Struct(test)
+	AssertError(t, err.(ValidationErrors), "Test.Value", "Test.Value", "Value", "Value", "oci_tag")
+}
+
 func TestRequired(t *testing.T) {
 	validate := New()
 	validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
@@ -12080,7 +12106,7 @@ func TestExcludedIf(t *testing.T) {
 
 	test11 := struct {
 		Field1 bool
-  		Field2 *string `validate:"excluded_if=Field1 false"`
+		Field2 *string `validate:"excluded_if=Field1 false"`
 	}{
 		Field1: false,
 		Field2: nil,


### PR DESCRIPTION
## Fixes Or Enhances

Added a new `oci_tag` to validate an OCI manifest tag as described in the OCI Distribution Spec: https://github.com/opencontainers/distribution-spec/blob/main/spec.md?plain=1#L164-L166

This is also more commonly referred to as a container tag or a docker tag.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers