### PR TITLE
fix(fqdn): enforce maximum DNS name length

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -2917,7 +2917,7 @@ func isHostnameRFC1123(fl FieldLevel) bool {
 func isFQDN(fl FieldLevel) bool {
 	val := fl.Field().String()
 
-	if val == "" {
+	if val == "" || len(strings.TrimSuffix(val, ".")) > 253 {
 		return false
 	}
 
@@ -3531,4 +3531,3 @@ var (
 	errMethodReturnNoValues    = errors.New(`method return o values (void)`)
 	errMethodReturnInvalidType = errors.New(`method should return invalid type`)
 )
-

--- a/validator_test.go
+++ b/validator_test.go
@@ -11168,6 +11168,8 @@ func TestHostnameRFC1123AliasValidation(t *testing.T) {
 }
 
 func TestFQDNValidation(t *testing.T) {
+	maxFQDN := strings.Repeat(strings.Repeat("a", 63)+".", 3) + strings.Repeat("a", 61)
+
 	tests := []struct {
 		param    string
 		expected bool
@@ -11185,6 +11187,10 @@ func TestFQDNValidation(t *testing.T) {
 		{"24.example24.com", true},
 		{"test.24.example.com", true},
 		{"test-site-http.test-site", true},
+		{maxFQDN, true},
+		{maxFQDN + ".", true},
+		{maxFQDN + "a", false},
+		{maxFQDN + "a.", false},
 		{"test24.example24.com..", false},
 		{"example", false},
 		{"192.168.0.1", false},


### PR DESCRIPTION
## Fixes Or Enhances

Fixes #1602.

The `fqdn` validator limited each individual label to 63 characters but did not enforce the 255-octet DNS wire-format limit for the complete name. As a result, syntactically valid labels could be repeated until the resulting domain exceeded the maximum DNS name length.

This change rejects FQDNs whose presentation form exceeds 253 characters, excluding the optional trailing root dot. It preserves support for a 254-character absolute FQDN when the final character is the root dot.

Boundary tests cover valid and invalid names both with and without the trailing dot.

Validation performed:

```text
go test ./... -count=1
```

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers
