### PR TITLE
fix: avoid max/min panic for struct-backed driver.Valuer fields

### DIFF
--- a/util.go
+++ b/util.go
@@ -1,6 +1,7 @@
 package validator
 
 import (
+	"database/sql/driver"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -36,6 +37,10 @@ BEGIN:
 				goto BEGIN
 			}
 		}
+		if value, ok := extractDriverValuerValue(current); ok {
+			current = value
+			goto BEGIN
+		}
 
 		current = current.Elem()
 		goto BEGIN
@@ -53,6 +58,10 @@ BEGIN:
 				current = reflect.ValueOf(v.ValidatorValue())
 				goto BEGIN
 			}
+		}
+		if value, ok := extractDriverValuerValue(current); ok {
+			current = value
+			goto BEGIN
 		}
 
 		current = current.Elem()
@@ -76,9 +85,44 @@ BEGIN:
 				goto BEGIN
 			}
 		}
+		if value, ok := extractDriverValuerValue(current); ok {
+			current = value
+			goto BEGIN
+		}
 
 		return current, current.Kind(), nullable
 	}
+}
+
+func extractDriverValuerValue(current reflect.Value) (reflect.Value, bool) {
+	if !current.IsValid() {
+		return current, false
+	}
+
+	tryExtract := func(valuer driver.Valuer) (reflect.Value, bool) {
+		value, err := valuer.Value()
+		if err != nil {
+			panic(err)
+		}
+		if value == nil {
+			return reflect.Value{}, true
+		}
+		return reflect.ValueOf(value), true
+	}
+
+	if current.CanInterface() {
+		if valuer, ok := current.Interface().(driver.Valuer); ok {
+			return tryExtract(valuer)
+		}
+	}
+
+	if current.Kind() != reflect.Ptr && current.CanAddr() && current.Addr().CanInterface() {
+		if valuer, ok := current.Addr().Interface().(driver.Valuer); ok {
+			return tryExtract(valuer)
+		}
+	}
+
+	return current, false
 }
 
 // getStructFieldOKInternal traverses a struct to retrieve a specific field denoted by the provided namespace and

--- a/validator_test.go
+++ b/validator_test.go
@@ -2391,6 +2391,23 @@ func TestSQLValueValidation(t *testing.T) {
 	Equal(t, errs, nil)
 }
 
+func TestMaxMinValidationWithDriverValuerStructFields(t *testing.T) {
+	type StructWithSQLNullInt struct {
+		Max sql.NullInt64 `validate:"max=10"`
+		Min sql.NullInt64 `validate:"min=10"`
+	}
+
+	validate := New()
+	errs := validate.Struct(StructWithSQLNullInt{
+		Max: sql.NullInt64{Int64: 15, Valid: true},
+		Min: sql.NullInt64{Int64: 15, Valid: true},
+	})
+
+	NotEqual(t, errs, nil)
+	Equal(t, len(errs.(ValidationErrors)), 1)
+	AssertError(t, errs, "StructWithSQLNullInt.Max", "StructWithSQLNullInt.Max", "Max", "Max", "max")
+}
+
 func TestMACValidation(t *testing.T) {
 	tests := []struct {
 		param    string


### PR DESCRIPTION
## Fixes Or Enhances

Fixes #1300.

This change unwraps `database/sql/driver.Valuer` values during internal type extraction. That allows built-in validators like `max`/`min` to operate on the underlying scalar value instead of panicking on struct-backed valuer types (for example, `null.Int` and `sql.NullInt64`).

### What changed
- Added `driver.Valuer` unwrapping in `extractTypeInternal` (including pointer-receiver valuer support).
- Added regression test `TestMaxMinValidationWithDriverValuerStructFields` using `sql.NullInt64`.

### Verification
- `/tmp/go1.25.0/bin/go test ./... -run TestMaxMinValidationWithDriverValuerStructFields -count=1`
- `/tmp/go1.25.0/bin/go test ./... -run 'TestSQLValueValidation|TestSQLValue2Validation|TestValuerInterface' -count=1`

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.
