### PR TITLE
fix: make "file://" fail `url` validation

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -1461,15 +1461,6 @@ func isURI(fl FieldLevel) bool {
 	panic(fmt.Sprintf("Bad field type %s", field.Type()))
 }
 
-// isFileURL is the helper function for validating if the `path` valid file URL as per RFC8089
-func isFileURL(path string) bool {
-	if !strings.HasPrefix(path, "file:/") {
-		return false
-	}
-	_, err := url.ParseRequestURI(path)
-	return err == nil
-}
-
 // isURL is the validation function for validating if the current field's value is a valid URL.
 func isURL(fl FieldLevel) bool {
 	field := fl.Field()
@@ -1483,16 +1474,13 @@ func isURL(fl FieldLevel) bool {
 			return false
 		}
 
-		if isFileURL(s) {
-			return true
-		}
-
 		url, err := url.Parse(s)
 		if err != nil || url.Scheme == "" {
 			return false
 		}
+		isFileScheme := url.Scheme == "file"
 
-		if url.Host == "" && url.Fragment == "" && url.Opaque == "" {
+		if (isFileScheme && (len(url.Path) == 0 || url.Path == "/")) || (!isFileScheme && len(url.Host) == 0 && len(url.Fragment) == 0 && len(url.Opaque) == 0) {
 			return false
 		}
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -8255,7 +8255,9 @@ func TestUrl(t *testing.T) {
 		{"file:///c:/Windows/file.txt", true},
 		{"file://localhost/path/to/file.txt", true},
 		{"file://localhost/c:/WINDOWS/file.txt", true},
-		{"file://", true},
+		{"file:", false},
+		{"file:/", false},
+		{"file://", false},
 		{"file:////remotehost/path/file.txt", true},
 	}
 


### PR DESCRIPTION
"file://" is not a valid URL since it has no path.

## Fixes Or Enhances

Makes `"file://"` fail the `url` validation instead of passing it.

This is akin to `"http://"` already failing as expected in tests. 

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers