### PR TITLE
docs: use errors.As in README and translations example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Validator returns only InvalidValidationError for bad validation input, nil or V
 
 ```go
 err := validate.Struct(mystruct)
-validationErrors := err.(validator.ValidationErrors)
+var validationErrors validator.ValidationErrors
+errors.As(err, &validationErrors)
  ```
 
 Usage and documentation

--- a/_examples/translations/main.go
+++ b/_examples/translations/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/go-playground/locales/en"
@@ -70,13 +71,14 @@ func translateAll(trans ut.Translator) {
 	if err != nil {
 
 		// translate all error at once
-		errs := err.(validator.ValidationErrors)
-
-		// returns a map with key = namespace & value = translated error
-		// NOTICE: 2 errors are returned and you'll see something surprising
-		// translations are i18n aware!!!!
-		// eg. '10 characters' vs '1 character'
-		fmt.Println(errs.Translate(trans))
+		var errs validator.ValidationErrors
+		if errors.As(err, &errs) {
+			// returns a map with key = namespace & value = translated error
+			// NOTICE: 2 errors are returned and you'll see something surprising
+			// translations are i18n aware!!!!
+			// eg. '10 characters' vs '1 character'
+			fmt.Println(errs.Translate(trans))
+		}
 	}
 }
 
@@ -91,11 +93,12 @@ func translateIndividual(trans ut.Translator) {
 	err := validate.Struct(user)
 	if err != nil {
 
-		errs := err.(validator.ValidationErrors)
-
-		for _, e := range errs {
-			// can translate each error one at a time.
-			fmt.Println(e.Translate(trans))
+		var errs validator.ValidationErrors
+		if errors.As(err, &errs) {
+			for _, e := range errs {
+				// can translate each error one at a time.
+				fmt.Println(e.Translate(trans))
+			}
 		}
 	}
 }
@@ -119,11 +122,12 @@ func translateOverride(trans ut.Translator) {
 	err := validate.Struct(user)
 	if err != nil {
 
-		errs := err.(validator.ValidationErrors)
-
-		for _, e := range errs {
-			// can translate each error one at a time.
-			fmt.Println(e.Translate(trans))
+		var errs validator.ValidationErrors
+		if errors.As(err, &errs) {
+			for _, e := range errs {
+				// can translate each error one at a time.
+				fmt.Println(e.Translate(trans))
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Fixes Or Enhances

Closes #743

Replace the `err.(validator.ValidationErrors)` type assertion in the README and `_examples/translations/main.go` with `errors.As`, matching the pattern already used in `_examples/simple/main.go` and `_examples/struct-level/main.go`. `go-errorlint` flags the type-assertion form.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers
