### PR TITLE
fix: exclude modernize linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -32,6 +32,7 @@ linters:
     - maintidx
     - misspell
     - mnd
+    - modernize
     - nakedret
     - nestif
     - nilnil


### PR DESCRIPTION
## Fixes Or Enhances

The CI linter step currently fails in several areas because of `modernize` linter rules.
This PR disables the `modernize` linter by removing it from the list of active linters.

Connected to: #1486
**Make sure that you've checked the boxes below before you submit PR:**
- [ ] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers