### PR TITLE
feat: add translations for alphaspace and alphanumspace tags in indonesian

### DIFF
--- a/translations/id/id.go
+++ b/translations/id/id.go
@@ -259,6 +259,16 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			override:    false,
 		},
 		{
+			tag:         "alphaspace",
+			translation: "{0} hanya dapat berisi karakter alfabet dan spasi",
+			override:    false,
+		},
+		{
+			tag:         "alphanumspace",
+			translation: "{0} hanya dapat berisi karakter alfanumerik dan spasi",
+			override:    false,
+		},
+		{
 			tag:         "alphanumunicode",
 			translation: "{0} hanya boleh berisi karakter alfanumerik unicode",
 			override:    false,

--- a/translations/id/id_test.go
+++ b/translations/id/id_test.go
@@ -399,6 +399,8 @@ func TestStringTagsTranslations(t *testing.T) {
 	// TestStringTags for string validations
 	type TestStringTags struct {
 		Alpha         string `validate:"alpha"`
+		Alphaspace    string `validate:"alphaspace"`
+		Alphanumspace string `validate:"alphanumspace"`
 		Alphanum      string `validate:"alphanum"`
 		AlphanumUni   string `validate:"alphanumunicode"`
 		AlphaUni      string `validate:"alphaunicode"`
@@ -425,6 +427,8 @@ func TestStringTagsTranslations(t *testing.T) {
 	// init test struct with invalid values
 	test := TestStringTags{
 		Alpha:         "123",                // should only contain letters
+		Alphaspace:    "abc3",               // should only contain letters and spaces
+		Alphanumspace: "abc!",               // should only contain letters, numbers, and spaces
 		Alphanum:      "!@#",                // should only contain letters and numbers
 		AlphanumUni:   "!@#",                // should only contain unicode letters and numbers
 		AlphaUni:      "123",                // should only contain unicode letters
@@ -463,6 +467,14 @@ func TestStringTagsTranslations(t *testing.T) {
 		{
 			ns:       "TestStringTags.Alpha",
 			expected: "Alpha hanya dapat berisi karakter alfanumerik",
+		},
+		{
+			ns:       "TestStringTags.Alphaspace",
+			expected: "Alphaspace hanya dapat berisi karakter alfabet dan spasi",
+		},
+		{
+			ns:       "TestStringTags.Alphanumspace",
+			expected: "Alphanumspace hanya dapat berisi karakter alfanumerik dan spasi",
 		},
 		{
 			ns:       "TestStringTags.Alphanum",


### PR DESCRIPTION
This pull request adds support for two new validation tags, `alphaspace` and `alphanumspace`, to the Indonesian translations. It also updates the corresponding unit tests to ensure these new tags are properly validated and translated.

**Translation additions:**

* Added Indonesian translation for the `alphaspace` validation tag, indicating that a field may only contain alphabetic characters and spaces.
* Added Indonesian translation for the `alphanumspace` validation tag, indicating that a field may only contain alphanumeric characters and spaces.

**Testing improvements:**

* Updated the `TestStringTagsTranslations` test struct and test cases to include fields for `Alphaspace` and `Alphanumspace`, and added invalid test values for both. [[1]](diffhunk://#diff-e71a6006a2e0721801e0d7233ec0aa3d5f2d250e037b05bcd8373d1fad2c7d09R402-R403) [[2]](diffhunk://#diff-e71a6006a2e0721801e0d7233ec0aa3d5f2d250e037b05bcd8373d1fad2c7d09R430-R431)
* Added expected error messages for the new validation tags to the test assertions, ensuring the translations are correct.## Fixes Or Enhances


**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers