### PR TITLE
Add uuid7 validation tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ validate := validator.New(validator.WithRequiredStructEnabled())
 | uuid4_rfc4122 | Universally Unique Identifier UUID v4 RFC4122 |
 | uuid5 | Universally Unique Identifier UUID v5 |
 | uuid5_rfc4122 | Universally Unique Identifier UUID v5 RFC4122 |
+| uuid7 | Universally Unique Identifier UUID v7 |
 | uuid_rfc4122 | Universally Unique Identifier UUID RFC4122 |
 | md4 | MD4 hash |
 | md5 | MD5 hash |

--- a/baked_in.go
+++ b/baked_in.go
@@ -175,6 +175,7 @@ var (
 		"uuid3":                         isUUID3,
 		"uuid4":                         isUUID4,
 		"uuid5":                         isUUID5,
+		"uuid7":                         isUUID7,
 		"uuid_rfc4122":                  isUUIDRFC4122,
 		"uuid3_rfc4122":                 isUUID3RFC4122,
 		"uuid4_rfc4122":                 isUUID4RFC4122,
@@ -644,6 +645,11 @@ func isASCII(fl FieldLevel) bool {
 // isUUID5 is the validation function for validating if the field's value is a valid v5 UUID.
 func isUUID5(fl FieldLevel) bool {
 	return fieldMatchesRegexByStringerValOrString(uUID5Regex, fl)
+}
+
+// isUUID7 is the validation function for validating if the field's value is a valid v7 UUID.
+func isUUID7(fl FieldLevel) bool {
+	return fieldMatchesRegexByStringerValOrString(uUID7Regex, fl)
 }
 
 // isUUID4 is the validation function for validating if the field's value is a valid v4 UUID.

--- a/doc.go
+++ b/doc.go
@@ -1205,6 +1205,12 @@ This validates that a string value contains a valid version 5 UUID.  Uppercase U
 
 	Usage: uuid5
 
+# Universally Unique Identifier UUID v7
+
+This validates that a string value contains a valid version 7 UUID (RFC 9562). Uppercase UUID values will not pass.
+
+	Usage: uuid7
+
 # Universally Unique Lexicographically Sortable Identifier ULID
 
 This validates that a string value contains a valid ULID value.

--- a/regexes.go
+++ b/regexes.go
@@ -33,6 +33,7 @@ const (
 	uUID3RegexString                 = "^[0-9a-f]{8}-[0-9a-f]{4}-3[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$"
 	uUID4RegexString                 = "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
 	uUID5RegexString                 = "^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+	uUID7RegexString                 = "^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
 	uUIDRegexString                  = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 	uUID3RFC4122RegexString          = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-3[0-9a-fA-F]{3}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 	uUID4RFC4122RegexString          = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
@@ -123,6 +124,7 @@ var (
 	uUID3Regex                 = lazyRegexCompile(uUID3RegexString)
 	uUID4Regex                 = lazyRegexCompile(uUID4RegexString)
 	uUID5Regex                 = lazyRegexCompile(uUID5RegexString)
+	uUID7Regex                 = lazyRegexCompile(uUID7RegexString)
 	uUIDRegex                  = lazyRegexCompile(uUIDRegexString)
 	uUID3RFC4122Regex          = lazyRegexCompile(uUID3RFC4122RegexString)
 	uUID4RFC4122Regex          = lazyRegexCompile(uUID4RFC4122RegexString)

--- a/validator_test.go
+++ b/validator_test.go
@@ -4223,6 +4223,43 @@ func TestUUID5Validation(t *testing.T) {
 	}
 }
 
+func TestUUID7Validation(t *testing.T) {
+	tests := []struct {
+		param    string
+		expected bool
+	}{
+		{"", false},
+		{"xxxa987fbc9-4bed-3078-cf07-9141ba07c9f3", false},
+		{"a987fbc9-4bed-3078-cf07-9141ba07c9f3", false},
+		{"57b73598-8764-4ad0-a76a-679bb6640eb1", false},
+		{"018f6c1a-2a3b-7c4d-ce5f-1a2b3c4d5e6f", false},
+		{"018F6C1A-2A3B-7C4D-8E5F-1A2B3C4D5E6F", false},
+		{"017f22e2-79b0-7cc3-98c4-dc0c0c07398f", true},
+		{"018f6c1a-2a3b-7c4d-8e5f-1a2b3c4d5e6f", true},
+	}
+
+	validate := New()
+
+	for i, test := range tests {
+		errs := validate.Var(test.param, "uuid7")
+
+		if test.expected {
+			if !IsEqual(errs, nil) {
+				t.Fatalf("Index: %d UUID7 failed Error: %s", i, errs)
+			}
+		} else {
+			if IsEqual(errs, nil) {
+				t.Fatalf("Index: %d UUID7 failed Error: %s", i, errs)
+			} else {
+				val := getError(errs, "", "")
+				if val.Tag() != "uuid7" {
+					t.Fatalf("Index: %d UUID7 failed Error: %s", i, errs)
+				}
+			}
+		}
+	}
+}
+
 func TestUUID4Validation(t *testing.T) {
 	tests := []struct {
 		param    string


### PR DESCRIPTION
## What type of PR is this?

- feature

## What this PR does / why we need it:

Adds a built-in `uuid7` validation tag for version 7 UUIDs (RFC 9562).

The library already validates UUID versions 3, 4 and 5, but there's no tag
for v7. UUIDv7 has become common as a time-ordered, index-friendly primary
key, so it's a natural addition to the existing set.

Changes, following the exact shape of the existing `uuid5` support:

- `regexes.go`: add `uUID7RegexString` / `uUID7Regex`. Same pattern as v4/v5
  with the version nibble pinned to `7` and the RFC 4122/9562 variant nibble
  `[89ab]`.
- `baked_in.go`: add `isUUID7` and register the `uuid7` tag.
- `doc.go` and `README.md`: document the new tag.

Like `uuid4`/`uuid5`, `uuid7` accepts lowercase hex only. I left a
case-insensitive `uuid7_rfc4122`-style variant out of this PR to keep it
focused and because the right name for it (given v7 is defined in RFC 9562,
not 4122) is a call I'd rather leave to you — happy to add it in a follow-up.

## Which issue(s) this PR fixes:

Fixes #1595

## Testing

Added `TestUUID7Validation` mirroring the existing UUID tests: empty input,
garbage prefix, wrong-version UUIDs (v3/v4), an invalid variant nibble, an
uppercase value (rejected), and two valid v7 values. `go test ./...` passes;
`go vet` is clean.

## Release Notes

```release-note
Add `uuid7` validation tag for RFC 9562 version 7 UUIDs.
```
