### PR TITLE
docs: fix ISO 3166-1 numeric validator usage

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1469,12 +1469,12 @@ see: https://www.iso.org/iso-3166-country-codes.html
 
 	Usage: iso3166_1_alpha3
 
-# Iso3166-1 alpha-numeric
+# ISO 3166-1 numeric
 
-This validates that a string value is a valid country code based on iso3166-1 alpha-numeric standard.
+This validates that a string value is a valid country code based on the ISO 3166-1 numeric standard.
 see: https://www.iso.org/iso-3166-country-codes.html
 
-	Usage: iso3166_1_alpha3
+	Usage: iso3166_1_alpha_numeric
 
 # BCP 47 Language Tag
 


### PR DESCRIPTION
## What does this PR do?

Corrects the ISO 3166-1 numeric validator documentation:

- uses the standard “ISO 3166-1 numeric” terminology
- replaces the incorrect `iso3166_1_alpha3` usage example with `iso3166_1_alpha_numeric`

## Tests

- [x] `go test ./...`
- [x] `git diff --check`

AI assistance was used to identify and prepare this documentation correction. I reviewed the change and ran the complete Go test suite.