### PR TITLE
fix: support non-base64 data URIs per RFC 2397

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -607,7 +607,21 @@ func isDataURI(fl FieldLevel) bool {
 		return false
 	}
 
-	return base64Regex().MatchString(uri[1])
+	// After "data:", the prefix must be empty, start with ";", or contain "/"
+	// to form a valid mediatype. This rejects partial matches like "data:text"
+	// where the regex only matches the "data:" portion.
+	if prefix := uri[0][5:]; prefix != "" && !strings.Contains(prefix, "/") && prefix[0] != ';' {
+		return false
+	}
+
+	// Only validate the data portion as base64 when ;base64 is specified.
+	// Per RFC 2397, ;base64 is a terminal flag that appears immediately
+	// before the comma, so it is always a suffix of the prefix portion.
+	if strings.HasSuffix(uri[0], ";base64") {
+		return base64Regex().MatchString(uri[1])
+	}
+
+	return true
 }
 
 // hasMultiByteCharacter is the validation function for validating if the field's value has a multi byte character.

--- a/validator_test.go
+++ b/validator_test.go
@@ -3997,8 +3997,11 @@ func TestDataURIValidation(t *testing.T) {
 		{"data:text,:;base85,U3VzcGVuZGlzc2UgbGVjdHVzIGxlbw==", false},
 		{"data:image/jpeg;key=value;base64,UEsDBBQAAAAI", true},
 		{"data:image/jpeg;key=value,UEsDBBQAAAAI", true},
-		{"data:;base64;sdfgsdfgsdfasdfa=s,UEsDBBQAAAAI", true},
+		{"data:;base64,UEsDBBQAAAAI", true},
 		{"data:,UEsDBBQAAAAI", true},
+		{"data:,ohai", true},
+		{"data:text/plain,hello world", true},
+		{"data:text/html,<h1>Hello</h1>", true},
 	}
 
 	validate := New()


### PR DESCRIPTION
## Summary

Fixes #518

Per [RFC 2397](https://datatracker.ietf.org/doc/html/rfc2397), the `;base64` flag in a data URI is optional. When absent, the data portion is URL-encoded text — not base64. The `datauri` validator currently checks **all** data URI payloads against the base64 regex, incorrectly rejecting valid URIs like `data:text/plain,hello world`.

### Changes

- Only validate the data portion as base64 when `;base64` is present in the prefix
- Add a prefix structure check to reject partial regex matches on invalid mediatypes (e.g. `data:text,...` where the regex only matches `data:`)
- Use `strings.HasSuffix` for `;base64` detection since RFC 2397 defines it as a terminal flag immediately before the comma
- Update test cases to cover non-base64 data URIs and fix a malformed test case

### Before

```go
// Always checked base64 — rejected valid non-base64 data URIs
validate.Var("data:text/plain,hello world", "datauri") // ❌ error
validate.Var("data:,ohai", "datauri")                   // ❌ error
```

### After

```go
validate.Var("data:text/plain,hello world", "datauri") // ✅ valid
validate.Var("data:,ohai", "datauri")                   // ✅ valid
validate.Var("data:image/png;base64,iVBOR...", "datauri") // ✅ still validated as base64
```

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New test cases added for non-base64 data URIs (`data:,ohai`, `data:text/plain,hello world`, `data:text/html,<h1>Hello</h1>`)
- [x] Fixed malformed test case that had invalid `;base64;sdfgsdfgsdfasdfa=s` prefix
- [x] Verified invalid data URIs are still rejected (e.g. `data:text,:;base85,...`)