### PR TITLE
fix: handle nil pointer fields in comparison validators

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -1418,6 +1418,13 @@ func isEq(fl FieldLevel) bool {
 	field := fl.Field()
 	param := fl.Param()
 
+	for field.Kind() == reflect.Ptr {
+		if field.IsNil() {
+			return false
+		}
+		field = field.Elem()
+	}
+
 	switch field.Kind() {
 	case reflect.String:
 		return field.String() == param
@@ -1462,6 +1469,13 @@ func isEq(fl FieldLevel) bool {
 func isEqIgnoreCase(fl FieldLevel) bool {
 	field := fl.Field()
 	param := fl.Param()
+
+	for field.Kind() == reflect.Ptr {
+		if field.IsNil() {
+			return false
+		}
+		field = field.Elem()
+	}
 
 	switch field.Kind() {
 	case reflect.String:
@@ -2276,6 +2290,13 @@ func isGte(fl FieldLevel) bool {
 	field := fl.Field()
 	param := fl.Param()
 
+	for field.Kind() == reflect.Ptr {
+		if field.IsNil() {
+			return false
+		}
+		field = field.Elem()
+	}
+
 	switch field.Kind() {
 	case reflect.String:
 		p := asInt(param)
@@ -2325,6 +2346,13 @@ func isGt(fl FieldLevel) bool {
 	field := fl.Field()
 	param := fl.Param()
 
+	for field.Kind() == reflect.Ptr {
+		if field.IsNil() {
+			return false
+		}
+		field = field.Elem()
+	}
+
 	switch field.Kind() {
 	case reflect.String:
 		p := asInt(param)
@@ -2370,6 +2398,13 @@ func isGt(fl FieldLevel) bool {
 func hasLengthOf(fl FieldLevel) bool {
 	field := fl.Field()
 	param := fl.Param()
+
+	for field.Kind() == reflect.Ptr {
+		if field.IsNil() {
+			return false
+		}
+		field = field.Elem()
+	}
 
 	switch field.Kind() {
 	case reflect.String:
@@ -2504,6 +2539,13 @@ func isLte(fl FieldLevel) bool {
 	field := fl.Field()
 	param := fl.Param()
 
+	for field.Kind() == reflect.Ptr {
+		if field.IsNil() {
+			return false
+		}
+		field = field.Elem()
+	}
+
 	switch field.Kind() {
 	case reflect.String:
 		p := asInt(param)
@@ -2552,6 +2594,13 @@ func isLte(fl FieldLevel) bool {
 func isLt(fl FieldLevel) bool {
 	field := fl.Field()
 	param := fl.Param()
+
+	for field.Kind() == reflect.Ptr {
+		if field.IsNil() {
+			return false
+		}
+		field = field.Elem()
+	}
 
 	switch field.Kind() {
 	case reflect.String:

--- a/repro_test.go
+++ b/repro_test.go
@@ -1,0 +1,136 @@
+package validator
+
+import (
+	"testing"
+)
+
+// TestNilPointerComparisonPanic tests that comparison validators (gte, gt, lte, lt, eq, len)
+// do not panic when the field is a nil pointer. This can occur when a conditional
+// required tag (e.g. required_if) passes but the field is nil, and a subsequent
+// comparison tag runs on the nil pointer value.
+// See: https://github.com/go-playground/validator/issues/907
+func TestNilPointerComparisonPanic(t *testing.T) {
+	validate := New()
+
+	t.Run("nil *int64 with gte", func(t *testing.T) {
+		type S struct {
+			Type     string `validate:"required"`
+			Quantity *int64 `validate:"required_if=Type special,gte=2"`
+		}
+		s := &S{Type: "notspecial"}
+		err := validate.Struct(s)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+
+	t.Run("nil *int64 with gt", func(t *testing.T) {
+		type S struct {
+			Type     string `validate:"required"`
+			Quantity *int64 `validate:"required_if=Type special,gt=0"`
+		}
+		s := &S{Type: "notspecial"}
+		err := validate.Struct(s)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+
+	t.Run("nil *int64 with lte", func(t *testing.T) {
+		type S struct {
+			Type     string `validate:"required"`
+			Quantity *int64 `validate:"required_if=Type special,lte=100"`
+		}
+		s := &S{Type: "notspecial"}
+		err := validate.Struct(s)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+
+	t.Run("nil *int64 with lt", func(t *testing.T) {
+		type S struct {
+			Type     string `validate:"required"`
+			Quantity *int64 `validate:"required_if=Type special,lt=100"`
+		}
+		s := &S{Type: "notspecial"}
+		err := validate.Struct(s)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+
+	t.Run("nil *int64 with eq", func(t *testing.T) {
+		type S struct {
+			Type     string `validate:"required"`
+			Quantity *int64 `validate:"required_if=Type special,eq=5"`
+		}
+		s := &S{Type: "notspecial"}
+		err := validate.Struct(s)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+
+	t.Run("nil *int64 with len", func(t *testing.T) {
+		type S struct {
+			Type     string `validate:"required"`
+			Quantity *int64 `validate:"required_if=Type special,len=5"`
+		}
+		s := &S{Type: "notspecial"}
+		err := validate.Struct(s)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+
+	t.Run("nil *float64 with gte", func(t *testing.T) {
+		type S struct {
+			Type  string   `validate:"required"`
+			Price *float64 `validate:"required_if=Type special,gte=0.01"`
+		}
+		s := &S{Type: "notspecial"}
+		err := validate.Struct(s)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+
+	t.Run("nil *string with gte", func(t *testing.T) {
+		type S struct {
+			Type string  `validate:"required"`
+			Name *string `validate:"required_if=Type special,gte=3"`
+		}
+		s := &S{Type: "notspecial"}
+		err := validate.Struct(s)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+
+	t.Run("non-nil *int64 with gte passes", func(t *testing.T) {
+		type S struct {
+			Type     string `validate:"required"`
+			Quantity *int64 `validate:"required_if=Type special,gte=2"`
+		}
+		q := int64(5)
+		s := &S{Type: "notspecial", Quantity: &q}
+		err := validate.Struct(s)
+		if err != nil {
+			t.Fatalf("unexpected validation error: %v", err)
+		}
+	})
+
+	t.Run("non-nil *int64 with gte fails", func(t *testing.T) {
+		type S struct {
+			Type     string `validate:"required"`
+			Quantity *int64 `validate:"required_if=Type special,gte=10"`
+		}
+		q := int64(5)
+		s := &S{Type: "notspecial", Quantity: &q}
+		err := validate.Struct(s)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #907

When a struct field is a nil pointer and has both a conditional required tag (e.g. `required_if`) and a comparison validator (e.g. `gte`, `gt`, `lte`, `lt`, `eq`, `len`), the comparison validator panics with a nil pointer dereference.

### Failing scenario

```go
type S struct {
    Type     string `validate:"required"`
    Quantity *int64 `validate:"required_if=Type special,gte=2"`
}
s := &S{Type: "notspecial"}  // Quantity is nil
validate.Struct(s)           // PANIC
```

When `Type` is `"notspecial"`, `required_if` correctly passes (field is not required). But `gte=2` still runs on the nil `*int64`, and the comparison functions assume a non-pointer value — causing a panic.

### Root cause

`extractTypeInternal` returns nil pointers as `reflect.Ptr` kind without dereferencing. When `required_if` is registered with `nilCheckable: true`, `traverseField` sets `runValidationWhenNil = true`, which skips the nil-pointer error path and falls through to the comparison validators. These validators (`isGte`, `isGt`, `isLte`, `isLt`, `isEq`, `isEqIgnoreCase`, `hasLengthOf`) call `fl.Field()` and switch on its `Kind()` — but a nil pointer doesn't match any numeric/string/slice kind, so it falls to the default case and panics.

### Fix

Added nil-pointer dereferencing at the top of each affected comparison validator function. If the field is a pointer, we dereference it (handling multi-level pointers); if it's nil at any level, we return `false` (the nil value does not satisfy the comparison constraint):

```go
for field.Kind() == reflect.Ptr {
    if field.IsNil() {
        return false
    }
    field = field.Elem()
}
```

This is added to: `isGte`, `isGt`, `isLte`, `isLt`, `isEq`, `isEqIgnoreCase`, `hasLengthOf`.

### Before / After

| Scenario | Before | After |
|----------|--------|-------|
| nil `*int64` + `gte=2` | **panic** | validation error (false) |
| nil `*int64` + `gt=0` | **panic** | validation error (false) |
| nil `*int64` + `lte=100` | **panic** | validation error (false) |
| nil `*int64` + `lt=100` | **panic** | validation error (false) |
| nil `*int64` + `eq=5` | **panic** | validation error (false) |
| nil `*int64` + `len=5` | **panic** | validation error (false) |
| non-nil `*int64(5)` + `gte=2` | pass | pass (unchanged) |
| non-nil `*int64(5)` + `gte=10` | fail | fail (unchanged) |

### Validation

- All existing tests pass (`go test ./...`)
- All translation tests pass
- Added regression test `TestNilPointerComparisonPanic` covering all affected validators with nil and non-nil pointer scenarios