### PR TITLE
unix_addr validator fix with verifying file path and file mode. See issue #1348

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -2580,9 +2580,14 @@ func isIPAddrResolvable(fl FieldLevel) bool {
 
 // isUnixAddrResolvable is the validation function for validating if the field's value is a resolvable unix address.
 func isUnixAddrResolvable(fl FieldLevel) bool {
-	_, err := net.ResolveUnixAddr("unix", fl.Field().String())
-
-	return err == nil
+	stats, err := os.Stat(fl.Field().String())
+	if err != nil {
+		return false
+	}
+	if (stats.Mode().Type() & os.ModeSocket) == 0 {
+		return false
+	}
+	return true
 }
 
 func isIP4Addr(fl FieldLevel) bool {

--- a/validator_test.go
+++ b/validator_test.go
@@ -2935,7 +2935,11 @@ func TestUnixAddrValidation(t *testing.T) {
 	}
 	f.Close()
 	socketName := t.TempDir() + "/go_validator_test_sock"
-	l, err := net.Listen("unix", socketName)
+	addr, err := net.ResolveUnixAddr("unix", socketName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l, err := net.ListenUnix("unix", addr)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Fixes Or Enhances


**Make sure that you've checked the boxes below before you submit PR:**
- [ +] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers