### PR TITLE
ci: Fix the linter version

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -40,4 +40,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.13.1

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 _obj
 _test
 bin
+.gocache/
+.gomodcache/
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,6 +14,7 @@ linters:
     - errorlint
     - exhaustive
     - exhaustruct
+    - exhaustruct_v5
     - forbidigo
     - forcetypeassert
     - funlen

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GOCMD=go
 linters-install:
 	@golangci-lint --version >/dev/null 2>&1 || { \
 		echo "installing linting tools..."; \
-		curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v2.0.2; \
+		curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v2.13.1; \
 	}
 
 lint: linters-install


### PR DESCRIPTION
# Fixes

`golangci-lint` has been pinned to the latest version. The latest version added `exhaustruct_v5` which is an upgrade from `exhaustruct` that we have disabled. 

With the PR we:
- disable the linter
- pin `golangci-lint` version so new things don't get added without us knowing

