### PR TITLE
feat(translations): add timezone support for en and ja locales

### DIFF
--- a/translations/en/en.go
+++ b/translations/en/en.go
@@ -1467,6 +1467,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			},
 		},
 		{
+			tag:         "timezone",
+			translation: "{0} must be a valid time zone",
+			override:    false,
+		},
+		{
 			tag:         "postcode_iso3166_alpha2",
 			translation: "{0} does not match postcode format of {1} country",
 			override:    false,

--- a/translations/en/en_test.go
+++ b/translations/en/en_test.go
@@ -46,66 +46,66 @@ func TestTranslations(t *testing.T) {
 	}
 
 	type Test struct {
-		Inner              Inner
-		RequiredString     string            `validate:"required"`
-		RequiredNumber     int               `validate:"required"`
-		RequiredMultiple   []string          `validate:"required"`
-		RequiredIf         string            `validate:"required_if=Inner.RequiredIf abcd"`
-		RequiredUnless     string            `validate:"required_unless=Inner.RequiredUnless abcd"`
-		RequiredWith       string            `validate:"required_with=Inner.RequiredWith"`
-		RequiredWithAll    string            `validate:"required_with_all=Inner.RequiredWith Inner.RequiredWithAll"`
-		RequiredWithout    string            `validate:"required_without=Inner.RequiredWithout"`
-		RequiredWithoutAll string            `validate:"required_without_all=Inner.RequiredWithout Inner.RequiredWithoutAll"`
-		ExcludedIf         string            `validate:"excluded_if=Inner.ExcludedIf abcd"`
-		ExcludedUnless     string            `validate:"excluded_unless=Inner.ExcludedUnless abcd"`
-		ExcludedWith       string            `validate:"excluded_with=Inner.ExcludedWith"`
-		ExcludedWithout    string            `validate:"excluded_with_all=Inner.ExcludedWithAll"`
-		ExcludedWithAll    string            `validate:"excluded_without=Inner.ExcludedWithout"`
-		ExcludedWithoutAll string            `validate:"excluded_without_all=Inner.ExcludedWithoutAll"`
-		IsDefault          string            `validate:"isdefault"`
-		LenString          string            `validate:"len=1"`
-		LenNumber          float64           `validate:"len=1113.00"`
-		LenMultiple        []string          `validate:"len=7"`
-		MinString          string            `validate:"min=1"`
-		MinNumber          float64           `validate:"min=1113.00"`
-		MinMultiple        []string          `validate:"min=7"`
-		MaxString          string            `validate:"max=3"`
-		MaxNumber          float64           `validate:"max=1113.00"`
-		MaxMultiple        []string          `validate:"max=7"`
-		EqString           string            `validate:"eq=3"`
-		EqNumber           float64           `validate:"eq=2.33"`
-		EqMultiple         []string          `validate:"eq=7"`
-		NeString           string            `validate:"ne="`
-		NeNumber           float64           `validate:"ne=0.00"`
-		NeMultiple         []string          `validate:"ne=0"`
-		LtString           string            `validate:"lt=3"`
-		LtNumber           float64           `validate:"lt=5.56"`
-		LtMultiple         []string          `validate:"lt=2"`
-		LtTime             time.Time         `validate:"lt"`
-		LteString          string            `validate:"lte=3"`
-		LteNumber          float64           `validate:"lte=5.56"`
-		LteMultiple        []string          `validate:"lte=2"`
-		LteTime            time.Time         `validate:"lte"`
-		GtString           string            `validate:"gt=3"`
-		GtNumber           float64           `validate:"gt=5.56"`
-		GtMultiple         []string          `validate:"gt=2"`
-		GtTime             time.Time         `validate:"gt"`
-		GteString          string            `validate:"gte=3"`
-		GteNumber          float64           `validate:"gte=5.56"`
-		GteMultiple        []string          `validate:"gte=2"`
-		GteTime            time.Time         `validate:"gte"`
-		EqFieldString      string            `validate:"eqfield=MaxString"`
-		EqCSFieldString    string            `validate:"eqcsfield=Inner.EqCSFieldString"`
-		NeCSFieldString    string            `validate:"necsfield=Inner.NeCSFieldString"`
-		GtCSFieldString    string            `validate:"gtcsfield=Inner.GtCSFieldString"`
-		GteCSFieldString   string            `validate:"gtecsfield=Inner.GteCSFieldString"`
-		LtCSFieldString    string            `validate:"ltcsfield=Inner.LtCSFieldString"`
-		LteCSFieldString   string            `validate:"ltecsfield=Inner.LteCSFieldString"`
-		NeFieldString      string            `validate:"nefield=EqFieldString"`
-		GtFieldString      string            `validate:"gtfield=MaxString"`
-		GteFieldString     string            `validate:"gtefield=MaxString"`
-		LtFieldString      string            `validate:"ltfield=MaxString"`
-		LteFieldString     string            `validate:"ltefield=MaxString"`
+		Inner                 Inner
+		RequiredString        string            `validate:"required"`
+		RequiredNumber        int               `validate:"required"`
+		RequiredMultiple      []string          `validate:"required"`
+		RequiredIf            string            `validate:"required_if=Inner.RequiredIf abcd"`
+		RequiredUnless        string            `validate:"required_unless=Inner.RequiredUnless abcd"`
+		RequiredWith          string            `validate:"required_with=Inner.RequiredWith"`
+		RequiredWithAll       string            `validate:"required_with_all=Inner.RequiredWith Inner.RequiredWithAll"`
+		RequiredWithout       string            `validate:"required_without=Inner.RequiredWithout"`
+		RequiredWithoutAll    string            `validate:"required_without_all=Inner.RequiredWithout Inner.RequiredWithoutAll"`
+		ExcludedIf            string            `validate:"excluded_if=Inner.ExcludedIf abcd"`
+		ExcludedUnless        string            `validate:"excluded_unless=Inner.ExcludedUnless abcd"`
+		ExcludedWith          string            `validate:"excluded_with=Inner.ExcludedWith"`
+		ExcludedWithout       string            `validate:"excluded_with_all=Inner.ExcludedWithAll"`
+		ExcludedWithAll       string            `validate:"excluded_without=Inner.ExcludedWithout"`
+		ExcludedWithoutAll    string            `validate:"excluded_without_all=Inner.ExcludedWithoutAll"`
+		IsDefault             string            `validate:"isdefault"`
+		LenString             string            `validate:"len=1"`
+		LenNumber             float64           `validate:"len=1113.00"`
+		LenMultiple           []string          `validate:"len=7"`
+		MinString             string            `validate:"min=1"`
+		MinNumber             float64           `validate:"min=1113.00"`
+		MinMultiple           []string          `validate:"min=7"`
+		MaxString             string            `validate:"max=3"`
+		MaxNumber             float64           `validate:"max=1113.00"`
+		MaxMultiple           []string          `validate:"max=7"`
+		EqString              string            `validate:"eq=3"`
+		EqNumber              float64           `validate:"eq=2.33"`
+		EqMultiple            []string          `validate:"eq=7"`
+		NeString              string            `validate:"ne="`
+		NeNumber              float64           `validate:"ne=0.00"`
+		NeMultiple            []string          `validate:"ne=0"`
+		LtString              string            `validate:"lt=3"`
+		LtNumber              float64           `validate:"lt=5.56"`
+		LtMultiple            []string          `validate:"lt=2"`
+		LtTime                time.Time         `validate:"lt"`
+		LteString             string            `validate:"lte=3"`
+		LteNumber             float64           `validate:"lte=5.56"`
+		LteMultiple           []string          `validate:"lte=2"`
+		LteTime               time.Time         `validate:"lte"`
+		GtString              string            `validate:"gt=3"`
+		GtNumber              float64           `validate:"gt=5.56"`
+		GtMultiple            []string          `validate:"gt=2"`
+		GtTime                time.Time         `validate:"gt"`
+		GteString             string            `validate:"gte=3"`
+		GteNumber             float64           `validate:"gte=5.56"`
+		GteMultiple           []string          `validate:"gte=2"`
+		GteTime               time.Time         `validate:"gte"`
+		EqFieldString         string            `validate:"eqfield=MaxString"`
+		EqCSFieldString       string            `validate:"eqcsfield=Inner.EqCSFieldString"`
+		NeCSFieldString       string            `validate:"necsfield=Inner.NeCSFieldString"`
+		GtCSFieldString       string            `validate:"gtcsfield=Inner.GtCSFieldString"`
+		GteCSFieldString      string            `validate:"gtecsfield=Inner.GteCSFieldString"`
+		LtCSFieldString       string            `validate:"ltcsfield=Inner.LtCSFieldString"`
+		LteCSFieldString      string            `validate:"ltecsfield=Inner.LteCSFieldString"`
+		NeFieldString         string            `validate:"nefield=EqFieldString"`
+		GtFieldString         string            `validate:"gtfield=MaxString"`
+		GteFieldString        string            `validate:"gtefield=MaxString"`
+		LtFieldString         string            `validate:"ltfield=MaxString"`
+		LteFieldString        string            `validate:"ltefield=MaxString"`
 		AlphaString           string            `validate:"alpha"`
 		AlphanumString        string            `validate:"alphanum"`
 		AlphaSpaceString      string            `validate:"alphaspace"`
@@ -113,85 +113,86 @@ func TestTranslations(t *testing.T) {
 		AlphaUnicodeString    string            `validate:"alphaunicode"`
 		AlphaNumUnicodeString string            `validate:"alphanumunicode"`
 		NumericString         string            `validate:"numeric"`
-		NumberString       string            `validate:"number"`
-		HexadecimalString  string            `validate:"hexadecimal"`
-		HexColorString     string            `validate:"hexcolor"`
-		RGBColorString     string            `validate:"rgb"`
-		RGBAColorString    string            `validate:"rgba"`
-		HSLColorString     string            `validate:"hsl"`
-		HSLAColorString    string            `validate:"hsla"`
-		Email              string            `validate:"email"`
-		URL                string            `validate:"url"`
-		URI                string            `validate:"uri"`
-		Base64             string            `validate:"base64"`
-		Contains           string            `validate:"contains=purpose"`
-		ContainsAny        string            `validate:"containsany=!@#$"`
-		Excludes           string            `validate:"excludes=text"`
-		ExcludesAll        string            `validate:"excludesall=!@#$"`
-		ExcludesRune       string            `validate:"excludesrune=☻"`
-		ISBN               string            `validate:"isbn"`
-		ISBN10             string            `validate:"isbn10"`
-		ISBN13             string            `validate:"isbn13"`
-		ISSN               string            `validate:"issn"`
-		URN                string            `validate:"urn_rfc2141"`
-		UUID               string            `validate:"uuid"`
-		UUID3              string            `validate:"uuid3"`
-		UUID4              string            `validate:"uuid4"`
-		UUID5              string            `validate:"uuid5"`
-		ULID               string            `validate:"ulid"`
-		ASCII              string            `validate:"ascii"`
-		PrintableASCII     string            `validate:"printascii"`
-		MultiByte          string            `validate:"multibyte"`
-		DataURI            string            `validate:"datauri"`
-		Latitude           string            `validate:"latitude"`
-		Longitude          string            `validate:"longitude"`
-		SSN                string            `validate:"ssn"`
-		IP                 string            `validate:"ip"`
-		IPv4               string            `validate:"ipv4"`
-		IPv6               string            `validate:"ipv6"`
-		CIDR               string            `validate:"cidr"`
-		CIDRv4             string            `validate:"cidrv4"`
-		CIDRv6             string            `validate:"cidrv6"`
-		TCPAddr            string            `validate:"tcp_addr"`
-		TCPAddrv4          string            `validate:"tcp4_addr"`
-		TCPAddrv6          string            `validate:"tcp6_addr"`
-		UDPAddr            string            `validate:"udp_addr"`
-		UDPAddrv4          string            `validate:"udp4_addr"`
-		UDPAddrv6          string            `validate:"udp6_addr"`
-		IPAddr             string            `validate:"ip_addr"`
-		IPAddrv4           string            `validate:"ip4_addr"`
-		IPAddrv6           string            `validate:"ip6_addr"`
-		UinxAddr           string            `validate:"unix_addr"` // can't fail from within Go's net package currently, but maybe in the future
-		MAC                string            `validate:"mac"`
-		FQDN               string            `validate:"fqdn"`
-		IsColor            string            `validate:"iscolor"`
-		StrPtrMinLen       *string           `validate:"min=10"`
-		StrPtrMaxLen       *string           `validate:"max=1"`
-		StrPtrLen          *string           `validate:"len=2"`
-		StrPtrLt           *string           `validate:"lt=1"`
-		StrPtrLte          *string           `validate:"lte=1"`
-		StrPtrGt           *string           `validate:"gt=10"`
-		StrPtrGte          *string           `validate:"gte=10"`
-		OneOfString        string            `validate:"oneof=red green"`
-		OneOfInt           int               `validate:"oneof=5 63"`
-		UniqueSlice        []string          `validate:"unique"`
-		UniqueArray        [3]string         `validate:"unique"`
-		UniqueMap          map[string]string `validate:"unique"`
-		JSONString         string            `validate:"json"`
-		JWTString          string            `validate:"jwt"`
-		LowercaseString    string            `validate:"lowercase"`
-		UppercaseString    string            `validate:"uppercase"`
-		Datetime           string            `validate:"datetime=2006-01-02"`
-		PostCode           string            `validate:"postcode_iso3166_alpha2=SG"`
-		PostCodeCountry    string
-		PostCodeByField    string        `validate:"postcode_iso3166_alpha2_field=PostCodeCountry"`
-		BooleanString      string        `validate:"boolean"`
-		Image              string        `validate:"image"`
-		MIMEType           string        `validate:"mimetype=image/png"`
-		CveString          string        `validate:"cve"`
-		MinDuration        time.Duration `validate:"min=1h30m,max=2h"`
-		MaxDuration        time.Duration `validate:"min=1h30m,max=2h"`
-		ValidateFn         Foo           `validate:"validateFn=IsBar"`
+		NumberString          string            `validate:"number"`
+		HexadecimalString     string            `validate:"hexadecimal"`
+		HexColorString        string            `validate:"hexcolor"`
+		RGBColorString        string            `validate:"rgb"`
+		RGBAColorString       string            `validate:"rgba"`
+		HSLColorString        string            `validate:"hsl"`
+		HSLAColorString       string            `validate:"hsla"`
+		Email                 string            `validate:"email"`
+		URL                   string            `validate:"url"`
+		URI                   string            `validate:"uri"`
+		Base64                string            `validate:"base64"`
+		Contains              string            `validate:"contains=purpose"`
+		ContainsAny           string            `validate:"containsany=!@#$"`
+		Excludes              string            `validate:"excludes=text"`
+		ExcludesAll           string            `validate:"excludesall=!@#$"`
+		ExcludesRune          string            `validate:"excludesrune=☻"`
+		ISBN                  string            `validate:"isbn"`
+		ISBN10                string            `validate:"isbn10"`
+		ISBN13                string            `validate:"isbn13"`
+		ISSN                  string            `validate:"issn"`
+		URN                   string            `validate:"urn_rfc2141"`
+		UUID                  string            `validate:"uuid"`
+		UUID3                 string            `validate:"uuid3"`
+		UUID4                 string            `validate:"uuid4"`
+		UUID5                 string            `validate:"uuid5"`
+		ULID                  string            `validate:"ulid"`
+		ASCII                 string            `validate:"ascii"`
+		PrintableASCII        string            `validate:"printascii"`
+		MultiByte             string            `validate:"multibyte"`
+		DataURI               string            `validate:"datauri"`
+		Latitude              string            `validate:"latitude"`
+		Longitude             string            `validate:"longitude"`
+		SSN                   string            `validate:"ssn"`
+		IP                    string            `validate:"ip"`
+		IPv4                  string            `validate:"ipv4"`
+		IPv6                  string            `validate:"ipv6"`
+		CIDR                  string            `validate:"cidr"`
+		CIDRv4                string            `validate:"cidrv4"`
+		CIDRv6                string            `validate:"cidrv6"`
+		TCPAddr               string            `validate:"tcp_addr"`
+		TCPAddrv4             string            `validate:"tcp4_addr"`
+		TCPAddrv6             string            `validate:"tcp6_addr"`
+		UDPAddr               string            `validate:"udp_addr"`
+		UDPAddrv4             string            `validate:"udp4_addr"`
+		UDPAddrv6             string            `validate:"udp6_addr"`
+		IPAddr                string            `validate:"ip_addr"`
+		IPAddrv4              string            `validate:"ip4_addr"`
+		IPAddrv6              string            `validate:"ip6_addr"`
+		UinxAddr              string            `validate:"unix_addr"` // can't fail from within Go's net package currently, but maybe in the future
+		MAC                   string            `validate:"mac"`
+		FQDN                  string            `validate:"fqdn"`
+		IsColor               string            `validate:"iscolor"`
+		StrPtrMinLen          *string           `validate:"min=10"`
+		StrPtrMaxLen          *string           `validate:"max=1"`
+		StrPtrLen             *string           `validate:"len=2"`
+		StrPtrLt              *string           `validate:"lt=1"`
+		StrPtrLte             *string           `validate:"lte=1"`
+		StrPtrGt              *string           `validate:"gt=10"`
+		StrPtrGte             *string           `validate:"gte=10"`
+		OneOfString           string            `validate:"oneof=red green"`
+		OneOfInt              int               `validate:"oneof=5 63"`
+		UniqueSlice           []string          `validate:"unique"`
+		UniqueArray           [3]string         `validate:"unique"`
+		UniqueMap             map[string]string `validate:"unique"`
+		JSONString            string            `validate:"json"`
+		JWTString             string            `validate:"jwt"`
+		LowercaseString       string            `validate:"lowercase"`
+		UppercaseString       string            `validate:"uppercase"`
+		Datetime              string            `validate:"datetime=2006-01-02"`
+		Timezone              string            `validate:"timezone"`
+		PostCode              string            `validate:"postcode_iso3166_alpha2=SG"`
+		PostCodeCountry       string
+		PostCodeByField       string        `validate:"postcode_iso3166_alpha2_field=PostCodeCountry"`
+		BooleanString         string        `validate:"boolean"`
+		Image                 string        `validate:"image"`
+		MIMEType              string        `validate:"mimetype=image/png"`
+		CveString             string        `validate:"cve"`
+		MinDuration           time.Duration `validate:"min=1h30m,max=2h"`
+		MaxDuration           time.Duration `validate:"min=1h30m,max=2h"`
+		ValidateFn            Foo           `validate:"validateFn=IsBar"`
 	}
 
 	var test Test
@@ -258,6 +259,7 @@ func TestTranslations(t *testing.T) {
 	test.UniqueSlice = []string{"1234", "1234"}
 	test.UniqueMap = map[string]string{"key1": "1234", "key2": "1234"}
 	test.Datetime = "2008-Feb-01"
+	test.Timezone = "abc"
 	test.BooleanString = "A"
 	test.CveString = "A"
 
@@ -807,6 +809,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.Datetime",
 			expected: "Datetime does not match the 2006-01-02 format",
+		},
+		{
+			ns:       "Test.Timezone",
+			expected: "Timezone must be a valid time zone",
 		},
 		{
 			ns:       "Test.PostCode",

--- a/translations/ja/ja.go
+++ b/translations/ja/ja.go
@@ -1389,6 +1389,11 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			},
 		},
 		{
+			tag:         "timezone",
+			translation: "{0}は正しいタイムゾーン文字列でなければなりません",
+			override:    false,
+		},
+		{
 			tag:         "postcode_iso3166_alpha2",
 			translation: "{0}は国名コード{1}の郵便番号形式と一致しません",
 			override:    false,

--- a/translations/ja/ja_test.go
+++ b/translations/ja/ja_test.go
@@ -149,6 +149,7 @@ func TestTranslations(t *testing.T) {
 		LowercaseString   string            `validate:"lowercase"`
 		UppercaseString   string            `validate:"uppercase"`
 		Datetime          string            `validate:"datetime=2006-01-02"`
+		Timezone          string            `validate:"timezone"`
 		PostCode          string            `validate:"postcode_iso3166_alpha2=SG"`
 		PostCodeCountry   string
 		PostCodeByField   string `validate:"postcode_iso3166_alpha2_field=PostCodeCountry"`
@@ -207,6 +208,7 @@ func TestTranslations(t *testing.T) {
 	test.UniqueSlice = []string{"1234", "1234"}
 	test.UniqueMap = map[string]string{"key1": "1234", "key2": "1234"}
 	test.Datetime = "2008-Feb-01"
+	test.Timezone = "abc"
 	test.BooleanString = "A"
 
 	test.Inner.RequiredIf = "abcd"
@@ -692,6 +694,10 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.Datetime",
 			expected: "Datetimeは2006-01-02の書式と一致しません",
+		},
+		{
+			ns:       "Test.Timezone",
+			expected: "Timezoneは正しいタイムゾーン文字列でなければなりません",
 		},
 		{
 			ns:       "Test.PostCode",


### PR DESCRIPTION
This PR adds missing translations for the `timezone` validation tag in both **English (en)** and **Japanese (ja)** locales. 

Previously, the `timezone` tag did not have a localized error message in these languages, causing it to fallback to the default tag name. This enhancement ensures a better user experience for developers using these locales.

## Changes
- Added `timezone` translation to  `translations/en/en.go`
- Added `timezone` translation to `translations/ja/ja.go`
- Added unit tests for `timezone` translation in `translations/en/en_test.go`
- Added unit tests for `timezone` translation in `translations/ja/ja_test.go`

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers