### PR TITLE
docs: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It has the following **unique** features:
 A Call for Maintainers
 ----------------------
 
-Please read the discussiong started [here](https://github.com/go-playground/validator/discussions/1330) if you are interested in contributing/helping maintain this package.
+Please read the discussion started [here](https://github.com/go-playground/validator/discussions/1330) if you are interested in contributing/helping maintain this package.
 
 Installation
 ------------
@@ -178,7 +178,7 @@ validate := validator.New(validator.WithRequiredStructEnabled())
 | spicedb | SpiceDb ObjectID/Permission/Type |
 | datetime | Datetime |
 | e164 | e164 formatted phone number |
-| ein | U.S. Employeer Identification Number |
+| ein | U.S. Employer Identification Number |
 | email | E-mail String
 | eth_addr | Ethereum Address |
 | hexadecimal | Hexadecimal String |

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -1103,7 +1103,7 @@ type T struct{}
 
 func (*T) Validate() error { return errors.New("ops") }
 
-func BenchmarkValidateFnSequencial(b *testing.B) {
+func BenchmarkValidateFnSequential(b *testing.B) {
 	validate := New()
 
 	type Test struct {

--- a/doc.go
+++ b/doc.go
@@ -1170,7 +1170,7 @@ This validates that a string value contains a valid longitude.
 
 	Usage: longitude
 
-# Employeer Identification Number EIN
+# Employer Identification Number EIN
 
 This validates that a string value contains a valid U.S. Employer Identification Number.
 


### PR DESCRIPTION
## Fixes Or Enhances

Fixes a few grammar mistakes in README, docs, and the benchmark name.

See https://en.wikipedia.org/wiki/Employer_Identification_Number

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers