### PR TITLE
fix(cron): anchor regex and accept full cron syntax

### DIFF
--- a/regexes.go
+++ b/regexes.go
@@ -77,7 +77,7 @@ const (
 	cveRegexString                   = `^CVE-(1999|2\d{3})-(0[^0]\d{2}|0\d[^0]\d{1}|0\d{2}[^0]|[1-9]{1}\d{3,})$` // CVE Format Id https://cve.mitre.org/cve/identifiers/syntaxchange.html
 	mongodbIdRegexString             = "^[a-f\\d]{24}$"
 	mongodbConnStringRegexString     = "^mongodb(\\+srv)?:\\/\\/(([a-zA-Z\\d]+):([a-zA-Z\\d$:\\/?#\\[\\]@]+)@)?(([a-z\\d.-]+)(:[\\d]+)?)((,(([a-z\\d.-]+)(:(\\d+))?))*)?(\\/[a-zA-Z-_]{1,64})?(\\?(([a-zA-Z]+)=([a-zA-Z\\d]+))(&(([a-zA-Z\\d]+)=([a-zA-Z\\d]+))?)*)?$"
-	cronRegexString                  = `(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\d+(ns|us|µs|ms|s|m|h))+)|((((\d+,)+\d+|((\*|\d+)(\/|-)\d+)|\d+|\*) ?){5,7})`
+	cronRegexString                  = `^((@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\d+(ns|us|µs|ms|s|m|h))+)|(([A-Za-z0-9*?][A-Za-z0-9*?/,#L-]+|[*?0-9])( +([A-Za-z0-9*?][A-Za-z0-9*?/,#L-]+|[*?0-9])){4,6}))$`
 	spicedbIDRegexString             = `^(([a-zA-Z0-9/_|\-=+]{1,})|\*)$`
 	spicedbPermissionRegexString     = "^([a-z][a-z0-9_]{1,62}[a-z0-9])?$"
 	spicedbTypeRegexString           = "^([a-z][a-z0-9_]{1,61}[a-z0-9]/)?[a-z][a-z0-9_]{1,62}[a-z0-9]$"

--- a/validator_test.go
+++ b/validator_test.go
@@ -15163,6 +15163,24 @@ func TestCronExpressionValidation(t *testing.T) {
 		{"0 15 10 ? * 6#3", "cron", true},
 		{"0 */15 * * *", "cron", true},
 		{"wrong", "cron", false},
+		// The regex must match the entire string, not a substring containing
+		// something cron-like. Without `^...$` anchors, arbitrary text wrapped
+		// around a valid cron expression would falsely validate.
+		{"random text @daily more text", "cron", false},
+		{"foo @yearly bar", "cron", false},
+		{"prefix @every 1h suffix", "cron", false},
+		{"x 1 2 3 4 5 y", "cron", false},
+		{"hello world this string has 1 2 3 4 5 numbers", "cron", false},
+		{"not at all valid; trailing junk: * * * * *", "cron", false},
+		// Known limitations: the following inputs still pass because the
+		// regex validates cron *syntax*, not semantics. Catching them would
+		// require a real cron parser (per-field value ranges, an enumerated
+		// list of valid alphabetic tokens like MON/TUE/JAN/FEB, etc.):
+		//   "60 25 32 13 7"           - all numeric fields out of range
+		//   "foo bar baz qux quux"    - nonsense alphabetic tokens, all 2+ chars
+		//   "5- * * * *"              - field with trailing separator
+		//   "0,,1 * * * *"            - field with empty list slot
+		//   "@every 0s"               - zero-duration interval
 	}
 
 	validate := New()


### PR DESCRIPTION
The cron validator's regex lacked `^...$` anchors, so any string containing a cron-like substring (e.g. `"random text @daily more text"`, `"prefix @every 1h suffix"`, `"x 1 2 3 4 5 y"`) was accepted as a valid cron expression.

Anchoring alone wasn't sufficient — the original field pattern only recognized plain numeric forms and was getting away with it via substring matching. Several existing positive test cases (`?`, `L`, `MON-FRI`, `#`, multi-field expressions with year) only passed because the regex matched a numeric fragment of the input. The field pattern is now expanded to accept the documented cron alphabet (`*`, `?`, digits, letters, `,`, `/`, `-`, `#`, `L`, `W`) while still rejecting bare single letters like "x" that aren't valid in any cron dialect.

Negative test cases added to lock in the new behavior, with a note documenting remaining false positives that would require a real cron parser to reject (out-of-range values, nonsense alphabetic tokens, etc).

- Fixes #1576

## Fixes Or Enhances

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers