### PR TITLE
add missing unique tag translations for zh and zh_tw

### DIFF
--- a/translations/zh/zh.go
+++ b/translations/zh/zh.go
@@ -1422,6 +1422,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			},
 		},
 		{
+			tag:         "unique",
+			translation: "{0}必须包含唯一值",
+			override:    false,
+		},
+		{
 			tag:         "image",
 			translation: "{0} 必须是有效图像",
 			override:    false,

--- a/translations/zh/zh_test.go
+++ b/translations/zh/zh_test.go
@@ -174,6 +174,7 @@ func TestTranslations(t *testing.T) {
 		UppercaseString       string    `validate:"uppercase"`
 		Datetime              string    `validate:"datetime=2006-01-02"`
 		Image                 string    `validate:"image"`
+		UniqueSlice           []string  `validate:"unique"`
 	}
 
 	var test Test
@@ -246,6 +247,8 @@ func TestTranslations(t *testing.T) {
 	test.UppercaseString = "abcdefg"
 
 	test.Datetime = "20060102"
+
+	test.UniqueSlice = []string{"1234", "1234"}
 
 	err = validate.Struct(test)
 	NotEqual(t, err, nil)
@@ -768,6 +771,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.Image",
 			expected: "Image 必须是有效图像",
+		},
+		{
+			ns:       "Test.UniqueSlice",
+			expected: "UniqueSlice必须包含唯一值",
 		},
 	}
 

--- a/translations/zh_tw/zh_tw.go
+++ b/translations/zh_tw/zh_tw.go
@@ -1353,6 +1353,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			},
 		},
 		{
+			tag:         "unique",
+			translation: "{0}必須包含唯一值",
+			override:    false,
+		},
+		{
 			tag:         "image",
 			translation: "{0} 必須是有效圖像",
 			override:    false,

--- a/translations/zh_tw/zh_tw_test.go
+++ b/translations/zh_tw/zh_tw_test.go
@@ -166,6 +166,7 @@ func TestTranslations(t *testing.T) {
 		OneOfInt           int       `validate:"oneof=5 63"`
 		Datetime           string    `validate:"datetime=2006-01-02"`
 		Image              string    `validate:"image"`
+		UniqueSlice        []string  `validate:"unique"`
 	}
 
 	var test Test
@@ -228,6 +229,8 @@ func TestTranslations(t *testing.T) {
 	test.StrPtrLen = &s
 
 	test.Datetime = "2008-Feb-01"
+
+	test.UniqueSlice = []string{"1234", "1234"}
 
 	err = validate.Struct(test)
 	NotEqual(t, err, nil)
@@ -718,6 +721,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.Image",
 			expected: "Image 必須是有效圖像",
+		},
+		{
+			ns:       "Test.UniqueSlice",
+			expected: "UniqueSlice必須包含唯一值",
 		},
 	}
 


### PR DESCRIPTION
Hey, noticed the `unique` tag translation is missing in both `zh` and `zh_tw` locales — see #879.

Added the translations and updated the tests for both packages.

- zh: `{0}必须包含唯一值`
- zh_tw: `{0}必須包含唯一值`