### PR TITLE
fix: reject non-digit characters in cve validator sequence number

### DIFF
--- a/regexes.go
+++ b/regexes.go
@@ -74,7 +74,7 @@ const (
 	bic2022RegexString               = `^[A-Z0-9]{4}[A-Z]{2}[A-Z0-9]{2}(?:[A-Z0-9]{3})?$`
 	semverRegexString                = `^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$` // numbered capture groups https://semver.org/
 	dnsRegexStringRFC1035Label       = "^[a-z]([-a-z0-9]*[a-z0-9])?$"
-	cveRegexString                   = `^CVE-(1999|2\d{3})-(0[^0]\d{2}|0\d[^0]\d{1}|0\d{2}[^0]|[1-9]{1}\d{3,})$` // CVE Format Id https://cve.mitre.org/cve/identifiers/syntaxchange.html
+	cveRegexString                   = `^CVE-(1999|2\d{3})-(0[1-9]\d{2}|0\d[1-9]\d{1}|0\d{2}[1-9]|[1-9]{1}\d{3,})$` // CVE Format Id https://cve.mitre.org/cve/identifiers/syntaxchange.html
 	mongodbIdRegexString             = "^[a-f\\d]{24}$"
 	mongodbConnStringRegexString     = "^mongodb(\\+srv)?:\\/\\/(([a-zA-Z\\d]+):([a-zA-Z\\d$:\\/?#\\[\\]@]+)@)?(([a-z\\d.-]+)(:[\\d]+)?)((,(([a-z\\d.-]+)(:(\\d+))?))*)?(\\/[a-zA-Z-_]{1,64})?(\\?(([a-zA-Z]+)=([a-zA-Z\\d]+))(&(([a-zA-Z\\d]+)=([a-zA-Z\\d]+))?)*)?$"
 	cronRegexString                  = `^((@(annually|yearly|monthly|weekly|daily|hourly|reboot))|(@every (\d+(ns|us|µs|ms|s|m|h))+)|(([A-Za-z0-9*?][A-Za-z0-9*?/,#L-]+|[*?0-9])( +([A-Za-z0-9*?][A-Za-z0-9*?/,#L-]+|[*?0-9])){4,6}))$`

--- a/validator_test.go
+++ b/validator_test.go
@@ -14565,6 +14565,10 @@ func TestCveFormatValidation(t *testing.T) {
 		{"CVE-3000-0001", "cve", false},
 		{"CVE-1999-0000", "cve", false},
 		{"CVE-2099-0000", "cve", false},
+		{"CVE-2020-0a00", "cve", false},
+		{"CVE-2020-0/00", "cve", false},
+		{"CVE-2020-00a0", "cve", false},
+		{"CVE-2020-000z", "cve", false},
 	}
 
 	validate := New()


### PR DESCRIPTION
The `cve` validator's regex uses `[^0]` (any character except `0`) in the three leading-zero sequence-number branches, where a non-zero **digit** `[1-9]` was intended — every other branch uses `\d` or `[1-9]`. So a sequence number containing a non-digit passes validation:

```
CVE-2020-0a00   valid  ❌
CVE-2020-0/00   valid  ❌
CVE-2020-00a0   valid  ❌
CVE-2020-000z   valid  ❌
```

A CVE ID's sequence number is decimal digits only (the syntax page linked in the code comment). Replacing `[^0]` with `[1-9]` in the three branches rejects the non-digit cases; the digit-only sequences those branches already matched are unchanged, so the existing tests still pass. Added the non-digit cases to `TestCveFormatValidation`.
