### PR TITLE
Fix integer overflows in test when run on 32bit systems

### DIFF
--- a/validator_test.go
+++ b/validator_test.go
@@ -13911,14 +13911,14 @@ func TestLuhnChecksumValidation(t *testing.T) {
 		expected bool
 	}{
 		{uint64(586824160825533338), "luhn_checksum", true}, // credit card numbers are just special cases of numbers with luhn checksum
-		{586824160825533338, "luhn_checksum", true},
+		{int64(586824160825533338), "luhn_checksum", true},
 		{"586824160825533338", "luhn_checksum", true},
 		{uint64(586824160825533328), "luhn_checksum", false},
-		{586824160825533328, "luhn_checksum", false},
+		{int64(586824160825533328), "luhn_checksum", false},
 		{"586824160825533328", "luhn_checksum", false},
-		{10000000116, "luhn_checksum", true}, // but there may be shorter numbers (11 digits)
+		{int64(10000000116), "luhn_checksum", true}, // but there may be shorter numbers (11 digits)
 		{"10000000116", "luhn_checksum", true},
-		{10000000117, "luhn_checksum", false},
+		{int64(10000000117), "luhn_checksum", false},
 		{"10000000117", "luhn_checksum", false},
 		{uint64(12345678123456789011), "luhn_checksum", true}, // or longer numbers (19 digits)
 		{"12345678123456789011", "luhn_checksum", true},


### PR DESCRIPTION
## Fixes Or Enhances

While 32bit systems are becoming rarer, Debian still fully supports `armhf`. On such systems, `TestLuhnChecksumValidation` fails because some of the integer values overflow without an explicit cast to `int64`.

```
# github.com/go-playground/validator/v10 [github.com/go-playground/validator/v10.test]
./validator_test.go:13914:4: cannot use 586824160825533338 (untyped int constant) as int value in struct literal (overflows)
./validator_test.go:13917:4: cannot use 586824160825533328 (untyped int constant) as int value in struct literal (overflows)
./validator_test.go:13919:4: cannot use 10000000116 (untyped int constant) as int value in struct literal (overflows)
./validator_test.go:13921:4: cannot use 10000000117 (untyped int constant) as int value in struct literal (overflows)
```

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers