### PR TITLE
test: add TestInvalidValidationError and fix doc typos in errors.go

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -17,7 +17,7 @@ const (
 type ValidationErrorsTranslations map[string]string
 
 // InvalidValidationError describes an invalid argument passed to
-// `Struct`, `StructExcept`, StructPartial` or `Field`
+// `Struct`, `StructExcept`, `StructPartial` or `Field`
 type InvalidValidationError struct {
 	Type reflect.Type
 }
@@ -99,7 +99,7 @@ type FieldError interface {
 	// See StructNamespace() for a version that returns actual names.
 	//
 	// NOTE: this field can be blank when validating a single primitive field
-	// using validate.Field(...) as there is no way to extract it's name
+	// using validate.Field(...) as there is no way to extract its name
 	Namespace() string
 
 	// StructNamespace returns the namespace for the field error, with the field's

--- a/validator_test.go
+++ b/validator_test.go
@@ -16767,3 +16767,22 @@ func TestValuerInterface(t *testing.T) {
 		}
 	})
 }
+
+func TestInvalidValidationError(t *testing.T) {
+	err := &InvalidValidationError{}
+	if err.Error() != "validator: (nil)" {
+		t.Fatalf("expected 'validator: (nil)', got %q", err.Error())
+	}
+
+	err = &InvalidValidationError{Type: reflect.TypeOf(123)}
+	if err.Error() != "validator: (nil int)" {
+		t.Fatalf("expected 'validator: (nil int)', got %q", err.Error())
+	}
+
+	v := New()
+	valErr := v.Struct(nil)
+	if _, ok := valErr.(*InvalidValidationError); !ok {
+		t.Fatalf("expected *InvalidValidationError for nil struct, got %T: %v", valErr, valErr)
+	}
+}
+


### PR DESCRIPTION
### Summary
- In `validator_test.go`, add unit test `TestInvalidValidationError` verifying `InvalidValidationError.Error()` output formats (for nil type and typed nil) and ensuring `v.Struct(nil)` yields `*InvalidValidationError`.
- Fix minor doc comment typos in `errors.go` (missing backtick around `` `StructPartial` `` and `it's name` -> `its name`).