### PR TITLE
feat: add origin validator for web origin URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ validate := validator.New(validator.WithRequiredStructEnabled())
 | url | URL String |
 | http_url | HTTP(s) URL String |
 | https_url | HTTPS-only URL String |
+| origin | Web origin (URL with HTTP(S) scheme and host, but no path/query/fragment) |
 | url_encoded | URL Encoded |
 | urn_rfc2141 | Urn RFC 2141 String |
 

--- a/baked_in.go
+++ b/baked_in.go
@@ -143,6 +143,7 @@ var (
 		"http_url":                      isHttpURL,
 		"https_url":                     isHttpsURL,
 		"uri":                           isURI,
+		"origin":                        isOrigin,
 		"urn_rfc2141":                   isUrnRFC2141, // RFC 2141
 		"file":                          isFile,
 		"filepath":                      isFilePath,
@@ -1556,6 +1557,66 @@ func isURI(fl FieldLevel) bool {
 		_, err := url.ParseRequestURI(s)
 
 		return err == nil
+	}
+
+	panic(fmt.Sprintf("Bad field type %s", field.Type()))
+}
+
+// isOrigin checks if a field value is a valid web origin URL with HTTP(S) scheme and host defined, but no path, query, or fragment.
+func isOrigin(fl FieldLevel) bool {
+	field := fl.Field()
+
+	switch field.Kind() {
+	case reflect.String:
+
+		s := field.String()
+
+		if len(s) == 0 {
+			return false
+		}
+
+		// Fragments with empty content ("#") are not detectable after parse and
+		// u.Fragment will be empty even if # is present in the URL.
+		if strings.Contains(s, "#") {
+			return false
+		}
+
+		u, err := url.Parse(s)
+		if err != nil {
+			return false
+		}
+
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return false
+		}
+
+		if u.Path != "" || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" {
+			return false
+		}
+
+		if u.User != nil {
+			return false
+		}
+
+		hostname := u.Hostname()
+		if hostname == "" {
+			return false
+		}
+		if !hostnameRegexRFC1123().MatchString(hostname) && net.ParseIP(hostname) == nil {
+			return false
+		}
+
+		portStr := u.Port()
+		if portStr != "" {
+			// Port 0 is reserved (RFC 6335) and has no valid use as an origin port.
+			// https://www.rfc-editor.org/rfc/rfc6335.html#section-6
+			port, portErr := strconv.ParseUint(portStr, 10, 16)
+			if portErr != nil || port == 0 {
+				return false
+			}
+		}
+
+		return true
 	}
 
 	panic(fmt.Sprintf("Bad field type %s", field.Type()))

--- a/baked_in.go
+++ b/baked_in.go
@@ -1566,9 +1566,7 @@ func isURI(fl FieldLevel) bool {
 func isOrigin(fl FieldLevel) bool {
 	field := fl.Field()
 
-	switch field.Kind() {
-	case reflect.String:
-
+	if field.Kind() == reflect.String {
 		s := field.String()
 
 		if len(s) == 0 {
@@ -1602,7 +1600,7 @@ func isOrigin(fl FieldLevel) bool {
 		if hostname == "" {
 			return false
 		}
-		if !hostnameRegexRFC1123().MatchString(hostname) && net.ParseIP(hostname) == nil {
+		if net.ParseIP(hostname) == nil && !hostnameRegexRFC1123().MatchString(hostname) {
 			return false
 		}
 

--- a/regexes.go
+++ b/regexes.go
@@ -57,7 +57,7 @@ const (
 	longitudeRegexString             = "^[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
 	sSNRegexString                   = `^[0-9]{3}[ -]?(0[1-9]|[1-9][0-9])[ -]?([1-9][0-9]{3}|[0-9][1-9][0-9]{2}|[0-9]{2}[1-9][0-9]|[0-9]{3}[1-9])$`
 	hostnameRegexStringRFC952        = `^[a-zA-Z]([a-zA-Z0-9\-]+[\.]?)*[a-zA-Z0-9]$`                                                                    // https://tools.ietf.org/html/rfc952
-	hostnameRegexStringRFC1123       = `^([a-zA-Z0-9]{1}[a-zA-Z0-9-]{0,62}){1}(\.[a-zA-Z0-9]{1}[a-zA-Z0-9-]{0,62})*?$`                                  // accepts hostname starting with a digit https://tools.ietf.org/html/rfc1123
+	hostnameRegexStringRFC1123       = `^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$`                  // accepts hostname starting with a digit https://tools.ietf.org/html/rfc1123
 	fqdnRegexStringRFC1123           = `^([a-zA-Z0-9]{1}[a-zA-Z0-9-]{0,62})(\.[a-zA-Z0-9]{1}[a-zA-Z0-9-]{0,62})*?(\.[a-zA-Z]{1}[a-zA-Z0-9-]{0,62})\.?$` // same as hostnameRegexStringRFC1123 but must contain a non numerical TLD (possibly ending with '.')
 	btcAddressRegexString            = `^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$`                                                                              // bitcoin address
 	btcAddressUpperRegexStringBech32 = `^BC1[02-9AC-HJ-NP-Z]{7,76}$`                                                                                    // bitcoin bech32 address https://en.bitcoin.it/wiki/Bech32

--- a/validator_test.go
+++ b/validator_test.go
@@ -8891,6 +8891,11 @@ func TestOrigin(t *testing.T) {
 		{"https://example.com:65536", false}, // port out of range
 		{"https://example.com:-1", false},    // negative port
 		{"https://example.com:abc", false},   // non-numeric port
+		{"http://example-.com", false},
+		{"http://-sub.example.com", false},
+		{"http://sub-.example.com", false},
+		{"http://example..com", false},
+		{"http://example.com.", false},
 	}
 
 	validate := New()
@@ -10808,6 +10813,18 @@ func TestHostnameRFC1123Validation(t *testing.T) {
 		{"2001:cdba:0000:0000:0000:0000:3257:9652", false},
 		{"2001:cdba:0:0:0:0:3257:9652", false},
 		{"2001:cdba::3257:9652", false},
+		{"", false},
+		{"-example.com", false},
+		{"example-.com", false},
+		{"foo.-bar.com", false},
+		{"foo.bar-.com", false},
+		{"example..com", false},
+		{".example.com", false},
+		{"foo.bar baz", false},
+		{"foo.bar/baz", false},
+		{"foo.bar:80", false},
+		{"foo$.example.com", false},
+		{"this-is-a-deliberately-overlong-subdomain-used-for-boundary-test.example.com", false},
 	}
 
 	validate := New()

--- a/validator_test.go
+++ b/validator_test.go
@@ -8791,6 +8791,133 @@ func TestUri(t *testing.T) {
 	PanicMatches(t, func() { _ = validate.Var(i, "uri") }, "Bad field type int")
 }
 
+func TestOrigin(t *testing.T) {
+	tests := []struct {
+		param    string
+		expected bool
+	}{
+		// Valid HTTP origins
+		{"http://example.com", true},
+		{"http://app.example.com", true},
+		{"http://example.com:8080", true},
+		{"http://localhost", true},
+		{"http://localhost:3000", true},
+		{"http://127.0.0.1", true},
+		{"http://127.0.0.1:8080", true},
+
+		// Valid HTTPS origins
+		{"https://example.com", true},
+		{"https://app.example.com", true},
+		{"https://example.com:8443", true},
+		{"https://example.com:443", true},
+		{"https://sub.domain.example.com", true},
+		{"https://example.co.uk", true},
+		{"https://xn--nxasmq6b.example.com", true}, // punycode (IDN)
+
+		// Valid IPv6 origins
+		{"http://[::1]", true},
+		{"http://[::1]:8080", true},
+		{"https://[2001:db8::1]", true},
+		{"https://[2001:db8::1]:8443", true},
+
+		// Invalid: wrong scheme
+		{"ftp://example.com", false},
+		{"file://example.com", false},
+		{"javascript://example.com", false},
+		{"data://example.com", false},
+		{"ws://example.com", false},
+		{"wss://example.com", false},
+		{"ssh://example.com", false},
+		{"mailto:user@example.com", false},
+		{"tel:+1234567890", false},
+
+		// Invalid: missing scheme
+		{"example.com", false},
+		{"app.example.com", false},
+		{"//example.com", false},
+		{"://example.com", false},
+
+		// Invalid: missing host
+		{"https://", false},
+		{"http://", false},
+		{"https:///path", false},
+		{"https://:8080", false},
+
+		// Invalid: has path
+		{"https://example.com/", false},
+		{"https://example.com/path", false},
+		{"https://example.com/path/to/resource", false},
+		{"http://example.com/", false},
+		{"https://example.com/a", false},
+
+		// Invalid: has query
+		{"https://example.com?foo=bar", false},
+		{"https://example.com?", false},
+		{"http://example.com?q=1&r=2", false},
+
+		// Invalid: has fragment
+		{"https://example.com#section", false},
+		{"https://example.com#", false},
+		{"http://example.com#top", false},
+		{"https://example.com%23", false},
+
+		// Invalid: combinations of path/query/fragment
+		{"https://example.com/path?q=1", false},
+		{"https://example.com/path#frag", false},
+		{"https://example.com/?q=1#frag", false},
+		{"https://example.com/path?q=1#frag", false},
+
+		// Invalid: malformed or meaningless
+		{"", false},
+		{" ", false},
+		{"not a url", false},
+		{"https:example.com", false},  // missing //
+		{"https:/example.com", false}, // single /
+		{"https//example.com", false}, // missing :
+		{"://", false},
+		{"http://  ", false}, // whitespace host
+		{"*", false},
+		{"https://*", false},
+
+		// Invalid: userinfo in URL (not valid in origin)
+		{"https://user:pass@example.com", false},
+		{"https://user@example.com", false},
+
+		// Case sensitivity and port boundary cases
+		{"HTTPS://example.com", true},        // uppercase scheme, Parse normalizes
+		{"https://EXAMPLE.COM", true},        // uppercase host, valid per RFC
+		{"https://example.com:65535", true},  // max valid port
+		{"https://example.com:0", false},     // port 0 isn't valid in the context of a web origin
+		{"https://example.com:65536", false}, // port out of range
+		{"https://example.com:-1", false},    // negative port
+		{"https://example.com:abc", false},   // non-numeric port
+	}
+
+	validate := New()
+
+	for i, test := range tests {
+		errs := validate.Var(test.param, "origin")
+
+		if test.expected {
+			if !IsEqual(errs, nil) {
+				t.Fatalf("Index: %d %q origin failed Error: %s", i, test.param, errs)
+			}
+		} else {
+			if IsEqual(errs, nil) {
+				t.Fatalf("Index: %d %q origin failed Error: %s", i, test.param, errs)
+			} else {
+				val := getError(errs, "", "")
+				if val.Tag() != "origin" {
+					t.Fatalf("Index: %d %q origin failed Error: %s", i, test.param, errs)
+				}
+			}
+		}
+	}
+
+	i := 1
+	PanicMatches(t, func() { _ = validate.Var(i, "origin") }, "Bad field type int")
+}
+
 func TestOrTag(t *testing.T) {
 	validate := New()
 


### PR DESCRIPTION
## Fixes Or Enhances

Added `origin` tag for web origin URLs.


**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers