### PR TITLE
fix: use idiomatic "at most" in English max/lte messages

### DIFF
--- a/translations/en/en.go
+++ b/translations/en/en.go
@@ -310,7 +310,7 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 					return
 				}
 
-				if err = ut.Add("max-items", "{0} must contain at maximum {1}", false); err != nil {
+				if err = ut.Add("max-items", "{0} must contain at most {1}", false); err != nil {
 					return
 				}
 				if err = ut.AddCardinal("max-items-item", "{0} item", locales.PluralRuleOne, false); err != nil {
@@ -548,7 +548,7 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 		{
 			tag: "lte",
 			customRegisFunc: func(ut ut.Translator) (err error) {
-				if err = ut.Add("lte-string", "{0} must be at maximum {1} in length", false); err != nil {
+				if err = ut.Add("lte-string", "{0} must be at most {1} in length", false); err != nil {
 					return
 				}
 
@@ -564,7 +564,7 @@ func RegisterDefaultTranslations(v *validator.Validate, trans ut.Translator) (er
 					return
 				}
 
-				if err = ut.Add("lte-items", "{0} must contain at maximum {1}", false); err != nil {
+				if err = ut.Add("lte-items", "{0} must contain at most {1}", false); err != nil {
 					return
 				}
 

--- a/translations/en/en_test.go
+++ b/translations/en/en_test.go
@@ -616,7 +616,7 @@ func TestTranslations(t *testing.T) {
 		},
 		{
 			ns:       "Test.LteString",
-			expected: "LteString must be at maximum 3 characters in length",
+			expected: "LteString must be at most 3 characters in length",
 		},
 		{
 			ns:       "Test.LteNumber",
@@ -624,7 +624,7 @@ func TestTranslations(t *testing.T) {
 		},
 		{
 			ns:       "Test.LteMultiple",
-			expected: "LteMultiple must contain at maximum 2 items",
+			expected: "LteMultiple must contain at most 2 items",
 		},
 		{
 			ns:       "Test.LteTime",
@@ -680,7 +680,7 @@ func TestTranslations(t *testing.T) {
 		},
 		{
 			ns:       "Test.MaxMultiple",
-			expected: "MaxMultiple must contain at maximum 7 items",
+			expected: "MaxMultiple must contain at most 7 items",
 		},
 		{
 			ns:       "Test.MinString",
@@ -784,7 +784,7 @@ func TestTranslations(t *testing.T) {
 		},
 		{
 			ns:       "Test.StrPtrLte",
-			expected: "StrPtrLte must be at maximum 1 character in length",
+			expected: "StrPtrLte must be at most 1 character in length",
 		},
 		{
 			ns:       "Test.StrPtrGt",


### PR DESCRIPTION
## Fixes Or Enhances

Fixes #1249.

English defaults for `max-items`, `lte-items`, and `lte-string` used "at maximum", which is unidiomatic. They now use "at most", matching the existing "at least" wording used by min/gte and the language already used in `doc.go` for max string length ("at most").

`max-string` already uses the correct phrase "a maximum of" and is left unchanged.

The same sibling scope (max-items together with related upper-bound item messages) has landed before in translation work such as #1250 for Japanese.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

Validation:
- On base `53a4402`, updated expectations alone fail because the library still emits "at maximum"
- `go test ./translations/en` passes on this branch
- `CGO_ENABLED=0 go test -cover ./...` passes (root package coverage 95.2%; `-race` not run on this host for lack of CGO)

@go-playground/validator-maintainers
