### PR TITLE
chore(deps): bump golang.org/x/crypto from 0.55.0 to 0.56.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-playground/validator/v10
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/gabriel-vasile/mimetype v1.4.15
@@ -8,7 +8,7 @@ require (
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
 	github.com/leodido/go-urn v1.5.0
-	golang.org/x/crypto v0.55.0
+	golang.org/x/crypto v0.56.0
 	golang.org/x/text v0.41.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.41.0 h1:vz/seA0lnX87Othu2f/0L24RcgrXD9/YFTSuGjj3rH8=


### PR DESCRIPTION
## Fixes Or Enhances

Update `golang.org/x/crypto` to `0.56.0`

### Rationale

Two vulnerabilities in `x/crypto/ssh` were reported for `golang.org/x/crypto` v0.55.0, and both are fixed in v0.56.0:

- CVE-2026-56855
- CVE-2026-78662

Running `govulncheck ./...` confirms that validator does not call the affected symbols. However, module-level scanners such as Trivy can still flag them for downstream users via the transitive dependency.

### Updating the `go` directive

`golang.org/x/crypto` v0.56.0 requires `go 1.26.0`, so the `go` directive in `go.mod` must be raised from `1.25.0` to `1.26.0`. This is in line with our MSGV policy of tracking the two most recent major Go versions (Go 1.27 is currently the latest), and is the same change that would be made in a "Go 1.27 support" PR. There are no changes to the source code itself.

**Make sure that you've checked the boxes below before you submit PR:**
- [ ] Tests exist or have been written that cover this particular change.

@go-playground/validator-maintainers