### PR TITLE
fix: anchor cron regex so substrings can't pass validation

### DIFF
--- a/regexes.go
+++ b/regexes.go
@@ -77,7 +77,7 @@ const (
 	cveRegexString                   = `^CVE-(1999|2\d{3})-(0[^0]\d{2}|0\d[^0]\d{1}|0\d{2}[^0]|[1-9]{1}\d{3,})$` // CVE Format Id https://cve.mitre.org/cve/identifiers/syntaxchange.html
 	mongodbIdRegexString             = "^[a-f\\d]{24}$"
 	mongodbConnStringRegexString     = "^mongodb(\\+srv)?:\\/\\/(([a-zA-Z\\d]+):([a-zA-Z\\d$:\\/?#\\[\\]@]+)@)?(([a-z\\d.-]+)(:[\\d]+)?)((,(([a-z\\d.-]+)(:(\\d+))?))*)?(\\/[a-zA-Z-_]{1,64})?(\\?(([a-zA-Z]+)=([a-zA-Z\\d]+))(&(([a-zA-Z\\d]+)=([a-zA-Z\\d]+))?)*)?$"
-	cronRegexString                  = `(@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\d+(ns|us|µs|ms|s|m|h))+)|((((\d+,)+\d+|((\*|\d+)(\/|-)\d+)|\d+|\*) ?){5,7})`
+	cronRegexString                  = `^((@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\d+(ns|us|µs|ms|s|m|h))+)|(([\dA-Z?*#,/-]+ ){4,6}[\dA-Z?*#,/-]+))$`
 	spicedbIDRegexString             = `^(([a-zA-Z0-9/_|\-=+]{1,})|\*)$`
 	spicedbPermissionRegexString     = "^([a-z][a-z0-9_]{1,62}[a-z0-9])?$"
 	spicedbTypeRegexString           = "^([a-z][a-z0-9_]{1,61}[a-z0-9]/)?[a-z][a-z0-9_]{1,62}[a-z0-9]$"

--- a/validator_test.go
+++ b/validator_test.go
@@ -15163,6 +15163,12 @@ func TestCronExpressionValidation(t *testing.T) {
 		{"0 15 10 ? * 6#3", "cron", true},
 		{"0 */15 * * *", "cron", true},
 		{"wrong", "cron", false},
+		{"random text @daily more text", "cron", false},
+		{"x 1 2 3 4 5 y", "cron", false},
+		{"prefix @every 1h suffix", "cron", false},
+		{"not at all valid; trailing junk: * * * * *", "cron", false},
+		{"* * * * * trailing", "cron", false},
+		{"leading * * * * *", "cron", false},
 	}
 
 	validate := New()


### PR DESCRIPTION
## Fixes Or Enhances

Closes #1576

The `cron` validator regex is the only one in `regexes.go` without `^...$` anchors, so any string that contains a cron-like substring passes validation. Examples that currently pass `validate:\"cron\"` but shouldn't:

- `random text @daily more text`
- `x 1 2 3 4 5 y`
- `prefix @every 1h suffix`
- `not at all valid; trailing junk: * * * * *`
- `* * * * * trailing`
- `leading * * * * *`

Just adding anchors breaks several of the existing tests though, because they use quartz syntax (`?`, `L`, `MON-FRI`, `6#3`) that the old field pattern doesn't actually match. Those only passed before because `MatchString` could find a 5+ field substring of basic digits-and-stars somewhere inside the input. So I also widened the field character class to cover the characters the existing tests already expect (digits, `*`, `?`, `/`, `,`, `-`, `#`, and uppercase letters), which keeps the same set of expressions valid while rejecting leading/trailing junk.

The `@yearly`/`@daily`/`@every` branches are unchanged.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers