### PR TITLE
Fix Release version badge on README page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Package validator
 =================
-<img align="right" src="logo.png">![Project status](https://img.shields.io/badge/version-10.25.0-green.svg)
+<img align="right" src="logo.png">[![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/go-playground/validator)](https://github.com/go-playground/validator/releases)
 [![Build Status](https://github.com/go-playground/validator/actions/workflows/workflow.yml/badge.svg)](https://github.com/go-playground/validator/actions)
 [![Coverage Status](https://coveralls.io/repos/go-playground/validator/badge.svg?branch=master&service=github)](https://coveralls.io/github/go-playground/validator?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/go-playground/validator)](https://goreportcard.com/report/github.com/go-playground/validator)


### PR DESCRIPTION
## Fixes Or Enhances

No need to manually update the Release version in README.md anymore.

<img width="643" alt="image" src="https://github.com/user-attachments/assets/97ce3327-6d96-4599-89be-03ac1167b492" />


**Make sure that you've checked the boxes below before you submit PR:**
- [ ] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers