### PR TITLE
Reduce build size with dead code elimination

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -3,7 +3,6 @@ package validator
 import (
 	"bufio"
 	"bytes"
-	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -3235,59 +3234,9 @@ func isEIN(fl FieldLevel) bool {
 	return einRegex().MatchString(field.String())
 }
 
-func isValidateFn(fl FieldLevel) bool {
-	const defaultParam = `Validate`
-
-	field := fl.Field()
-	validateFn := cmp.Or(fl.Param(), defaultParam)
-
-	ok, err := tryCallValidateFn(field, validateFn)
-	if err != nil {
-		return false
-	}
-
-	return ok
-}
-
 var (
 	errMethodNotFound          = errors.New(`method not found`)
 	errMethodReturnNoValues    = errors.New(`method return o values (void)`)
 	errMethodReturnInvalidType = errors.New(`method should return invalid type`)
 )
 
-func tryCallValidateFn(field reflect.Value, validateFn string) (bool, error) {
-	method := field.MethodByName(validateFn)
-	if field.CanAddr() && !method.IsValid() {
-		method = field.Addr().MethodByName(validateFn)
-	}
-
-	if !method.IsValid() {
-		return false, fmt.Errorf("unable to call %q on type %q: %w",
-			validateFn, field.Type().String(), errMethodNotFound)
-	}
-
-	returnValues := method.Call([]reflect.Value{})
-	if len(returnValues) == 0 {
-		return false, fmt.Errorf("unable to use result of method %q on type %q: %w",
-			validateFn, field.Type().String(), errMethodReturnNoValues)
-	}
-
-	firstReturnValue := returnValues[0]
-
-	switch firstReturnValue.Kind() {
-	case reflect.Bool:
-		return firstReturnValue.Bool(), nil
-	case reflect.Interface:
-		errorType := reflect.TypeOf((*error)(nil)).Elem()
-
-		if firstReturnValue.Type().Implements(errorType) {
-			return firstReturnValue.IsNil(), nil
-		}
-
-		return false, fmt.Errorf("unable to use result of method %q on type %q: %w (got interface %v expect error)",
-			validateFn, field.Type().String(), errMethodReturnInvalidType, firstReturnValue.Type().String())
-	default:
-		return false, fmt.Errorf("unable to use result of method %q on type %q: %w (got %v expect error or bool)",
-			validateFn, field.Type().String(), errMethodReturnInvalidType, firstReturnValue.Type().String())
-	}
-}

--- a/doc.go
+++ b/doc.go
@@ -150,6 +150,12 @@ so the above will become excludesall=0x7C
 		Field `validate:"excludesall=0x7C"` // GOOD! Use the UTF-8 hex representation.
 	}
 
+# Build tags
+
+The library provides a build tag for build size optimizations. If you are not using
+`validateFn` you can add the `validator_novalidatefn` build tag to enabled better dead
+code elimination. With this build tag, any usage of `validateFn` tags will panic.
+
 # Baked In Validators and Tags
 
 Here is a list of the current built in validators:

--- a/no_validate_fn.go
+++ b/no_validate_fn.go
@@ -1,12 +1,12 @@
-//go:build !novalidatefn
+//go:build !validator_novalidatefn
+
 package validator
 
 import (
+	"cmp"
 	"fmt"
 	"reflect"
-	"cmp"
 )
-
 
 func isValidateFn(fl FieldLevel) bool {
 	const defaultParam = `Validate`

--- a/no_validate_fn.go
+++ b/no_validate_fn.go
@@ -1,0 +1,60 @@
+//go:build !novalidatefn
+package validator
+
+import (
+	"fmt"
+	"reflect"
+	"cmp"
+)
+
+
+func isValidateFn(fl FieldLevel) bool {
+	const defaultParam = `Validate`
+
+	field := fl.Field()
+	validateFn := cmp.Or(fl.Param(), defaultParam)
+
+	ok, err := tryCallValidateFn(field, validateFn)
+	if err != nil {
+		return false
+	}
+
+	return ok
+}
+
+func tryCallValidateFn(field reflect.Value, validateFn string) (bool, error) {
+	method := field.MethodByName(validateFn)
+	if field.CanAddr() && !method.IsValid() {
+		method = field.Addr().MethodByName(validateFn)
+	}
+
+	if !method.IsValid() {
+		return false, fmt.Errorf("unable to call %q on type %q: %w",
+			validateFn, field.Type().String(), errMethodNotFound)
+	}
+
+	returnValues := method.Call([]reflect.Value{})
+	if len(returnValues) == 0 {
+		return false, fmt.Errorf("unable to use result of method %q on type %q: %w",
+			validateFn, field.Type().String(), errMethodReturnNoValues)
+	}
+
+	firstReturnValue := returnValues[0]
+
+	switch firstReturnValue.Kind() {
+	case reflect.Bool:
+		return firstReturnValue.Bool(), nil
+	case reflect.Interface:
+		errorType := reflect.TypeOf((*error)(nil)).Elem()
+
+		if firstReturnValue.Type().Implements(errorType) {
+			return firstReturnValue.IsNil(), nil
+		}
+
+		return false, fmt.Errorf("unable to use result of method %q on type %q: %w (got interface %v expect error)",
+			validateFn, field.Type().String(), errMethodReturnInvalidType, firstReturnValue.Type().String())
+	default:
+		return false, fmt.Errorf("unable to use result of method %q on type %q: %w (got %v expect error or bool)",
+			validateFn, field.Type().String(), errMethodReturnInvalidType, firstReturnValue.Type().String())
+	}
+}

--- a/validate_fn.go
+++ b/validate_fn.go
@@ -1,0 +1,7 @@
+//go:build novalidatefn
+package validator
+
+
+func isValidateFn(fl FieldLevel) bool {
+	panic("validateFn is not supported with 'no-validate-fn' tag")
+}

--- a/validate_fn.go
+++ b/validate_fn.go
@@ -1,6 +1,6 @@
-//go:build novalidatefn
-package validator
+//go:build validator_novalidatefn
 
+package validator
 
 func isValidateFn(fl FieldLevel) bool {
 	panic("validateFn is not supported with 'no-validate-fn' tag")


### PR DESCRIPTION
Based on discussion in [1496](https://github.com/go-playground/validator/issues/1496) a experimental change to allow reducing the build sizes. 

This adds a build tag `validator_novalidatefn` that makes any usage of `validateFn` panic. The idea is that we can eliminate calls to `tryCallValidateFn` that in turn uses `field.MethodByName` that can't be dead code eliminated. 

Added a small block for docs, but I am not the best doc writer, so some feedback would be welcome there. Maybe something more is needed? 