### PR TITLE
fix(baked_in): handle "nil" param in excluded_if for pointer fields

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -2059,15 +2059,27 @@ func requireCheckFieldValue(
 
 	switch kind {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if value == "nil" {
+			return false
+		}
 		return field.Int() == asInt(value)
 
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		if value == "nil" {
+			return false
+		}
 		return field.Uint() == asUint(value)
 
 	case reflect.Float32:
+		if value == "nil" {
+			return false
+		}
 		return field.Float() == asFloat32(value)
 
 	case reflect.Float64:
+		if value == "nil" {
+			return false
+		}
 		return field.Float() == asFloat64(value)
 
 	case reflect.Slice, reflect.Map:
@@ -2075,19 +2087,21 @@ func requireCheckFieldValue(
 			return field.IsNil()
 		}
 		return int64(field.Len()) == asInt(value)
+
 	case reflect.Array:
 		// Arrays can't be nil, so only compare lengths
+		if value == "nil" {
+			return false
+		}
 		return int64(field.Len()) == asInt(value)
 
 	case reflect.Bool:
 		return field.Bool() == (value == "true")
 
 	case reflect.Ptr:
-		if field.IsNil() {
-			return value == "nil"
-		}
-		// Handle non-nil pointers
-		return requireCheckFieldValue(fl, param, value, defaultNotFoundValue)
+		// extractTypeInternal dereferences non-nil pointers before reaching here,
+		// so this case is only reached when the pointer itself is nil.
+		return value == "nil"
 	}
 
 	// default reflect.String:

--- a/validator_test.go
+++ b/validator_test.go
@@ -13143,6 +13143,32 @@ func TestExcludedIf(t *testing.T) {
 	}
 	errs = validate.Struct(test12)
 	Equal(t, errs, nil)
+
+	// Issue #1320: excluded_if with "nil" param must not panic when comparing
+	// a non-nil pointer-to-numeric field against the literal "nil".
+	w13 := 10
+	r13 := 0
+	test13 := struct {
+		W *int
+		R *int `validate:"excluded_if=W nil"`
+	}{
+		W: &w13,
+		R: &r13,
+	}
+	errs = validate.Struct(test13)
+	Equal(t, errs, nil) // W is non-nil → excluded_if condition false → R not excluded → no error
+
+	// When W IS nil the excluded_if condition fires and R must be empty/nil to pass.
+	test14 := struct {
+		W *int
+		R *int `validate:"excluded_if=W nil"`
+	}{
+		W: nil,
+		R: nil,
+	}
+	errs = validate.Struct(test14)
+	Equal(t, errs, nil) // W is nil → excluded_if condition true → R must be nil/absent → passes
+
 	// Checks number of params in struct tag is correct
 	defer func() {
 		if r := recover(); r == nil {


### PR DESCRIPTION
## Summary

Fixes #1320 — `excluded_if` panics with `strconv.ParseInt: parsing "nil": invalid syntax` when a tag like `excluded_if=W nil` is used and `W` is a non-nil pointer-to-numeric type.

### Root cause

`requireCheckFieldValue` uses `extractTypeInternal` to resolve the comparison field, which dereferences non-nil pointers to their underlying type. So a `*int` field whose value is non-nil arrives at the `reflect.Int` switch case. The function then called `asInt("nil")` unconditionally, which panics.

The same bug exists for `*uint`, `*float32`, `*float64`, and `*[N]T` comparisons against `"nil"`.

### Fix

- Add an early `if value == "nil" { return false }` guard in the Int, Uint, Float32, Float64, and Array cases of `requireCheckFieldValue`. A fully-dereferenced numeric/array value can never be nil, so the comparison is always false.
- Simplify the `reflect.Ptr` case: `extractTypeInternal` only returns `kind == reflect.Ptr` for **nil** pointers (non-nil ones are dereferenced to their element kind), so the non-nil recursive branch was dead code and has been removed.

### Test

Two new sub-cases added to `TestExcludedIf`:
- `W *int` non-nil, `R *int` non-nil with `excluded_if=W nil` — previously panicked, now returns nil error.
- `W *int` nil, `R *int` nil with `excluded_if=W nil` — condition fires, R is absent, passes.

All existing tests continue to pass (`go test ./...`).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>