### PR TITLE
docs: clarify fieldexcludes behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ validate := validator.New(validator.WithRequiredStructEnabled())
 | eqcsfield | Field Equals Another Field (relative)|
 | eqfield | Field Equals Another Field |
 | fieldcontains | Check the indicated characters are present in the Field |
-| fieldexcludes | Check the indicated characters are not present in the field |
+| fieldexcludes | Current field does not contain another field's value |
 | gtcsfield | Field Greater Than Another Relative Field |
 | gtecsfield | Field Greater Than or Equal To Another Relative Field |
 | gtefield | Field Greater Than or Equal To Another Field |

--- a/doc.go
+++ b/doc.go
@@ -803,13 +803,14 @@ other types.
 
 	Usage: containsfield=InnerStructField.Field
 
-# Field Excludes Another Field
+# Field Excludes Another Field's Value
 
-This does the same as excludes except for struct fields. It should only be used
-with string types. See the behavior of reflect.Value.String() for behavior on
-other types.
+This validates that the current field's string value does not contain the
+string value of the field named by the parameter. It should only be used with
+string types. If the referenced field cannot be resolved, validation succeeds.
+See the behavior of reflect.Value.String() for behavior on other types.
 
-	Usage: excludesfield=InnerStructField.Field
+	Usage: fieldexcludes=InnerStructField.Field
 
 # Unique
 


### PR DESCRIPTION
## Fixes Or Enhances

Fixes #663.

Clarifies the `fieldexcludes` documentation to match the current implementation:

- the parameter names another struct field;
- validation checks that the current field's string value does not contain that field's value;
- validation succeeds when the referenced field cannot be resolved;
- the package documentation now uses the registered `fieldexcludes` tag instead of the nonexistent `excludesfield` spelling.

No runtime behavior or public API changes.

### Verification

- `go test -run '^TestFieldExcludes$' .`
- `make test`
- `golangci-lint v2.12.2 run`
- `go doc .`

### AI assistance disclosure

AI assistance was used to search for a non-duplicated contribution candidate, inspect the implementation and existing tests, draft the documentation wording, and run verification commands.

Affected files: `README.md` and `doc.go`.

Human validation required before submission: review the final two-file diff, confirm the wording matches `fieldExcludes` and `TestFieldExcludes`, and confirm the commands above passed. The contributor remains responsible for the change and should be able to explain it without AI assistance.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist that cover this behavior (`TestFieldExcludes`).

@go-playground/validator-maintainers
