### PR TITLE
fix: minor spelling fix in docs

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1519,7 +1519,7 @@ This package panics when bad input is provided, this is by design, bad code like
 that should not make it to production.
 
 	type Test struct {
-		TestField string `validate:"nonexistantfunction=1"`
+		TestField string `validate:"nonexistentfunction=1"`
 	}
 
 	t := &Test{


### PR DESCRIPTION
## Fixes Or Enhances

Single-line change fixing a spelling error at the end of the docs.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers