### PR TITLE
Fix reference to parameter name in docs

### DIFF
--- a/struct_level.go
+++ b/struct_level.go
@@ -46,9 +46,9 @@ type StructLevel interface {
 	//
 	// NOTES:
 	//
-	// fieldName and altName get appended to the existing namespace that
-	// validator is on. e.g. pass 'FirstName' or 'Names[0]' depending
-	// on the nesting
+	// fieldName and structFieldName get appended to the existing
+	// namespace that validator is on. e.g. pass 'FirstName' or
+	// 'Names[0]' depending on the nesting
 	//
 	// tag can be an existing validation tag or just something you make up
 	// and process on the flip side it's up to you.


### PR DESCRIPTION
The docs still mentioned the old name of the parameter, which threw me a bit off, this PR just updates the comment.

@go-playground/validator-maintainers