### PR TITLE
fix: prevent panic in unique validation with nil pointer elements

### DIFF
--- a/validator_test.go
+++ b/validator_test.go
@@ -11029,6 +11029,14 @@ func TestUniqueValidationNilPtrSlice(t *testing.T) {
 			t.Fatalf("nil and non-nil map values should pass unique validation, got: %v", errs)
 		}
 	})
+
+	t.Run("unique_slice_with_nil_and_zero_value_struct", func(t *testing.T) {
+		s := []*Inner{nil, {Name: ""}}
+		errs := validate.Var(s, "unique")
+		if errs != nil {
+			t.Fatalf("nil and zero value struct should pass unique validation, got: %v", errs)
+		}
+	})
 }
 
 func TestHTMLValidation(t *testing.T) {


### PR DESCRIPTION
## Fixes Or Enhances

This is an alternative approach to resolve the panic issue in the unique validator.
Releated to: https://github.com/go-playground/validator/pull/1530

**Make sure that you've checked the boxes below before you submit PR:**
- [ ] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers