### PR TITLE
feat: Add hostname label validation tag

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -2916,7 +2916,48 @@ func isHostnameRFC1123(fl FieldLevel) bool {
 }
 
 func isHostnameLabel(fl FieldLevel) bool {
-	return hostnameLabelRegex().MatchString(fl.Field().String())
+	v := fl.Field().String()
+
+	const maxLabelLength = 63
+
+	// ASCII only.
+	isLetter := func(c byte) bool {
+		return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+	}
+
+	// ASCII only.
+	isDigit := func(c byte) bool {
+		return (c >= '0' && c <= '9')
+	}
+
+	valueLen := len(v)
+
+	// The empty label is not a valid label
+	if valueLen <= 0 || valueLen > maxLabelLength {
+		return false
+	}
+
+	firstChar := v[0]
+
+	if !isLetter(firstChar) && !isDigit(firstChar) {
+		return false
+	}
+
+	for i := range valueLen - 2 {
+		c := v[i+1]
+
+		if !isLetter(c) && !isDigit(c) && c != '-' {
+			return false
+		}
+	}
+
+	lastChar := v[valueLen-1]
+
+	if !isLetter(lastChar) && !isDigit(lastChar) {
+		return false
+	}
+
+	return true
 }
 
 func isFQDN(fl FieldLevel) bool {

--- a/baked_in.go
+++ b/baked_in.go
@@ -217,6 +217,7 @@ var (
 		"mac":                           isMAC,
 		"hostname":                      isHostnameRFC952,  // RFC 952
 		"hostname_rfc1123":              isHostnameRFC1123, // RFC 1123
+		"hostname_label":                isHostnameLabel,
 		"fqdn":                          isFQDN,
 		"unique":                        isUnique,
 		"oneof":                         isOneOf,
@@ -2912,6 +2913,10 @@ func isHostnameRFC952(fl FieldLevel) bool {
 
 func isHostnameRFC1123(fl FieldLevel) bool {
 	return hostnameRegexRFC1123().MatchString(fl.Field().String())
+}
+
+func isHostnameLabel(fl FieldLevel) bool {
+	return hostnameLabelRegex().MatchString(fl.Field().String())
 }
 
 func isFQDN(fl FieldLevel) bool {

--- a/doc.go
+++ b/doc.go
@@ -563,7 +563,6 @@ Kind of like an 'enum'.
 	       noneof='red green' 'blue yellow'
 		   noneof=5 7 9
 
-
 # None Of Case Insensitive
 Works the same as noneof but is case insensitive and therefore only accepts strings.
 
@@ -1389,6 +1388,13 @@ This validates that a string value is a valid Hostname according to RFC 952 http
 This validates that a string value is a valid Hostname according to RFC 1123 https://tools.ietf.org/html/rfc1123
 
 	Usage: hostname_rfc1123 or if you want to continue to use 'hostname' in your tags, create an alias.
+
+# Hostname Label
+
+This validates that a string value is a valid hostname label (The 'label' in 'label.domain.name') according to
+RFC 1123 https://tools.ietf.org/rfc1123.
+
+	Usage: hostname_label
 
 Full Qualified Domain Name (FQDN)
 

--- a/regexes.go
+++ b/regexes.go
@@ -56,8 +56,9 @@ const (
 	latitudeRegexString              = "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?)$"
 	longitudeRegexString             = "^[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
 	sSNRegexString                   = `^[0-9]{3}[ -]?(0[1-9]|[1-9][0-9])[ -]?([1-9][0-9]{3}|[0-9][1-9][0-9]{2}|[0-9]{2}[1-9][0-9]|[0-9]{3}[1-9])$`
-	hostnameRegexStringRFC952        = `^[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$`                     // https://tools.ietf.org/html/rfc952
-	hostnameRegexStringRFC1123       = `^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$`                  // accepts hostname starting with a digit https://tools.ietf.org/html/rfc1123
+	hostnameRegexStringRFC952        = `^[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$`    // https://tools.ietf.org/html/rfc952
+	hostnameRegexStringRFC1123       = `^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$` // accepts hostname starting with a digit https://tools.ietf.org/html/rfc1123
+	hostnameLabelRegexString         = `^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`
 	fqdnRegexStringRFC1123           = `^([a-zA-Z0-9]{1}[a-zA-Z0-9-]{0,62})(\.[a-zA-Z0-9]{1}[a-zA-Z0-9-]{0,62})*?(\.[a-zA-Z]{1}[a-zA-Z0-9-]{0,62})\.?$` // same as hostnameRegexStringRFC1123 but must contain a non numerical TLD (possibly ending with '.')
 	btcAddressRegexString            = `^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$`                                                                              // bitcoin address
 	btcAddressUpperRegexStringBech32 = `^BC1[02-9AC-HJ-NP-Z]{7,76}$`                                                                                    // bitcoin bech32 address https://en.bitcoin.it/wiki/Bech32
@@ -148,6 +149,7 @@ var (
 	sSNRegex                   = lazyRegexCompile(sSNRegexString)
 	hostnameRegexRFC952        = lazyRegexCompile(hostnameRegexStringRFC952)
 	hostnameRegexRFC1123       = lazyRegexCompile(hostnameRegexStringRFC1123)
+	hostnameLabelRegex         = lazyRegexCompile(hostnameLabelRegexString)
 	fqdnRegexRFC1123           = lazyRegexCompile(fqdnRegexStringRFC1123)
 	btcAddressRegex            = lazyRegexCompile(btcAddressRegexString)
 	btcUpperAddressRegexBech32 = lazyRegexCompile(btcAddressUpperRegexStringBech32)

--- a/regexes.go
+++ b/regexes.go
@@ -56,9 +56,8 @@ const (
 	latitudeRegexString              = "^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?)$"
 	longitudeRegexString             = "^[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)$"
 	sSNRegexString                   = `^[0-9]{3}[ -]?(0[1-9]|[1-9][0-9])[ -]?([1-9][0-9]{3}|[0-9][1-9][0-9]{2}|[0-9]{2}[1-9][0-9]|[0-9]{3}[1-9])$`
-	hostnameRegexStringRFC952        = `^[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$`    // https://tools.ietf.org/html/rfc952
-	hostnameRegexStringRFC1123       = `^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$` // accepts hostname starting with a digit https://tools.ietf.org/html/rfc1123
-	hostnameLabelRegexString         = `^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`
+	hostnameRegexStringRFC952        = `^[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$`                     // https://tools.ietf.org/html/rfc952
+	hostnameRegexStringRFC1123       = `^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$`                  // accepts hostname starting with a digit https://tools.ietf.org/html/rfc1123
 	fqdnRegexStringRFC1123           = `^([a-zA-Z0-9]{1}[a-zA-Z0-9-]{0,62})(\.[a-zA-Z0-9]{1}[a-zA-Z0-9-]{0,62})*?(\.[a-zA-Z]{1}[a-zA-Z0-9-]{0,62})\.?$` // same as hostnameRegexStringRFC1123 but must contain a non numerical TLD (possibly ending with '.')
 	btcAddressRegexString            = `^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$`                                                                              // bitcoin address
 	btcAddressUpperRegexStringBech32 = `^BC1[02-9AC-HJ-NP-Z]{7,76}$`                                                                                    // bitcoin bech32 address https://en.bitcoin.it/wiki/Bech32
@@ -149,7 +148,6 @@ var (
 	sSNRegex                   = lazyRegexCompile(sSNRegexString)
 	hostnameRegexRFC952        = lazyRegexCompile(hostnameRegexStringRFC952)
 	hostnameRegexRFC1123       = lazyRegexCompile(hostnameRegexStringRFC1123)
-	hostnameLabelRegex         = lazyRegexCompile(hostnameLabelRegexString)
 	fqdnRegexRFC1123           = lazyRegexCompile(fqdnRegexStringRFC1123)
 	btcAddressRegex            = lazyRegexCompile(btcAddressRegexString)
 	btcUpperAddressRegexBech32 = lazyRegexCompile(btcAddressUpperRegexStringBech32)

--- a/validator_test.go
+++ b/validator_test.go
@@ -11167,6 +11167,55 @@ func TestHostnameRFC1123AliasValidation(t *testing.T) {
 	}
 }
 
+func TestHostnameLabelValidation(t *testing.T) {
+	tests := []struct {
+		param    string
+		expected bool
+	}{
+		{"", false},
+		{"test", true},
+		{"2example", true},
+		{"example2", true},
+		{"57", true},
+		{"a.b.c", false},
+		{"complete.domain.name", false},
+		{"example.com", false},
+		{"1.test.com", false},
+		{"-invalid", false},
+		{"invalid-", false},
+		{".invalid", false},
+		{"invalid.", false},
+		{"192.168.0.1", false},
+		{"luznoceda", true},
+		{"akkoxdiana", true},
+		{"example-label", true},
+		{"example:80", false},
+		{"a$b", false},
+		{"this-is-another-deliberately-overlong-subdomain-used-for-boundary-test", false},
+	}
+
+	validate := New()
+
+	for i, test := range tests {
+		errs := validate.Var(test.param, "hostname_label")
+
+		if test.expected {
+			if !IsEqual(errs, nil) {
+				t.Fatalf("Hostname Label: %v failed Error: %v", test, errs)
+			}
+		} else {
+			if IsEqual(errs, nil) {
+				t.Fatalf("Hostname Label: %v failed Error: %v", test, errs)
+			} else {
+				val := getError(errs, "", "")
+				if val.Tag() != "hostname_label" {
+					t.Fatalf("Hostname Label: %v failed Error: %v", i, errs)
+				}
+			}
+		}
+	}
+}
+
 func TestFQDNValidation(t *testing.T) {
 	maxFQDN := strings.Repeat(strings.Repeat("a", 63)+".", 3) + strings.Repeat("a", 61)
 


### PR DESCRIPTION
## Fixes Or Enhances

Add `hostname_label` validation tag. Resolves #1543.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers