### PR TITLE
Use correct pointer in errors.As(). Fix "panic: errors: *target must be interface or implement error" in examples.

### DIFF
--- a/_examples/simple/main.go
+++ b/_examples/simple/main.go
@@ -62,7 +62,8 @@ func validateStruct() {
 		// this check is only needed when your code could produce
 		// an invalid value for validation such as interface with nil
 		// value most including myself do not usually have code like this.
-		if errors.As(err, &validator.InvalidValidationError{}) {
+		var invalidValidationError *validator.InvalidValidationError
+		if errors.As(err, &invalidValidationError) {
 			fmt.Println(err)
 			return
 		}

--- a/_examples/struct-level/main.go
+++ b/_examples/struct-level/main.go
@@ -115,7 +115,8 @@ func main() {
 		// this check is only needed when your code could produce
 		// an invalid value for validation such as interface with nil
 		// value most including myself do not usually have code like this.
-		if errors.As(err, &validator.InvalidValidationError{}) {
+		var invalidValidationError *validator.InvalidValidationError
+		if errors.As(err, &invalidValidationError) {
 			fmt.Println(err)
 			return
 		}


### PR DESCRIPTION
Only *InvalidValidationError implements error, so we must use double pointer.
good explanation: https://www.reddit.com/r/golang/comments/txi397/comment/i3lybab/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button
and https://stackoverflow.com/a/69448087/9066110

## Fixes Or Enhances
Fixes `panic: errors: *target must be interface or implement error` for `_examples/simple/` and `_examples/struct-level/` that was introduced in https://github.com/go-playground/validator/pull/1346

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers