### PR TITLE
Update workflow to support the last three Go versions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.x,1.21.x,1.22.x,1.23.x]
+        go-version: [1.22.x,1.23.x, 1.24.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -24,7 +24,7 @@ jobs:
         run: go test -race -covermode=atomic -coverprofile="profile.cov" ./...
 
       - name: Send Coverage
-        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.22.x'
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.23.x'
         uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: profile.cov
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:


### PR DESCRIPTION
## Fixes Or Enhances
This package follows the Go release policy, supporting the two most recent major versions.  
This PR updates the GitHub workflow to use the last three Go versions instead of four.

**Make sure that you've checked the boxes below before you submit PR:**
- [ ] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers