### PR TITLE
Align excluded_without with its stated multi-field contract

### DIFF
--- a/baked_in.go
+++ b/baked_in.go
@@ -2253,8 +2253,11 @@ func requiredWithAll(fl FieldLevel) bool {
 // excludedWithout is the validation function
 // The field under validation must not be present or is empty when any of the other specified fields are not present.
 func excludedWithout(fl FieldLevel) bool {
-	if requireCheckFieldKind(fl, strings.TrimSpace(fl.Param()), true) {
-		return !hasValue(fl)
+	params := parseOneOfParam2(fl.Param())
+	for _, param := range params {
+		if requireCheckFieldKind(fl, param, true) {
+			return !hasValue(fl)
+		}
 	}
 	return true
 }

--- a/validator_test.go
+++ b/validator_test.go
@@ -12829,6 +12829,36 @@ func TestExcludedWithout(t *testing.T) {
 
 	errs = validate.Struct(test3)
 	Equal(t, errs, nil)
+
+	// Multiple parameters: the field is excluded only when one of them is absent.
+	test4 := struct {
+		Field1 string `validate:"excluded_without=Field2 Field3" json:"field_1"`
+		Field2 string `json:"field_2"`
+		Field3 string `json:"field_3"`
+	}{
+		Field1: "test",
+		Field2: "test",
+		Field3: "test",
+	}
+
+	errs = validate.Struct(&test4)
+	Equal(t, errs, nil)
+
+	test5 := struct {
+		Field1 string `validate:"excluded_without=Field2 Field3" json:"field_1"`
+		Field2 string `json:"field_2"`
+		Field3 string `json:"field_3"`
+	}{
+		Field1: "test",
+		Field3: "test",
+	}
+
+	errs = validate.Struct(&test5)
+	NotEqual(t, errs, nil)
+
+	ve = errs.(ValidationErrors)
+	Equal(t, len(ve), 1)
+	AssertError(t, errs, "Field1", "Field1", "Field1", "Field1", "excluded_without")
 }
 
 func TestExcludedWithAll(t *testing.T) {


### PR DESCRIPTION
## Fixes Or Enhances

`excludedWithout` passes the whole parameter to `requireCheckFieldKind` as one field name, so `excluded_without=Field2 Field3` looks up a field literally named `"Field2 Field3"`, never finds it, and falls back to `defaultNotFoundValue=true`. The field is then excluded **unconditionally**, whatever Field2 and Field3 hold — a silent wrong answer, not an error.

Its own doc comment says "when **any** of the other specified fields are not present", and all seven `excluded_with*`/`required_with*`/`required_without*` siblings parse with `parseOneOfParam2` and loop. `requiredWithout`, directly below it, got exactly this fix in #1422; the adjacent twin was not swept.

Measured with Field1 set:

| Field2 | Field3 | before | after |
|---|---|---|---|
| set | set | invalid | **valid** |
| set | absent | invalid | invalid |
| absent | set | invalid | invalid |
| absent | absent | invalid | invalid |

Single-parameter behaviour is unchanged (`parseOneOfParam2("A")` → `["A"]`).

Run back to back: upstream fails the new test, the fix passes, `go test ./...` is 25/25 ok. A naive variant using `excluded_without_all`'s all-absent loop also fails the new test — that case is what separates the two tags.

Drafted with Claude Opus 5 (`claude-opus-5`); every claim was executed.

**Make sure that you've checked the boxes below before you submit PR:**
- [x] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers
