### PR TITLE
Add English translations for prefix and suffix validators

### DIFF
--- a/translations/en/en.go
+++ b/translations/en/en.go
@@ -1188,6 +1188,62 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 			},
 		},
 		{
+			tag:         "startswith",
+			translation: "{0} must start with '{1}'",
+			override:    false,
+			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
+				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
+				if err != nil {
+					log.Printf("warning: error translating FieldError: %#v", fe)
+					return fe.(error).Error()
+				}
+
+				return t
+			},
+		},
+		{
+			tag:         "endswith",
+			translation: "{0} must end with '{1}'",
+			override:    false,
+			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
+				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
+				if err != nil {
+					log.Printf("warning: error translating FieldError: %#v", fe)
+					return fe.(error).Error()
+				}
+
+				return t
+			},
+		},
+		{
+			tag:         "startsnotwith",
+			translation: "{0} must not start with '{1}'",
+			override:    false,
+			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
+				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
+				if err != nil {
+					log.Printf("warning: error translating FieldError: %#v", fe)
+					return fe.(error).Error()
+				}
+
+				return t
+			},
+		},
+		{
+			tag:         "endsnotwith",
+			translation: "{0} must not end with '{1}'",
+			override:    false,
+			customTransFunc: func(ut ut.Translator, fe validator.FieldError) string {
+				t, err := ut.T(fe.Tag(), fe.Field(), fe.Param())
+				if err != nil {
+					log.Printf("warning: error translating FieldError: %#v", fe)
+					return fe.(error).Error()
+				}
+
+				return t
+			},
+		},
+		{
 			tag:         "excludes",
 			translation: "{0} cannot contain the text '{1}'",
 			override:    false,

--- a/translations/en/en_test.go
+++ b/translations/en/en_test.go
@@ -126,6 +126,10 @@ func TestTranslations(t *testing.T) {
 		Base64                string            `validate:"base64"`
 		Contains              string            `validate:"contains=purpose"`
 		ContainsAny           string            `validate:"containsany=!@#$"`
+		StartsWith            string            `validate:"startswith=start"`
+		EndsWith              string            `validate:"endswith=end"`
+		StartsNotWith         string            `validate:"startsnotwith=start"`
+		EndsNotWith           string            `validate:"endsnotwith=end"`
 		Excludes              string            `validate:"excludes=text"`
 		ExcludesAll           string            `validate:"excludesall=!@#$"`
 		ExcludesRune          string            `validate:"excludesrune=☻"`
@@ -243,6 +247,10 @@ func TestTranslations(t *testing.T) {
 	test.Excludes = "this is some test text"
 	test.ExcludesAll = "This is Great!"
 	test.ExcludesRune = "Love it ☻"
+	test.StartsWith = "end"
+	test.EndsWith = "start"
+	test.StartsNotWith = "start value"
+	test.EndsNotWith = "value end"
 
 	test.ASCII = "ｶﾀｶﾅ"
 	test.PrintableASCII = "ｶﾀｶﾅ"
@@ -437,6 +445,22 @@ func TestTranslations(t *testing.T) {
 		{
 			ns:       "Test.Contains",
 			expected: "Contains must contain the text 'purpose'",
+		},
+		{
+			ns:       "Test.StartsWith",
+			expected: "StartsWith must start with 'start'",
+		},
+		{
+			ns:       "Test.EndsWith",
+			expected: "EndsWith must end with 'end'",
+		},
+		{
+			ns:       "Test.StartsNotWith",
+			expected: "StartsNotWith must not start with 'start'",
+		},
+		{
+			ns:       "Test.EndsNotWith",
+			expected: "EndsNotWith must not end with 'end'",
 		},
 		{
 			ns:       "Test.Base64",


### PR DESCRIPTION
## Fixes Or Enhances

Fixes #1167.

Adds English default translations for `startswith`, `endswith`, `startsnotwith`, and `endsnotwith`, plus test coverage for the translated messages.

**Make sure that you have checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Validation:
- `go test ./translations/en`
- `git diff --check`

@go-playground/validator-maintainers