### PR TITLE
Add Go fuzz tests for OSS-Fuzz integration

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -2,7 +2,8 @@ name: CIFuzz
 on:
   pull_request:
     paths:
-      - '**'
+      - '**.go'
+      - '.github/workflows/cifuzz.yml'
   push:
     branches: [main, master]
 permissions:
@@ -13,17 +14,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sanitizer: [address]
+        sanitizer: [address, memory]
     steps:
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build
-      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@ba0e2e0 # v1.0.0
       with:
         oss-fuzz-project-name: 'validator'
         language: go
         sanitizer: ${{ matrix.sanitizer }}
     - name: Run Fuzzers (${{ matrix.sanitizer }})
-      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@ba0e2e0 # v1.0.0
       with:
         oss-fuzz-project-name: 'validator'
         language: go
@@ -31,8 +32,8 @@ jobs:
         sanitizer: ${{ matrix.sanitizer }}
         output-sarif: true
     - name: Upload Sarif
-      if: always() && steps.build.outcome == 'success'
-      uses: github/codeql-action/upload-sarif@v3
+      if: steps.build.outcome == 'success'
+      uses: github/codeql-action/upload-sarif@601d5b1 # v3.28.15
       with:
         sarif_file: cifuzz-sarif/results.sarif
         category: fuzz-${{ matrix.sanitizer }}

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -6,25 +6,29 @@ on:
       - '.github/workflows/cifuzz.yml'
   push:
     branches: [main, master]
+
 permissions:
   contents: read
+  security-events: write
+
 jobs:
   fuzzing:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        sanitizer: [address, memory]
+        sanitizer: [address]
     steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Build Fuzzers (${{ matrix.sanitizer }})
       id: build
-      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@ba0e2e0 # v1.0.0
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@ba0e2e0399a10b7b42afb16e7a6c4ccd3ff52431
       with:
         oss-fuzz-project-name: 'validator'
         language: go
         sanitizer: ${{ matrix.sanitizer }}
     - name: Run Fuzzers (${{ matrix.sanitizer }})
-      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@ba0e2e0 # v1.0.0
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@ba0e2e0399a10b7b42afb16e7a6c4ccd3ff52431
       with:
         oss-fuzz-project-name: 'validator'
         language: go
@@ -32,8 +36,8 @@ jobs:
         sanitizer: ${{ matrix.sanitizer }}
         output-sarif: true
     - name: Upload Sarif
-      if: steps.build.outcome == 'success'
-      uses: github/codeql-action/upload-sarif@601d5b1 # v3.28.15
+      if: always() && steps.build.outcome == 'success'
+      uses: github/codeql-action/upload-sarif@601d5b1bcb3e5ef5eea97a6d0dcdbbb8c2b80116
       with:
         sarif_file: cifuzz-sarif/results.sarif
         category: fuzz-${{ matrix.sanitizer }}

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,38 @@
+name: CIFuzz
+on:
+  pull_request:
+    paths:
+      - '**'
+  push:
+    branches: [main, master]
+permissions:
+  contents: read
+jobs:
+  fuzzing:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'validator'
+        language: go
+        sanitizer: ${{ matrix.sanitizer }}
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'validator'
+        language: go
+        fuzz-seconds: 300
+        sanitizer: ${{ matrix.sanitizer }}
+        output-sarif: true
+    - name: Upload Sarif
+      if: always() && steps.build.outcome == 'success'
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: cifuzz-sarif/results.sarif
+        category: fuzz-${{ matrix.sanitizer }}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,42 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) 2015 Dean Karn
+// SPDX-License-Identifier: MIT
+
+package validator_test
+
+import (
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// FuzzValidatorStruct validates arbitrary struct field values
+// against validation tags. The validator processes user input
+// through struct tags — a bug here can bypass validation.
+//
+// Validator has 20K+ GitHub stars and is the standard Go
+// struct validation library.
+func FuzzValidatorStruct(f *testing.F) {
+	validate := validator.New()
+
+	f.Add("test@example.com", "email")
+	f.Add("123", "gte=0,lte=100")
+	f.Add("", "required")
+	f.Add("not-a-url", "url")
+
+	f.Fuzz(func(t *testing.T, value, tag string) {
+		if len(value) > 10000 || len(tag) > 10000 {
+			return
+		}
+
+		type testStruct struct {
+			Field string `validate:"%s"`
+		}
+
+		// Validate must never panic
+		s := testStruct{Field: value}
+		_ = validate.Struct(s)
+	})
+}


### PR DESCRIPTION
Adds Go native fuzz target for OSS-Fuzz integration. Validator (20K stars) is the standard Go struct validation library.