### PR TITLE
fix(ssn): reject mixed separators in SSN validation

### DIFF
--- a/regexes.go
+++ b/regexes.go
@@ -55,7 +55,7 @@ const (
 	dataURIRegexString               = `^data:((?:\w+\/(?:([^;]|;[^;]).)+)?)`
 	latitudeRegexString              = "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?)$"
 	longitudeRegexString             = "^[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
-	sSNRegexString                   = `^[0-9]{3}[ -]?(0[1-9]|[1-9][0-9])[ -]?([1-9][0-9]{3}|[0-9][1-9][0-9]{2}|[0-9]{2}[1-9][0-9]|[0-9]{3}[1-9])$`
+	sSNRegexString                   = `^(?:[0-9]{3}-(?:0[1-9]|[1-9][0-9])-(?:[1-9][0-9]{3}|[0-9][1-9][0-9]{2}|[0-9]{2}[1-9][0-9]|[0-9]{3}[1-9])|[0-9]{3} (?:0[1-9]|[1-9][0-9]) (?:[1-9][0-9]{3}|[0-9][1-9][0-9]{2}|[0-9]{2}[1-9][0-9]|[0-9]{3}[1-9]))$`
 	hostnameRegexStringRFC952        = `^[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$`                     // https://tools.ietf.org/html/rfc952
 	hostnameRegexStringRFC1123       = `^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$`                  // accepts hostname starting with a digit https://tools.ietf.org/html/rfc1123
 	fqdnRegexStringRFC1123           = `^([a-zA-Z0-9]{1}[a-zA-Z0-9-]{0,62})(\.[a-zA-Z0-9]{1}[a-zA-Z0-9-]{0,62})*?(\.[a-zA-Z]{1}[a-zA-Z0-9-]{0,62})\.?$` // same as hostnameRegexStringRFC1123 but must contain a non numerical TLD (possibly ending with '.')

--- a/validator_test.go
+++ b/validator_test.go
@@ -3913,6 +3913,15 @@ func TestSSNValidation(t *testing.T) {
 		{"66690-76", false},
 		{"191 60 2869", true},
 		{"191-60-2869", true},
+		// mixed separators must be rejected
+		{"191-60 2869", false},
+		{"191 60-2869", false},
+		// group number 00 must be rejected
+		{"191-00-2869", false},
+		{"191 00 2869", false},
+		// serial number 0000 must be rejected
+		{"191-60-0000", false},
+		{"191 60 0000", false},
 	}
 
 	validate := New()


### PR DESCRIPTION
## Bug

The `ssn` validator used `[ -]?` independently for each separator position, which allowed mixed-separator formats to pass validation:

- `191-60 2869` (hyphen then space) - incorrectly accepted
- `191 60-2869` (space then hyphen) - incorrectly accepted

Social security numbers use a single consistent separator throughout: either all hyphens (`NNN-NN-NNNN`) or all spaces (`NNN NN NNNN`). Mixed formats are not valid.

Fixes #1272.

## Fix

Replace the single regex with alternation so both separator positions are constrained to the same character:

**Before:**
```
^[0-9]{3}[ -]?(0[1-9]|[1-9][0-9])[ -]?(...)$
```

**After:**
```
^(?:[0-9]{3}-(?:0[1-9]|[1-9][0-9])-(?:...)|[0-9]{3} (?:0[1-9]|[1-9][0-9]) (?:...))$
```

The length pre-check in `baked_in.go` (`field.Len() != 11`) is unchanged and remains a valid fast path.

## Reproduction

```go
validate := validator.New()
err := validate.Var("191-60 2869", "ssn") // was nil (bug), now returns error
err  = validate.Var("191 60-2869", "ssn") // was nil (bug), now returns error
err  = validate.Var("191-60-2869", "ssn") // still nil (valid)
err  = validate.Var("191 60 2869", "ssn") // still nil (valid)
```

## Tests

Added six new table-driven cases to `TestSSNValidation` covering mixed separators, zero group number, and zero serial number.