### PR TITLE
fix(fqdn): allow hyphens in last domain label

### DIFF
--- a/regexes.go
+++ b/regexes.go
@@ -58,7 +58,7 @@ const (
 	sSNRegexString                   = `^[0-9]{3}[ -]?(0[1-9]|[1-9][0-9])[ -]?([1-9][0-9]{3}|[0-9][1-9][0-9]{2}|[0-9]{2}[1-9][0-9]|[0-9]{3}[1-9])$`
 	hostnameRegexStringRFC952        = `^[a-zA-Z]([a-zA-Z0-9\-]+[\.]?)*[a-zA-Z0-9]$`                                                                   // https://tools.ietf.org/html/rfc952
 	hostnameRegexStringRFC1123       = `^([a-zA-Z0-9]{1}[a-zA-Z0-9-]{0,62}){1}(\.[a-zA-Z0-9]{1}[a-zA-Z0-9-]{0,62})*?$`                                 // accepts hostname starting with a digit https://tools.ietf.org/html/rfc1123
-	fqdnRegexStringRFC1123           = `^([a-zA-Z0-9]{1}[a-zA-Z0-9-]{0,62})(\.[a-zA-Z0-9]{1}[a-zA-Z0-9-]{0,62})*?(\.[a-zA-Z]{1}[a-zA-Z0-9]{0,62})\.?$` // same as hostnameRegexStringRFC1123 but must contain a non numerical TLD (possibly ending with '.')
+	fqdnRegexStringRFC1123           = `^([a-zA-Z0-9]{1}[a-zA-Z0-9-]{0,62})(\.[a-zA-Z0-9]{1}[a-zA-Z0-9-]{0,62})*?(\.[a-zA-Z]{1}[a-zA-Z0-9-]{0,62})\.?$` // same as hostnameRegexStringRFC1123 but must contain a non numerical TLD (possibly ending with '.')
 	btcAddressRegexString            = `^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$`                                                                             // bitcoin address
 	btcAddressUpperRegexStringBech32 = `^BC1[02-9AC-HJ-NP-Z]{7,76}$`                                                                                   // bitcoin bech32 address https://en.bitcoin.it/wiki/Bech32
 	btcAddressLowerRegexStringBech32 = `^bc1[02-9ac-hj-np-z]{7,76}$`                                                                                   // bitcoin bech32 address https://en.bitcoin.it/wiki/Bech32

--- a/validator_test.go
+++ b/validator_test.go
@@ -10643,6 +10643,7 @@ func TestFQDNValidation(t *testing.T) {
 		{"test24.example24.com.", true},
 		{"24.example24.com", true},
 		{"test.24.example.com", true},
+		{"test-site-http.test-site", true},
 		{"test24.example24.com..", false},
 		{"example", false},
 		{"192.168.0.1", false},


### PR DESCRIPTION
## Fixes Or Enhances
## Summary

The `fqdn` validator was rejecting valid domain names that contain hyphens in the last label (e.g. `test-site-http.test-site`), because the TLD character class `[a-zA-Z0-9]` did not include `-`.

## Change

One character added to the last label's character class in `fqdnRegexStringRFC1123`:


No other parts of the regex were modified.
 
## Test
 
Added regression case to [TestFQDNValidation](cci:1://file:///Users/admin/validator/validator_test.go:10628:0-10676:1):
 
- `test-site-http.test-site` → valid

@go-playground/validator-maintainers