### PR TITLE
feat: Add ISIN validator

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -260,6 +260,7 @@ var (
 		"cron":                          isCron,
 		"spicedb":                       isSpiceDB,
 		"ein":                           isEIN,
+		"isin":                          isISIN,
 		"validateFn":                    isValidateFn,
 	}
 )
@@ -3505,9 +3506,30 @@ func isEIN(fl FieldLevel) bool {
 	return einRegex().MatchString(field.String())
 }
 
+// isISIN is the validation function for validating if the current field's value is a valid International Securities Identification Number (ISIN)
+func isISIN(fl FieldLevel) bool {
+	field := fl.Field()
+	isin := field.String()
+
+	if !isinRegex().MatchString(isin) {
+		return false
+	}
+
+	var digits []string
+	for _, c := range isin {
+		if c >= 'A' && c <= 'Z' {
+			val := int(c - 'A' + 10)
+			digits = append(digits, strconv.Itoa(val/10), strconv.Itoa(val%10))
+		} else {
+			digits = append(digits, string(c))
+		}
+	}
+
+	return digitsHaveLuhnChecksum(digits)
+}
+
 var (
 	errMethodNotFound          = errors.New(`method not found`)
 	errMethodReturnNoValues    = errors.New(`method return o values (void)`)
 	errMethodReturnInvalidType = errors.New(`method should return invalid type`)
 )
-

--- a/regexes.go
+++ b/regexes.go
@@ -82,6 +82,7 @@ const (
 	spicedbPermissionRegexString     = "^([a-z][a-z0-9_]{1,62}[a-z0-9])?$"
 	spicedbTypeRegexString           = "^([a-z][a-z0-9_]{1,61}[a-z0-9]/)?[a-z][a-z0-9_]{1,62}[a-z0-9]$"
 	einRegexString                   = "^(\\d{2}-\\d{7})$"
+	isinRegexString                  = `^[A-Z]{2}[A-Z0-9]{9}[0-9]$`
 )
 
 func lazyRegexCompile(str string) func() *regexp.Regexp {
@@ -170,4 +171,5 @@ var (
 	spicedbPermissionRegex     = lazyRegexCompile(spicedbPermissionRegexString)
 	spicedbTypeRegex           = lazyRegexCompile(spicedbTypeRegexString)
 	einRegex                   = lazyRegexCompile(einRegexString)
+	isinRegex                  = lazyRegexCompile(isinRegexString)
 )

--- a/validator_test.go
+++ b/validator_test.go
@@ -6321,32 +6321,32 @@ func TestMIMETypeValidation(t *testing.T) {
 	}
 
 	tests := []struct {
-		title       string
-		param       string
-		tag         string
-		expected    bool
-		createFile  func()
+		title      string
+		param      string
+		tag        string
+		expected   bool
+		createFile func()
 	}{
 		{
-			title:       "empty path",
-			param:       paths["empty"],
-			tag:         "mimetype=image/png",
-			expected:    false,
-			createFile:  func() {},
+			title:      "empty path",
+			param:      paths["empty"],
+			tag:        "mimetype=image/png",
+			expected:   false,
+			createFile: func() {},
 		},
 		{
-			title:       "directory, not a file",
-			param:       paths["directory"],
-			tag:         "mimetype=image/png",
-			expected:    false,
-			createFile:  func() {},
+			title:      "directory, not a file",
+			param:      paths["directory"],
+			tag:        "mimetype=image/png",
+			expected:   false,
+			createFile: func() {},
 		},
 		{
-			title:       "missing file",
-			param:       paths["missing"],
-			tag:         "mimetype=image/png",
-			expected:    false,
-			createFile:  func() {},
+			title:      "missing file",
+			param:      paths["missing"],
+			tag:        "mimetype=image/png",
+			expected:   false,
+			createFile: func() {},
 		},
 		{
 			title:    "exact png match",
@@ -6401,11 +6401,11 @@ func TestMIMETypeValidation(t *testing.T) {
 			},
 		},
 		{
-			title:       "type mismatch",
-			param:       paths["go"],
-			tag:         "mimetype=image/*",
-			expected:    false,
-			createFile:  func() {},
+			title:      "type mismatch",
+			param:      paths["go"],
+			tag:        "mimetype=image/*",
+			expected:   false,
+			createFile: func() {},
 		},
 		{
 			title:    "subtype mismatch",
@@ -6425,11 +6425,11 @@ func TestMIMETypeValidation(t *testing.T) {
 			},
 		},
 		{
-			title:       "invalid validator param missing subtype",
-			param:       paths["go"],
-			tag:         "mimetype=image",
-			expected:    false,
-			createFile:  func() {},
+			title:      "invalid validator param missing subtype",
+			param:      paths["go"],
+			tag:        "mimetype=image",
+			expected:   false,
+			createFile: func() {},
 		},
 	}
 
@@ -15499,6 +15499,39 @@ func TestEINStringValidation(t *testing.T) {
 		} else {
 			if IsEqual(errs, nil) {
 				t.Fatalf("Index: %d ein failed Error: %s", i, errs)
+			}
+		}
+	}
+}
+
+func TestISINStringValidation(t *testing.T) {
+	tests := []struct {
+		value    string `validate:"isin"`
+		expected bool
+	}{
+		{"US0378331005", true},
+		{"GB0002634946", true},
+		{"DE0005140008", true},
+		{"US037833100", false},
+		{"US03783310055", false},
+		{"0S0378331005", false},
+		{"U00378331005", false},
+		{"US0378331006", false},
+		{"us0378331005", false},
+		{"US037833100a", false},
+	}
+	validate := New()
+
+	for i, test := range tests {
+		errs := validate.Var(test.value, "isin")
+
+		if test.expected {
+			if !IsEqual(errs, nil) {
+				t.Fatalf("Index: %d isin failed Error: %s", i, errs)
+			}
+		} else {
+			if IsEqual(errs, nil) {
+				t.Fatalf("Index: %d isin failed Error: %s", i, errs)
 			}
 		}
 	}


### PR DESCRIPTION
Adds an `isin` struct tag validator for International Securities Identification Numbers (ISO 6166). Validation checks:
1. Format: 2-letter country code + 9 alphanumeric chars + 1 check digit
2. Luhn checksum: letters are expanded to their two-digit values (A=10 … Z=35) before applying the standard Luhn algorithm.

- regexes.go: add isinRegexString and isinRegex
- baked_in.go: register "isin" tag and implement isISIN()
- validator_test.go: add TestISINStringValidation with valid ISINs (Apple, BP, BASF) and invalid cases (length, format, checksum, lowercase)

## Fixes Or Enhances


**Make sure that you've checked the boxes below before you submit PR:**
- [ ] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers