### PR TITLE
fix(lint): correctly disable govet inline analyzer & deprecated gomodguard

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -53,3 +53,8 @@ linters:
     - varnamelen
     - wrapcheck
     - wsl
+    - gomodguard
+  settings:
+    govet:
+      disable:
+        - inline


### PR DESCRIPTION
## Fixes Or Enhances

- Move `inline` from `linters.disable` to `settings.govet.disable` to properly suppress Go 1.24+ false positives regarding `reflect.Ptr` constant inlining
- Disable deprecated `gomodguard` linter to resolve golangci-lint v2 warnings

Related to: https://github.com/go-playground/validator/actions/runs/25698487406/job/75452753081
```
run golangci-lint
  Running [/home/runner/golangci-lint-2.12.2-linux-amd64/golangci-lint config path] in [/home/runner/work/validator/validator] ...
  Running [/home/runner/golangci-lint-2.12.2-linux-amd64/golangci-lint config verify] in [/home/runner/work/validator/validator] ...
  Running [/home/runner/golangci-lint-2.12.2-linux-amd64/golangci-lint run] in [/home/runner/work/validator/validator] ...
  Error: baked_in.go:390:23: inline: Constant reflect.Ptr should be inlined (govet)
  				if elem.Kind() == reflect.Ptr {
  				                  ^
  Error: baked_in.go:409:22: inline: Constant reflect.Ptr should be inlined (govet)
  			if elem.Kind() == reflect.Ptr {
  			                  ^
  Error: baked_in.go:431:20: inline: Constant reflect.Ptr should be inlined (govet)
  			if sf.Kind() == reflect.Ptr {
  			                ^
  3 issues:
  * govet: 3
  
  level=warning msg="The linter 'gomodguard' is deprecated (since v2.12.0) due to: new major version. Replaced by gomodguard_v2."
  level=warning msg="Suggested new configuration:\nlinters:\n  enable:\n    - gomodguard_v2\n"
  
  Error: issues found
  Ran golangci-lint in 19996ms

```

**Make sure that you've checked the boxes below before you submit PR:**
- [ ] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers