### PR TITLE
lint: disable exhaustruct_v5 linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,6 +4,7 @@ linters:
   disable:
     - noinlineerr
     - wsl_v5
+    - exhaustruct_v5
     - copyloopvar
     - cyclop
     - depguard


### PR DESCRIPTION
## Fixes Or Enhances

The latest `golangci-lint` ships versioned analyzer aliases (e.g. exhaustruct_v5) alongside the base name. Disabling `exhaustruct` alone doesn't suppress it, since golangci-lint run reports findings under exhaustruct_v5.

Fixing GHA linter errors:
https://github.com/go-playground/validator/actions/runs/33327944360/job/99301313089
```
Running [/home/runner/golangci-lint-2.13.2-linux-amd64/golangci-lint config path] in [/home/runner/work/validator/validator] ...
  Running [/home/runner/golangci-lint-2.13.2-linux-amd64/golangci-lint config verify] in [/home/runner/work/validator/validator] ...
  Running [/home/runner/golangci-lint-2.13.2-linux-amd64/golangci-lint run] in [/home/runner/work/validator/validator] ...
  Error: benchmarks_test.go:192:74: validator.valuer is missing field Name (exhaustruct_v5)
  	validate.RegisterCustomTypeFunc(ValidateValuerType, (*sql.Valuer)(nil), valuer{})
...
```

@go-playground/validator-maintainers