### PR TITLE
fixed validation of cron expression

### DIFF
--- a/regexes.go
+++ b/regexes.go
@@ -77,7 +77,7 @@ const (
 	cveRegexString                   = `^CVE-(1999|2\d{3})-(0[^0]\d{2}|0\d[^0]\d{1}|0\d{2}[^0]|[1-9]{1}\d{3,})$` // CVE Format Id https://cve.mitre.org/cve/identifiers/syntaxchange.html
 	mongodbIdRegexString             = "^[a-f\\d]{24}$"
 	mongodbConnStringRegexString     = "^mongodb(\\+srv)?:\\/\\/(([a-zA-Z\\d]+):([a-zA-Z\\d$:\\/?#\\[\\]@]+)@)?(([a-z\\d.-]+)(:[\\d]+)?)((,(([a-z\\d.-]+)(:(\\d+))?))*)?(\\/[a-zA-Z-_]{1,64})?(\\?(([a-zA-Z]+)=([a-zA-Z\\d]+))(&(([a-zA-Z\\d]+)=([a-zA-Z\\d]+))?)*)?$"
-	cronRegexString                  = `(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\d+(ns|us|µs|ms|s|m|h))+)|((((\d+,)+\d+|((\*|\d+)(\/|-)\d+)|\d+|\*) ?){5,7})`
+	cronRegexString                  = `^(@(annually|yearly|monthly|weekly|daily|hourly|reboot)|@every (\d+(ns|us|µs|ms|s|m|h))+|(((\d+(-\d+)?|\*|\?|\d*L(?:W)?|\d*W|\d+#\d+|[A-Z]{3}(-[A-Z]{3})?)(\/\d+)?)(,(\d+(-\d+)?|\*|\?|\d*L(?:W)?|\d*W|\d+#\d+|[A-Z]{3}(-[A-Z]{3})?)(\/\d+)?)* ?){5,7})$`
 	spicedbIDRegexString             = `^(([a-zA-Z0-9/_|\-=+]{1,})|\*)$`
 	spicedbPermissionRegexString     = "^([a-z][a-z0-9_]{1,62}[a-z0-9])?$"
 	spicedbTypeRegexString           = "^([a-z][a-z0-9_]{1,61}[a-z0-9]/)?[a-z][a-z0-9_]{1,62}[a-z0-9]$"

--- a/validator_test.go
+++ b/validator_test.go
@@ -14491,6 +14491,12 @@ func TestCronExpressionValidation(t *testing.T) {
 		{"0 15 10 ? * 6#3", "cron", true},
 		{"0 */15 * * *", "cron", true},
 		{"wrong", "cron", false},
+		{"10 0-3,9-23 * * *", "cron", true},
+		{"15-25 9-23,0-3 1-2 1-2 1-2", "cron", true}, // range values
+		{"/15 * * * *", "cron", false},               // invalid step value
+		{"*/12 */1 */1 */1 */1", "cron", true},       // valid step value
+		{"@daily", "cron", true},                     // macro
+		{"* * * * *", "cron", true},                  // Standard
 	}
 
 	validate := New()


### PR DESCRIPTION
## Fixes Or Enhances

- fixes #1529 and #1130
- no validates range values & steps
- added new test cases

```go
// regexes.go
cronRegexString = `^(@(annually|yearly|monthly|weekly|daily|hourly|reboot)|@every (\d+(ns|us|µs|ms|s|m|h))+|(((\d+(-\d+)?|\*|\?|\d*L(?:W)?|\d*W|\d+#\d+|[A-Z]{3}(-[A-Z]{3})?)(\/\d+)?)(,(\d+(-\d+)?|\*|\?|\d*L(?:W)?|\d*W|\d+#\d+|[A-Z]{3}(-[A-Z]{3})?)(\/\d+)?)* ?){5,7})$`

```

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers